### PR TITLE
test: automate PR #1's manual verification scenarios

### DIFF
--- a/cmd/scribe/commit_test.go
+++ b/cmd/scribe/commit_test.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"context"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -127,6 +129,102 @@ func TestCommitRefusesOnUnparseableConfig(t *testing.T) {
 	}
 	if holdSecretFiles(root, cfg) {
 		t.Error("holdSecretFiles must fail closed when the config is unparseable")
+	}
+}
+
+// logRecorder is a slog.Handler that keeps every message in memory so
+// tests can assert on operator-facing log lines (logMsg routes through
+// slog.Default). Attrs/groups are irrelevant for these assertions.
+type logRecorder struct {
+	mu    sync.Mutex
+	lines []string
+}
+
+func (r *logRecorder) Enabled(context.Context, slog.Level) bool { return true }
+func (r *logRecorder) Handle(_ context.Context, rec slog.Record) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.lines = append(r.lines, rec.Message)
+	return nil
+}
+func (r *logRecorder) WithAttrs([]slog.Attr) slog.Handler { return r }
+func (r *logRecorder) WithGroup(string) slog.Handler      { return r }
+func (r *logRecorder) joined() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return strings.Join(r.lines, "\n")
+}
+
+// recordLogs swaps the default slog logger for an in-memory recorder
+// for the duration of the test. Safe without t.Parallel(): serial tests
+// never overlap, and the recorder itself is mutex-guarded.
+func recordLogs(t *testing.T) func() string {
+	t.Helper()
+	rec := &logRecorder{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(rec))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return rec.joined
+}
+
+// TestCommitSecretGateHoldThenAllowMarker automates PR #1's manual
+// verification #1 end-to-end on the commit path: a team-mode KB with a
+// runtime-assembled AWS-shaped token in an article must log SECRET HELD
+// and keep the file out of the commit; after a human marks the line
+// with `scribe:allow`, the very same file commits.
+func TestCommitSecretGateHoldThenAllowMarker(t *testing.T) {
+	root := commitTestKB(t)
+	logs := recordLogs(t)
+	before := headSubject(t, root)
+
+	article := func(body string) string {
+		return "---\ntitle: \"Leaky\"\ntype: research\ndomain: general\ncreated: 2026-06-12\nupdated: 2026-06-12\nconfidence: low\ntags: []\nrelated: []\nsources: []\n---\n\n" + body + "\n"
+	}
+	leakyLine := "the deploy used " + fakeAWSKey() + " for staging"
+	writeTestArticle(t, root, "wiki/leaky.md", article(leakyLine))
+
+	// Run 1: the gate holds the file, loudly, and commits nothing.
+	if err := commitRun(root); err != nil {
+		t.Fatalf("commitRun with held file must not error: %v", err)
+	}
+	got := logs()
+	if !strings.Contains(got, "SECRET HELD: wiki/leaky.md:") {
+		t.Errorf("no SECRET HELD line for wiki/leaky.md; logs:\n%s", got)
+	}
+	if !strings.Contains(got, "[AWS Access Key ID]") {
+		t.Errorf("SECRET HELD line missing the rule label; logs:\n%s", got)
+	}
+	if strings.Contains(got, fakeAWSKey()) {
+		t.Fatalf("log output leaked the credential value:\n%s", got)
+	}
+	if subj := headSubject(t, root); subj != before {
+		t.Errorf("HEAD moved to %q — held-only change must not commit", subj)
+	}
+	lsFiles := exec.CommandContext(context.Background(), "git", "ls-files", "wiki/leaky.md")
+	lsFiles.Dir = root
+	if out, _ := lsFiles.Output(); strings.TrimSpace(string(out)) != "" {
+		t.Error("held file reached the index/commit")
+	}
+	if _, err := os.Stat(filepath.Join(root, "wiki", "leaky.md")); err != nil {
+		t.Fatal("held file must stay in the worktree for the human to resolve")
+	}
+
+	// Run 2: the human reviews and marks the line as a placeholder.
+	writeTestArticle(t, root, "wiki/leaky.md", article(leakyLine+" <!-- scribe:allow -->"))
+	if err := commitRun(root); err != nil {
+		t.Fatalf("commitRun after scribe:allow: %v", err)
+	}
+	if subj := headSubject(t, root); !strings.Contains(subj, "(1 wiki)") {
+		t.Errorf("allow-marked file did not commit; HEAD subject = %q", subj)
+	}
+	show := exec.CommandContext(context.Background(), "git", "show", "HEAD:wiki/leaky.md")
+	show.Dir = root
+	out, err := show.Output()
+	if err != nil {
+		t.Fatalf("allow-marked file missing from HEAD: %v", err)
+	}
+	if !strings.Contains(string(out), "scribe:allow") {
+		t.Error("committed blob lost the scribe:allow marker")
 	}
 }
 

--- a/cmd/scribe/config_update_test.go
+++ b/cmd/scribe/config_update_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -103,6 +105,121 @@ func TestAppendTemplateBlocksIsCommentedAndValid(t *testing.T) {
 	}
 	if before.OwnerName != after.OwnerName || len(before.Domains) != len(after.Domains) {
 		t.Error("append changed parsed config values")
+	}
+}
+
+// captureStdout swaps os.Stdout for a pipe while fn runs and returns
+// everything written. A concurrent reader keeps fn from blocking on the
+// pipe buffer (runBootstrap prints a multi-KB plan).
+func captureStdout(t *testing.T, fn func() error) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	orig := os.Stdout
+	os.Stdout = w
+	var buf bytes.Buffer
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = io.Copy(&buf, r)
+	}()
+	runErr := fn()
+	os.Stdout = orig
+	_ = w.Close()
+	<-done
+	if runErr != nil {
+		t.Fatalf("command failed: %v\noutput:\n%s", runErr, buf.String())
+	}
+	return buf.String()
+}
+
+// TestConfigUpdateFreshScaffoldNothingMissing automates half of PR #1's
+// manual verification #2: against a KB scaffolded today (the real init
+// path, embedded templates), `scribe config update --check` must report
+// nothing missing — every reported block must be GENUINELY missing, so
+// a fresh file yields zero false positives.
+func TestConfigUpdateFreshScaffoldNothingMissing(t *testing.T) {
+	if testing.Short() {
+		t.Skip("scaffolds a full KB")
+	}
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	kb := filepath.Join(t.TempDir(), "fresh-kb")
+	c := &InitCmd{Path: kb, Yes: true, NoCron: true, NoGit: true, Domains: []string{"general"}}
+	_ = captureStdout(t, c.runBootstrap) // scaffold output not under test
+
+	t.Setenv("SCRIBE_KB", kb)
+	path := filepath.Join(kb, "scribe.yaml")
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("scaffold did not write scribe.yaml: %v", err)
+	}
+
+	out := captureStdout(t, (&ConfigUpdateCmd{Check: true}).Run)
+	if !strings.Contains(out, "already documents every current option") {
+		t.Errorf("fresh scaffold reported missing blocks (false positives):\n%s", out)
+	}
+	after, _ := os.ReadFile(path)
+	if !bytes.Equal(before, after) {
+		t.Error("--check modified a fresh scaffold")
+	}
+}
+
+// TestConfigUpdateCheckListsOnlyGenuinelyMissing pins the other half of
+// manual verification #2 at the Run() level: keys the user file already
+// mentions (active OR commented) must not be listed or re-appended; the
+// appended tail must be commented documentation only, after the
+// untouched original content.
+func TestConfigUpdateCheckListsOnlyGenuinelyMissing(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("SCRIBE_KB", root)
+	path := filepath.Join(root, "scribe.yaml")
+	original := "owner_name: x\nowners:\n  backend: Alice\n# secret_scan:\n#   disable: false\n"
+	if err := os.WriteFile(path, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out := captureStdout(t, (&ConfigUpdateCmd{Check: true}).Run)
+	if !strings.Contains(out, "would append") {
+		t.Fatalf("--check did not report pending blocks:\n%s", out)
+	}
+	for _, mentioned := range []string{"owners", "secret_scan"} {
+		if strings.Contains(out, mentioned) {
+			t.Errorf("--check listed %q although the file already mentions it:\n%s", mentioned, out)
+		}
+	}
+	for _, missing := range []string{"subscriptions", "sources"} {
+		if !strings.Contains(out, missing) {
+			t.Errorf("--check did not list genuinely missing block %q:\n%s", missing, out)
+		}
+	}
+
+	// Real run: append-only commented tail covering exactly the missing set.
+	captureStdout(t, (&ConfigUpdateCmd{}).Run)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(string(data), original) {
+		t.Fatal("update rewrote existing content instead of appending")
+	}
+	tail := strings.TrimPrefix(string(data), original)
+	if !strings.Contains(tail, "appended by `scribe config update`") {
+		t.Error("appended tail missing the provenance header")
+	}
+	for _, line := range strings.Split(tail, "\n") {
+		if line != "" && !strings.HasPrefix(line, "#") {
+			t.Errorf("appended tail has an active (uncommented) line: %q", line)
+		}
+	}
+	if configMentionsKey(tail, "owners") || configMentionsKey(tail, "secret_scan") {
+		t.Error("update re-appended a block the file already mentioned")
+	}
+	if !configMentionsKey(tail, "subscriptions") || !configMentionsKey(tail, "sources") {
+		t.Errorf("update did not append the missing blocks; tail:\n%s", tail)
 	}
 }
 

--- a/cmd/scribe/dream_lease_test.go
+++ b/cmd/scribe/dream_lease_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -121,6 +122,97 @@ func TestAcquireDreamLease(t *testing.T) {
 	}
 	if got := readDreamLease(root); got == nil || got.Host != hostnameShort() {
 		t.Errorf("steal did not rewrite the lease: %+v", got)
+	}
+}
+
+// setupLeaseTeam simulates PR #1's two-machine setup: a bare origin and
+// two clones with distinct git identities. Both tests run on one host,
+// so the clones share hostnameShort() — exactly the "every fresh Mac is
+// MacBook-Pro" collision the lease's By field exists to disambiguate;
+// the contributor (repo-local user.name) is what tells them apart.
+func setupLeaseTeam(t *testing.T) (cloneA, cloneB, origin string) {
+	t.Helper()
+	origin = filepath.Join(t.TempDir(), "origin.git")
+	gitRun(t, t.TempDir(), "init", "-q", "--bare", origin)
+
+	seed := initTestGitRepo(t, "Seeder")
+	writeKBFile(t, seed, "scribe.yaml", "owner_name: t\nteam: true\n")
+	gitRun(t, seed, "add", ".")
+	gitRun(t, seed, "commit", "-q", "-m", "base")
+	gitRun(t, seed, "remote", "add", "origin", origin)
+	gitRun(t, seed, "push", "-q", "-u", "origin", "HEAD:main")
+
+	cloneA = filepath.Join(t.TempDir(), "machine-a")
+	gitRun(t, t.TempDir(), "clone", "-q", origin, cloneA)
+	gitRun(t, cloneA, "config", "user.name", "Alice")
+	gitRun(t, cloneA, "config", "user.email", "a@example.com")
+
+	cloneB = filepath.Join(t.TempDir(), "machine-b")
+	gitRun(t, t.TempDir(), "clone", "-q", origin, cloneB)
+	gitRun(t, cloneB, "config", "user.name", "Bob")
+	gitRun(t, cloneB, "config", "user.email", "b@example.com")
+	return cloneA, cloneB, origin
+}
+
+// TestDreamLeaseTwoMachineCoordination automates PR #1's manual
+// verification #3: machine A acquires the weekly dream lease and the
+// claim propagates through origin; machine B's run pulls, sees the
+// active lease, reports the holder, and skips without writing a claim;
+// once the lease window expires, B steals it — and A then backs off.
+func TestDreamLeaseTwoMachineCoordination(t *testing.T) {
+	cloneA, cloneB, origin := setupLeaseTeam(t)
+	now := time.Now()
+
+	// Machine A claims the cycle; the claim is committed and pushed.
+	acquired, holder := acquireDreamLease(cloneA, now)
+	if !acquired || holder != "" {
+		t.Fatalf("machine A acquire = (%v, %q), want (true, \"\")", acquired, holder)
+	}
+	originLease := runCmd(origin, "git", "show", "HEAD:scripts/dream-lease.json")
+	if !strings.Contains(originLease, `"by": "Alice"`) {
+		t.Fatalf("machine A's claim did not reach origin:\n%s", originLease)
+	}
+
+	// Machine B pulls, sees A's active lease, reports the holder, skips.
+	acquired, holder = acquireDreamLease(cloneB, now.Add(time.Minute))
+	if acquired {
+		t.Fatal("machine B must skip while machine A holds the lease")
+	}
+	lease := readDreamLease(cloneB)
+	if lease == nil || lease.By != "Alice" {
+		t.Fatalf("machine B did not pull A's lease: %+v", lease)
+	}
+	if holder != lease.Host {
+		t.Errorf("reported holder %q does not name the lease holder %q", holder, lease.Host)
+	}
+	// B must not have overwritten the claim on origin.
+	if cur := runCmd(origin, "git", "show", "HEAD:scripts/dream-lease.json"); !strings.Contains(cur, `"by": "Alice"`) {
+		t.Errorf("machine B's skip altered the origin lease:\n%s", cur)
+	}
+
+	// Expired lease is stealable: B retries after the lease window.
+	later := now.Add((dreamLeaseHours + 1) * time.Hour)
+	acquired, _ = acquireDreamLease(cloneB, later)
+	if !acquired {
+		t.Fatal("machine B must steal an expired lease")
+	}
+	if cur := runCmd(origin, "git", "show", "HEAD:scripts/dream-lease.json"); !strings.Contains(cur, `"by": "Bob"`) {
+		t.Errorf("machine B's steal did not reach origin:\n%s", cur)
+	}
+
+	// The steal is visible back on machine A: its next run backs off.
+	acquired, holder = acquireDreamLease(cloneA, later.Add(time.Minute))
+	if acquired {
+		t.Error("machine A must back off after B's steal")
+	}
+	if got := readDreamLease(cloneA); got == nil || got.By != "Bob" {
+		t.Errorf("machine A did not pull B's lease: %+v", got)
+	}
+	if holder == "" {
+		t.Error("skip must report which machine holds the lease")
+	}
+	if rebaseInProgress(cloneA) || rebaseInProgress(cloneB) {
+		t.Error("lease coordination left a repo mid-rebase")
 	}
 }
 

--- a/cmd/scribe/gitmerge_test.go
+++ b/cmd/scribe/gitmerge_test.go
@@ -79,6 +79,40 @@ func TestPullRebaseAutoResolvesDerivedConflict(t *testing.T) {
 	}
 }
 
+// TestPullRebaseAutoResolvesAllDerivedFiles automates PR #1's manual
+// verification #4 across the FULL derived set: two machines touching
+// _index.md, _backlinks.json, and _digest.md concurrently must pull
+// clean — every derived file resolves without manual intervention in a
+// single rebase, not just the index.
+func TestPullRebaseAutoResolvesAllDerivedFiles(t *testing.T) {
+	derived := []string{"wiki/_index.md", "wiki/_backlinks.json", "wiki/_digest.md"}
+	clone := setupCloneWithConflict(t, derived...)
+
+	ok, pulled, err := pullRebase(clone)
+	if err != nil {
+		t.Fatalf("pullRebase must auto-resolve all derived files, got: %v", err)
+	}
+	if !ok || !pulled {
+		t.Errorf("pullRebase = (ok=%v, pulled=%v), want (true, true)", ok, pulled)
+	}
+	if rebaseInProgress(clone) {
+		t.Error("rebase left in progress")
+	}
+	if got := conflictedFiles(clone); len(got) != 0 {
+		t.Errorf("unmerged files remain: %v", got)
+	}
+	for _, rel := range derived {
+		data, err := os.ReadFile(filepath.Join(clone, filepath.FromSlash(rel)))
+		if err != nil {
+			t.Errorf("%s missing after auto-resolve: %v", rel, err)
+			continue
+		}
+		if firstConflictMarkerLine(data) != 0 {
+			t.Errorf("conflict markers left in %s:\n%s", rel, data)
+		}
+	}
+}
+
 func TestPullRebaseAbortsOnArticleConflict(t *testing.T) {
 	clone := setupCloneWithConflict(t, "wiki/real-article.md")
 


### PR DESCRIPTION
Turns the four manual verification scenarios from PR #1's description into integration tests, so the PR can merge on green CI instead of hand-testing:

1. **Secret gate lifecycle** — `TestCommitSecretGateHoldThenAllowMarker`: runtime-assembled AWS key → `SECRET HELD`, file kept out of HEAD, token never logged; `scribe:allow` → commits.
2. **`config update --check`** — zero false positives on a fresh scaffold (`TestConfigUpdateFreshScaffoldNothingMissing`); lists only genuinely missing blocks; append is provenance-headed, fully commented, idempotent.
3. **Dream lease, two machines** — `TestDreamLeaseTwoMachineCoordination`: bare origin + two clones; claim, holder-report-and-skip, steal after the 6h window, back-off propagation, no mid-rebase state.
4. **Derived-file conflicts** — `TestPullRebaseAutoResolvesAllDerivedFiles`: all three derived files conflicting in one pull rebase clean.

Still needs a human eventually: true multi-machine races (clock skew, offline remote) and one `config update` run against an organically drifted production scribe.yaml.

Suite + golangci-lint green. Intended to merge into PR #1 itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/oliver-kriska/scribe/pull/29">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->