### PR TITLE
test: stub LLM provider harness — the three nolint'd drivers get real coverage

### DIFF
--- a/cmd/scribe/claude.go
+++ b/cmd/scribe/claude.go
@@ -22,7 +22,12 @@ var promptFS embed.FS
 // ErrRateLimit is returned when claude -p hits Anthropic rate limits.
 var ErrRateLimit = fmt.Errorf("rate limit hit")
 
-func runClaude(ctx context.Context, root, prompt, model string, tools []string, timeout time.Duration) (string, error) {
+// runClaude is a package variable (pointing at realRunClaude) purely so
+// driver tests can swap in a scripted stub (see llm_stub_test.go) without
+// shelling out to a real `claude` binary; production code never reassigns it.
+var runClaude = realRunClaude
+
+func realRunClaude(ctx context.Context, root, prompt, model string, tools []string, timeout time.Duration) (string, error) {
 	// Daily anthropic output-token ceiling: read once per call so a
 	// long-running absorb that crosses the ceiling mid-run aborts at
 	// the next claude -p invocation rather than barreling through.

--- a/cmd/scribe/config.go
+++ b/cmd/scribe/config.go
@@ -252,18 +252,23 @@ type IngestSmartRoutingConfig struct {
 	MaxPDFPages int   `yaml:"max_pdf_pages"`
 }
 
+// ingestDefaults returns the canonical IngestConfig defaults. Each *bool
+// gets its own variable — yaml.Unmarshal writes through prefilled non-nil
+// pointers, so a shared default bool would alias the two knobs (see the
+// absorbDefaults doc comment for the full story).
 func ingestDefaults() IngestConfig {
-	trueV := true
+	mpsFallback := true
+	smartRouting := true
 	return IngestConfig{
 		InboxPath: "raw/inbox",
 		Marker: IngestMarkerConfig{
 			TimeoutSeconds: 300,
-			MPSFallback:    &trueV,
+			MPSFallback:    &mpsFallback,
 			Device:         "auto",
 		},
 		Converters: map[string]string{},
 		SmartRouting: IngestSmartRoutingConfig{
-			Enabled:     &trueV,
+			Enabled:     &smartRouting,
 			MaxPDFBytes: 500 * 1024, // 500 KB
 			MaxPDFPages: 5,
 		},

--- a/cmd/scribe/config_absorb.go
+++ b/cmd/scribe/config_absorb.go
@@ -152,8 +152,17 @@ type ContextualizeConfig struct {
 
 // absorbDefaults returns the canonical defaults for AbsorbConfig. Used by
 // loadConfig to fill missing fields after yaml.Unmarshal.
+//
+// Every *bool default gets its OWN variable. loadConfig prefills the
+// config with this struct before yaml.Unmarshal, and yaml.v3 writes
+// through existing non-nil pointers instead of allocating fresh ones —
+// so two fields sharing one default bool alias each other, and a user
+// setting `contextualize.enabled: false` silently flipped
+// `chapter_aware` off too (caught by the issue-#9 stub-harness tests;
+// regression-pinned in TestAbsorbDefaults_NoBoolPointerAliasing).
 func absorbDefaults() AbsorbConfig {
-	trueV := true
+	chapterAware := true
+	contextualizeEnabled := true
 	return AbsorbConfig{
 		Strictness:             "medium",
 		MaxPerRun:              5,
@@ -171,7 +180,7 @@ func absorbDefaults() AbsorbConfig {
 		Pass2TimeoutMin:      5,
 		Pass2Parallel:        3,
 		SinglePassTimeoutMin: 5,
-		ChapterAware:         &trueV,
+		ChapterAware:         &chapterAware,
 		ChapterThreshold:     3,
 		ChapterParallel:      2,
 		// AtomicFacts off by default. Users opt in by setting
@@ -186,7 +195,7 @@ func absorbDefaults() AbsorbConfig {
 		Pass1Provider:      "anthropic",
 		SinglePassProvider: "anthropic",
 		Contextualize: ContextualizeConfig{
-			Enabled:    &trueV,
+			Enabled:    &contextualizeEnabled,
 			Provider:   "anthropic",
 			Model:      "haiku",
 			OllamaURL:  defaultOllamaURL,

--- a/cmd/scribe/config_bool_aliasing_test.go
+++ b/cmd/scribe/config_bool_aliasing_test.go
@@ -1,0 +1,66 @@
+// config_bool_aliasing_test.go — regression tests for the *bool default
+// aliasing bug found while building the issue-#9 stub harness.
+//
+// loadConfig prefills the config struct with the defaults constructors
+// BEFORE yaml.Unmarshal, and yaml.v3 writes through existing non-nil
+// pointers instead of allocating new ones. absorbDefaults used a single
+// `trueV` variable for both ChapterAware and Contextualize.Enabled, so a
+// user writing `absorb.contextualize.enabled: false` silently flipped
+// `chapter_aware` off too (and vice versa). ingestDefaults had the same
+// aliasing between Marker.MPSFallback and SmartRouting.Enabled. The
+// constructors now give every *bool its own variable; these tests pin it.
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeKBConfig(t *testing.T, yaml string) string {
+	t.Helper()
+	root := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	if err := os.WriteFile(filepath.Join(root, "scribe.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatalf("write scribe.yaml: %v", err)
+	}
+	return root
+}
+
+func TestAbsorbDefaults_NoBoolPointerAliasing(t *testing.T) {
+	t.Run("contextualize.enabled=false leaves chapter_aware on", func(t *testing.T) {
+		root := writeKBConfig(t, "absorb:\n  contextualize:\n    enabled: false\n")
+		cfg := loadConfig(root)
+		if cfg.LoadErr != nil {
+			t.Fatalf("LoadErr: %v", cfg.LoadErr)
+		}
+		if cfg.Absorb.ChapterAware == nil || !*cfg.Absorb.ChapterAware {
+			t.Errorf("chapter_aware flipped off by contextualize.enabled=false (default-pointer aliasing)")
+		}
+		if cfg.Absorb.Contextualize.Enabled == nil || *cfg.Absorb.Contextualize.Enabled {
+			t.Errorf("contextualize.enabled=false not honored")
+		}
+	})
+
+	t.Run("chapter_aware=false leaves contextualize.enabled on", func(t *testing.T) {
+		root := writeKBConfig(t, "absorb:\n  chapter_aware: false\n")
+		cfg := loadConfig(root)
+		if cfg.Absorb.Contextualize.Enabled == nil || !*cfg.Absorb.Contextualize.Enabled {
+			t.Errorf("contextualize.enabled flipped off by chapter_aware=false (default-pointer aliasing)")
+		}
+		if cfg.Absorb.ChapterAware == nil || *cfg.Absorb.ChapterAware {
+			t.Errorf("chapter_aware=false not honored")
+		}
+	})
+}
+
+func TestIngestDefaults_NoBoolPointerAliasing(t *testing.T) {
+	root := writeKBConfig(t, "ingest:\n  smart_routing:\n    enabled: false\n")
+	cfg := loadConfig(root)
+	if cfg.Ingest.Marker.MPSFallback == nil || !*cfg.Ingest.Marker.MPSFallback {
+		t.Errorf("marker.mps_fallback flipped off by smart_routing.enabled=false (default-pointer aliasing)")
+	}
+	if cfg.Ingest.SmartRouting.Enabled == nil || *cfg.Ingest.SmartRouting.Enabled {
+		t.Errorf("smart_routing.enabled=false not honored")
+	}
+}

--- a/cmd/scribe/deep.go
+++ b/cmd/scribe/deep.go
@@ -29,7 +29,7 @@ var excludedDirNames = map[string]bool{
 	"evals":        true,
 }
 
-//nolint:gocognit // LLM-driving path with 0% test coverage — decompose only once a stub-provider harness exists, a blind refactor risks silent behavior drift
+//nolint:gocognit // LLM-driving batch loop — behavior now pinned by the stub-harness tests in deep_run_test.go (issue #9); decompose in a dedicated change with those tests green
 func (d *DeepCmd) Run() error {
 	root, err := kbDir()
 	if err != nil {

--- a/cmd/scribe/deep_run_test.go
+++ b/cmd/scribe/deep_run_test.go
@@ -1,0 +1,361 @@
+// deep_run_test.go — driver tests for DeepCmd.Run against the stub LLM
+// harness (llm_stub_test.go). Pins the per-directory batch loop's
+// observable semantics for both protocols: envelope mode through the
+// newLLMProvider seam and legacy tools mode through the runClaude seam —
+// manifest checkpointing, rate-limit stop, per-directory error
+// tolerance, dry-run, already-extracted skip, and the batch cap.
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// deepKB scaffolds a KB + a fake project with the given knowledge dirs
+// and registers the project in the manifest. Also sandboxes PATH with a
+// no-op qmd so the post-batch reindex can't touch a real index (and the
+// absent git makes gitIsDirty fall out false, skipping commit/push).
+// Returns (kbRoot, projectDir).
+func deepKB(t *testing.T, mode string, dirs ...string) (string, string) {
+	t.Helper()
+	yaml := `kb_name: stubkb
+deep_ingest:
+  mode: ` + mode + `
+  provider: anthropic
+  model: haiku
+`
+	root := stubHarnessKB(t, yaml)
+
+	proj := t.TempDir()
+	for _, d := range dirs {
+		if err := os.MkdirAll(filepath.Join(proj, d), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+		note := filepath.Join(proj, d, "notes.md")
+		if err := os.WriteFile(note, []byte("# Notes in "+d+"\n\ncontent for "+d+"\n"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", note, err)
+		}
+	}
+
+	manifest := map[string]any{
+		"projects": map[string]any{
+			"acme": map[string]any{"path": proj, "domain": "general"},
+		},
+	}
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "scripts", "projects.json"), data, 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	// PATH sandbox: a fake bin dir whose only binary is a no-op qmd.
+	fakeBin := t.TempDir()
+	if err := os.WriteFile(filepath.Join(fakeBin, "qmd"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write fake qmd: %v", err)
+	}
+	t.Setenv("PATH", fakeBin)
+
+	// runStats is package-global telemetry the envelope path mutates;
+	// isolate it per test.
+	origStats := runStats
+	runStats = nil
+	t.Cleanup(func() { runStats = origStats })
+
+	return root, proj
+}
+
+// reloadProject re-reads the manifest and returns the acme entry.
+func reloadProject(t *testing.T, root string) *ProjectEntry {
+	t.Helper()
+	m, err := loadManifest(root)
+	if err != nil {
+		t.Fatalf("reload manifest: %v", err)
+	}
+	e, ok := m.Projects["acme"]
+	if !ok {
+		t.Fatal("acme missing from manifest after run")
+	}
+	return e
+}
+
+// deepEnvelope renders an EnvelopeV2 creating one wiki page for a dir.
+func deepEnvelope(t *testing.T, dir string) string {
+	t.Helper()
+	return envelopeJSON(t, 2, "Deep "+dir, "wiki/deep-"+dir+".md", "Extracted from "+dir+".")
+}
+
+// TestDeepRun_EnvelopeMode_ExtractsAndCheckpointsManifest: every
+// knowledge directory gets one envelope call, the resulting wiki pages
+// land via applyWikiActions, and the manifest records the extracted
+// dirs + timestamps ("no-git" for a project without git history).
+func TestDeepRun_EnvelopeMode_ExtractsAndCheckpointsManifest(t *testing.T) {
+	root, _ := deepKB(t, "envelope", "alphadocs", "betadocs")
+
+	stub := &stubLLM{}
+	stub.Rules = []*stubRule{
+		{MatchOp: "deep-extract", MatchPrompt: "alphadocs", Reply: deepEnvelope(t, "alphadocs")},
+		{MatchOp: "deep-extract", MatchPrompt: "betadocs", Reply: deepEnvelope(t, "betadocs")},
+	}
+	reqs := installStubLLM(t, stub)
+
+	d := &DeepCmd{Project: "acme", BatchMax: 5, Model: "sonnet"}
+	if err := d.Run(); err != nil {
+		t.Fatalf("DeepCmd.Run: %v", err)
+	}
+
+	calls := stub.CallsWithOp("deep-extract")
+	if len(calls) != 2 {
+		t.Fatalf("deep-extract calls = %d, want 2", len(calls))
+	}
+	for _, c := range calls {
+		if c.NumCtx <= 0 {
+			t.Errorf("deep call num_ctx = %d, want >0", c.NumCtx)
+		}
+		if !strings.Contains(c.Prompt, "acme") {
+			t.Errorf("deep prompt missing project name")
+		}
+	}
+	// Config routing reached the seam: deep_ingest provider/model pair.
+	if pairs := reqs.Pairs(); len(pairs) == 0 || pairs[0] != "anthropic/haiku" {
+		t.Errorf("provider requests = %v, want anthropic/haiku first", pairs)
+	}
+
+	for _, dir := range []string{"alphadocs", "betadocs"} {
+		if _, err := os.Stat(filepath.Join(root, "wiki", "deep-"+dir+".md")); err != nil {
+			t.Errorf("missing wiki page for %s: %v", dir, err)
+		}
+	}
+
+	e := reloadProject(t, root)
+	if e.ExtractedDirs != "alphadocs,betadocs" {
+		t.Errorf("ExtractedDirs = %q, want %q", e.ExtractedDirs, "alphadocs,betadocs")
+	}
+	if e.LastExtracted == "" {
+		t.Errorf("LastExtracted not stamped")
+	}
+	if e.LastSHA != "no-git" {
+		t.Errorf("LastSHA = %q, want no-git", e.LastSHA)
+	}
+}
+
+// TestDeepRun_EnvelopeMode_RateLimitStopsRun: a rate-limited directory
+// stops the batch loop immediately — the rate-limited dir is NOT marked
+// extracted (it has to retry next run) and later dirs are never asked.
+// Run itself returns nil so cron exits clean.
+func TestDeepRun_EnvelopeMode_RateLimitStopsRun(t *testing.T) {
+	root, _ := deepKB(t, "envelope", "alphadocs", "betadocs")
+
+	stub := &stubLLM{}
+	stub.Rules = []*stubRule{
+		{MatchOp: "deep-extract", MatchPrompt: "alphadocs", Err: ErrRateLimit},
+	}
+	installStubLLM(t, stub)
+
+	d := &DeepCmd{Project: "acme", BatchMax: 5, Model: "sonnet"}
+	if err := d.Run(); err != nil {
+		t.Fatalf("DeepCmd.Run: %v (rate limit should stop cleanly)", err)
+	}
+	if got := len(stub.CallsWithOp("deep-extract")); got != 1 {
+		t.Errorf("deep-extract calls = %d, want 1 (betadocs must not be attempted)", got)
+	}
+	e := reloadProject(t, root)
+	if e.ExtractedDirs != "" {
+		t.Errorf("ExtractedDirs = %q, want empty — rate-limited dir must retry next run", e.ExtractedDirs)
+	}
+}
+
+// TestDeepRun_EnvelopeMode_ErrorContinuesToNextDir: a non-rate-limit
+// failure on one directory is logged and the loop moves on; the failed
+// dir is still marked extracted (matching the legacy claude-error
+// behavior) so one persistently broken dir can't wedge the batch loop
+// forever.
+func TestDeepRun_EnvelopeMode_ErrorContinuesToNextDir(t *testing.T) {
+	root, _ := deepKB(t, "envelope", "alphadocs", "betadocs")
+
+	stub := &stubLLM{}
+	stub.Rules = []*stubRule{
+		{MatchOp: "deep-extract", MatchPrompt: "alphadocs", Reply: "not an envelope at all"},
+		{MatchOp: "deep-extract", MatchPrompt: "betadocs", Reply: deepEnvelope(t, "betadocs")},
+	}
+	installStubLLM(t, stub)
+
+	d := &DeepCmd{Project: "acme", BatchMax: 5, Model: "sonnet"}
+	if err := d.Run(); err != nil {
+		t.Fatalf("DeepCmd.Run: %v", err)
+	}
+	if got := len(stub.CallsWithOp("deep-extract")); got != 2 {
+		t.Errorf("deep-extract calls = %d, want 2", got)
+	}
+	if _, err := os.Stat(filepath.Join(root, "wiki", "deep-alphadocs.md")); !os.IsNotExist(err) {
+		t.Errorf("alphadocs page should not exist, stat err = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "wiki", "deep-betadocs.md")); err != nil {
+		t.Errorf("betadocs page missing: %v", err)
+	}
+	if e := reloadProject(t, root); e.ExtractedDirs != "alphadocs,betadocs" {
+		t.Errorf("ExtractedDirs = %q, want both dirs recorded", e.ExtractedDirs)
+	}
+}
+
+// TestDeepRun_ToolsMode_UsesRunClaude: legacy tools mode shells out per
+// directory through the runClaude seam with the broad file/git tool
+// set, the CLI-selected model, and the 600s timeout.
+func TestDeepRun_ToolsMode_UsesRunClaude(t *testing.T) {
+	root, proj := deepKB(t, "tools", "alphadocs", "betadocs")
+
+	claude := &stubClaude{Reply: "extracted"}
+	installStubClaude(t, claude)
+
+	d := &DeepCmd{Project: "acme", BatchMax: 5, Model: "sonnet"}
+	if err := d.Run(); err != nil {
+		t.Fatalf("DeepCmd.Run: %v", err)
+	}
+
+	calls := claude.Calls()
+	if len(calls) != 2 {
+		t.Fatalf("runClaude calls = %d, want 2", len(calls))
+	}
+	var sawAlpha, sawBeta bool
+	for _, c := range calls {
+		if c.Model != "sonnet" {
+			t.Errorf("model = %q, want sonnet", c.Model)
+		}
+		if c.Op != "deep-extract" {
+			t.Errorf("op = %q, want deep-extract", c.Op)
+		}
+		if c.Timeout != 600*time.Second {
+			t.Errorf("timeout = %v, want 600s", c.Timeout)
+		}
+		joined := strings.Join(c.Tools, ",")
+		if !strings.Contains(joined, "Write") || !strings.Contains(joined, "Bash(git log:*)") {
+			t.Errorf("tools %v missing expected entries", c.Tools)
+		}
+		if !strings.Contains(c.Prompt, proj) {
+			t.Errorf("prompt missing project path")
+		}
+		if strings.Contains(c.Prompt, "alphadocs") {
+			sawAlpha = true
+		}
+		if strings.Contains(c.Prompt, "betadocs") {
+			sawBeta = true
+		}
+	}
+	if !sawAlpha || !sawBeta {
+		t.Errorf("per-dir prompts incomplete: alpha=%v beta=%v", sawAlpha, sawBeta)
+	}
+	if e := reloadProject(t, root); e.ExtractedDirs != "alphadocs,betadocs" {
+		t.Errorf("ExtractedDirs = %q, want both dirs", e.ExtractedDirs)
+	}
+}
+
+// TestDeepRun_ToolsMode_RateLimitStops: same stop semantics on the
+// legacy path — first rate limit breaks the loop, nothing is recorded.
+func TestDeepRun_ToolsMode_RateLimitStops(t *testing.T) {
+	root, _ := deepKB(t, "tools", "alphadocs", "betadocs")
+
+	claude := &stubClaude{Script: func(claudeCall) (string, error) {
+		return "", ErrRateLimit
+	}}
+	installStubClaude(t, claude)
+
+	d := &DeepCmd{Project: "acme", BatchMax: 5, Model: "sonnet"}
+	if err := d.Run(); err != nil {
+		t.Fatalf("DeepCmd.Run: %v", err)
+	}
+	if got := len(claude.Calls()); got != 1 {
+		t.Errorf("runClaude calls = %d, want 1", got)
+	}
+	if e := reloadProject(t, root); e.ExtractedDirs != "" {
+		t.Errorf("ExtractedDirs = %q, want empty", e.ExtractedDirs)
+	}
+}
+
+// TestDeepRun_DryRun: dry run lists files without any LLM call and
+// without touching the manifest.
+func TestDeepRun_DryRun(t *testing.T) {
+	root, _ := deepKB(t, "envelope", "alphadocs")
+
+	stub := &stubLLM{}
+	installStubLLM(t, stub)
+	claude := &stubClaude{}
+	installStubClaude(t, claude)
+
+	d := &DeepCmd{Project: "acme", BatchMax: 5, Model: "sonnet", DryRun: true}
+	if err := d.Run(); err != nil {
+		t.Fatalf("DeepCmd.Run: %v", err)
+	}
+	if got := len(stub.Calls()); got != 0 {
+		t.Errorf("provider calls = %d, want 0 in dry run", got)
+	}
+	if got := len(claude.Calls()); got != 0 {
+		t.Errorf("runClaude calls = %d, want 0 in dry run", got)
+	}
+	e := reloadProject(t, root)
+	if e.ExtractedDirs != "" || e.LastExtracted != "" {
+		t.Errorf("dry run must not checkpoint the manifest: dirs=%q extracted=%q", e.ExtractedDirs, e.LastExtracted)
+	}
+}
+
+// TestDeepRun_SkipsExtractedAndHonorsBatchMax: directories already in
+// extracted_dirs are skipped, and batch-max caps how many new dirs one
+// run takes on — the remainder waits for the next run.
+func TestDeepRun_SkipsExtractedAndHonorsBatchMax(t *testing.T) {
+	root, proj := deepKB(t, "envelope", "alphadocs", "betadocs", "gammadocs")
+
+	// Pre-seed alphadocs as already extracted.
+	m, err := loadManifest(root)
+	if err != nil {
+		t.Fatalf("load manifest: %v", err)
+	}
+	m.Projects["acme"].ExtractedDirs = "alphadocs"
+	m.Projects["acme"].Path = proj
+	if err := m.save(); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+
+	stub := &stubLLM{}
+	stub.Rules = []*stubRule{
+		{MatchOp: "deep-extract", MatchPrompt: "betadocs", Reply: deepEnvelope(t, "betadocs")},
+	}
+	installStubLLM(t, stub)
+
+	d := &DeepCmd{Project: "acme", BatchMax: 1, Model: "sonnet"}
+	if err := d.Run(); err != nil {
+		t.Fatalf("DeepCmd.Run: %v", err)
+	}
+
+	calls := stub.CallsWithOp("deep-extract")
+	if len(calls) != 1 {
+		t.Fatalf("deep-extract calls = %d, want 1 (batch-max 1)", len(calls))
+	}
+	if !strings.Contains(calls[0].Prompt, "betadocs") {
+		t.Errorf("expected betadocs (first unextracted dir) to be processed")
+	}
+	if e := reloadProject(t, root); e.ExtractedDirs != "alphadocs,betadocs" {
+		t.Errorf("ExtractedDirs = %q, want alphadocs,betadocs (gammadocs waits)", e.ExtractedDirs)
+	}
+}
+
+// TestDeepRun_UnknownProjectErrors: a project missing from the manifest
+// fails fast with a pointer at sync --discover.
+func TestDeepRun_UnknownProjectErrors(t *testing.T) {
+	deepKB(t, "envelope", "alphadocs")
+
+	stub := &stubLLM{}
+	installStubLLM(t, stub)
+
+	d := &DeepCmd{Project: "ghost", BatchMax: 5, Model: "sonnet"}
+	err := d.Run()
+	if err == nil || !strings.Contains(err.Error(), "not in manifest") {
+		t.Fatalf("err = %v, want not-in-manifest error", err)
+	}
+	if got := len(stub.Calls()); got != 0 {
+		t.Errorf("provider calls = %d, want 0", got)
+	}
+}

--- a/cmd/scribe/llm.go
+++ b/cmd/scribe/llm.go
@@ -47,15 +47,21 @@ func generateMaybeJSON(ctx context.Context, p llmProviderGenerator, prompt strin
 	return p.Generate(ctx, prompt)
 }
 
-// newLLMProvider picks the provider backend based on scribe.yaml. Unknown
-// provider names fall back to anthropic with a log line so misconfiguration
-// never silently no-ops.
+// newLLMProvider picks the provider backend based on scribe.yaml. It is a
+// package variable (pointing at realNewLLMProvider) purely so driver tests
+// can swap in a scripted stub provider (see llm_stub_test.go) without a
+// network or a real LLM; production code never reassigns it.
+var newLLMProvider = realNewLLMProvider
+
+// realNewLLMProvider is the production implementation behind the
+// newLLMProvider seam. Unknown provider names fall back to anthropic with
+// a log line so misconfiguration never silently no-ops.
 //
 // kbRoot is forwarded to the anthropic provider so its claude calls can
 // land in output/costs/<day>.jsonl alongside calls from runClaude. Empty
 // kbRoot is tolerated — appendCostEntry no-ops on empty root, so callers
 // without a KB context (e.g. unit tests) keep working.
-func newLLMProvider(provider, model, ollamaURL, kbRoot string) llmProviderGenerator {
+func realNewLLMProvider(provider, model, ollamaURL, kbRoot string) llmProviderGenerator {
 	switch strings.ToLower(provider) {
 	case "ollama":
 		return &ollamaProvider{baseURL: ollamaURL, model: model, root: kbRoot}

--- a/cmd/scribe/llm_stub_test.go
+++ b/cmd/scribe/llm_stub_test.go
@@ -1,0 +1,382 @@
+// llm_stub_test.go — the stub LLM provider harness (issue #9).
+//
+// The three LLM-driving paths flagged with `nolint:gocognit`
+// (absorbDenseTwoPass, ScanCmd.Run, DeepCmd.Run) had 0% test coverage
+// because every test would have shelled out to `claude -p` or hit a
+// local Ollama server. This file provides the fake that breaks that
+// dependency:
+//
+//   - stubLLM implements llmProviderGenerator with scripted responses,
+//     recorded prompts (plus the op label and num_ctx pulled from the
+//     call context), injectable failures, and rate-limit / budget
+//     signals. It also tracks concurrency (max in-flight calls and
+//     which prompts were active when each call entered) so tests can
+//     assert errgroup SetLimit caps and the per-label mutex.
+//   - stubClaude replaces the runClaude seam for the legacy
+//     tools-mode paths.
+//
+// Injection happens through two package-level seams that production
+// code never reassigns:
+//
+//	newLLMProvider (llm.go)  — swapped via installStubLLM
+//	runClaude      (claude.go) — swapped via installStubClaude
+//
+// Both helpers restore the real implementation in t.Cleanup, and none
+// of the tests using them call t.Parallel(), so the package-global
+// swap is race-free.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	gosync "sync"
+	"testing"
+	"time"
+)
+
+// stubCall is one recorded provider invocation.
+type stubCall struct {
+	// Prompt is the full rendered prompt the driver sent.
+	Prompt string
+	// JSONMode is true when the call arrived via GenerateJSON.
+	JSONMode bool
+	// Op is the op label tagged on the context (withOpLabel) — lets
+	// tests distinguish absorb-pass1-whole / absorb-pass2 / absorb-single
+	// / deep-extract calls without fragile prompt sniffing.
+	Op string
+	// NumCtx is the Ollama num_ctx tagged on the context
+	// (withOllamaNumCtx); 0 when untagged.
+	NumCtx int
+	// ActiveAtEntry snapshots the prompts of calls already in flight
+	// when this call entered. Used to prove serialization (per-label
+	// mutex) and parallelism (SetLimit).
+	ActiveAtEntry []string
+}
+
+// stubRule is one scripted response. Rules are evaluated in order;
+// the first matching (and, for once-rules, unconsumed) rule wins.
+type stubRule struct {
+	// MatchOp, when non-empty, requires the context op label to equal it.
+	MatchOp string
+	// MatchPrompt, when non-empty, requires the prompt to contain it.
+	MatchPrompt string
+	// Reply is returned when Err is nil.
+	Reply string
+	// Err is returned instead of Reply when non-nil.
+	Err error
+	// Once consumes the rule after its first match — lets tests script
+	// "fail first, succeed on retry" sequences.
+	Once bool
+
+	used bool
+}
+
+// stubLLM is a scripted llmProviderGenerator. Safe for concurrent use.
+//
+// The zero value answers every call with DefaultReply (""), so tests
+// only script what they assert on.
+type stubLLM struct {
+	mu gosync.Mutex
+
+	// Rules are matched in order; see stubRule.
+	Rules []*stubRule
+	// DefaultReply / DefaultErr answer calls no rule matched.
+	DefaultReply string
+	DefaultErr   error
+	// Delay is slept (outside the lock) before returning, giving
+	// concurrency assertions a window to observe overlap.
+	Delay time.Duration
+	// RendezvousOp + Rendezvous make calls whose op label equals
+	// RendezvousOp wait (up to rendezvousTimeout) until Rendezvous
+	// calls are in flight simultaneously. Proves SetLimit actually
+	// admits N concurrent workers without sleeping blind.
+	RendezvousOp string
+	Rendezvous   int
+
+	calls         []stubCall
+	activePrompts []string
+	inFlight      int
+	maxInFlight   int
+}
+
+const rendezvousTimeout = 2 * time.Second
+
+func (s *stubLLM) Name() string { return "stub/test" }
+
+func (s *stubLLM) Generate(ctx context.Context, prompt string) (string, error) {
+	return s.respond(ctx, prompt, false)
+}
+
+func (s *stubLLM) respond(ctx context.Context, prompt string, jsonMode bool) (string, error) {
+	// Mirror the real providers: a canceled/expired context fails the
+	// call. absorbDenseTwoPass checks gctx.Err() before dispatching, so
+	// in practice the stop-the-world tests never reach this — but the
+	// stub should not answer through a dead context either way.
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+
+	s.mu.Lock()
+	call := stubCall{
+		Prompt:        prompt,
+		JSONMode:      jsonMode,
+		Op:            opLabelFromContext(ctx),
+		NumCtx:        ollamaNumCtxFromContext(ctx),
+		ActiveAtEntry: append([]string(nil), s.activePrompts...),
+	}
+	s.calls = append(s.calls, call)
+	s.activePrompts = append(s.activePrompts, prompt)
+	s.inFlight++
+	if s.inFlight > s.maxInFlight {
+		s.maxInFlight = s.inFlight
+	}
+	// Rendezvous: wait for the configured number of same-op calls to
+	// be in flight at once. Poll-with-deadline keeps the implementation
+	// trivially race-free; on a mis-capped errgroup the wait times out
+	// instead of deadlocking and the test's maxInFlight assert fails.
+	if s.Rendezvous > 0 && call.Op == s.RendezvousOp {
+		deadline := time.Now().Add(rendezvousTimeout)
+		for s.inFlight < s.Rendezvous && time.Now().Before(deadline) {
+			s.mu.Unlock()
+			time.Sleep(time.Millisecond)
+			s.mu.Lock()
+		}
+	}
+	reply, err := s.pickLocked(prompt, call.Op)
+	delay := s.Delay
+	s.mu.Unlock()
+
+	if delay > 0 {
+		time.Sleep(delay)
+	}
+
+	s.mu.Lock()
+	s.inFlight--
+	for i, p := range s.activePrompts {
+		if p == prompt {
+			s.activePrompts = append(s.activePrompts[:i], s.activePrompts[i+1:]...)
+			break
+		}
+	}
+	s.mu.Unlock()
+
+	return reply, err
+}
+
+// pickLocked resolves the scripted response for a call. Caller holds s.mu.
+func (s *stubLLM) pickLocked(prompt, op string) (string, error) {
+	for _, r := range s.Rules {
+		if r.Once && r.used {
+			continue
+		}
+		if r.MatchOp != "" && r.MatchOp != op {
+			continue
+		}
+		if r.MatchPrompt != "" && !strings.Contains(prompt, r.MatchPrompt) {
+			continue
+		}
+		r.used = true
+		return r.Reply, r.Err
+	}
+	return s.DefaultReply, s.DefaultErr
+}
+
+// Calls returns a snapshot of every recorded call.
+func (s *stubLLM) Calls() []stubCall {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]stubCall(nil), s.calls...)
+}
+
+// CallsWithOp returns the recorded calls whose context op label equals op.
+func (s *stubLLM) CallsWithOp(op string) []stubCall {
+	var out []stubCall
+	for _, c := range s.Calls() {
+		if c.Op == op {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// MaxInFlight reports the high-water mark of concurrent calls.
+func (s *stubLLM) MaxInFlight() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.maxInFlight
+}
+
+// stubJSONLLM is stubLLM plus the jsonModeProvider capability, so
+// generateMaybeJSON dispatches to GenerateJSON (the Ollama-shaped path).
+// Calls record JSONMode=true.
+type stubJSONLLM struct {
+	stubLLM
+}
+
+func (s *stubJSONLLM) GenerateJSON(ctx context.Context, prompt string) (string, error) {
+	return s.respond(ctx, prompt, true)
+}
+
+// installStubLLM points the newLLMProvider seam at p for the duration of
+// the test, recording the (provider, model) pairs the driver asked for.
+// Restored in t.Cleanup. Tests using this must not call t.Parallel().
+func installStubLLM(t *testing.T, p llmProviderGenerator) *providerRequests {
+	t.Helper()
+	reqs := &providerRequests{}
+	orig := newLLMProvider
+	newLLMProvider = func(provider, model, _, _ string) llmProviderGenerator {
+		reqs.mu.Lock()
+		reqs.pairs = append(reqs.pairs, provider+"/"+model)
+		reqs.mu.Unlock()
+		return p
+	}
+	t.Cleanup(func() { newLLMProvider = orig })
+	return reqs
+}
+
+// providerRequests records the provider/model pairs requested through the
+// newLLMProvider seam, so tests can assert config routing (e.g. pass-1
+// model vs pass-2 model) without caring which stub answered.
+type providerRequests struct {
+	mu    gosync.Mutex
+	pairs []string
+}
+
+func (p *providerRequests) Pairs() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]string(nil), p.pairs...)
+}
+
+// claudeCall is one recorded runClaude invocation (tools-mode paths).
+type claudeCall struct {
+	Root    string
+	Prompt  string
+	Model   string
+	Tools   []string
+	Timeout time.Duration
+	Op      string
+}
+
+// stubClaude is a scripted stand-in for runClaude. Script, when set, is
+// consulted per call; otherwise every call succeeds with Reply.
+type stubClaude struct {
+	mu     gosync.Mutex
+	Script func(call claudeCall) (string, error)
+	Reply  string
+
+	calls []claudeCall
+}
+
+func (s *stubClaude) run(ctx context.Context, root, prompt, model string, tools []string, timeout time.Duration) (string, error) {
+	call := claudeCall{
+		Root:    root,
+		Prompt:  prompt,
+		Model:   model,
+		Tools:   append([]string(nil), tools...),
+		Timeout: timeout,
+		Op:      opLabelFromContext(ctx),
+	}
+	s.mu.Lock()
+	s.calls = append(s.calls, call)
+	script := s.Script
+	reply := s.Reply
+	s.mu.Unlock()
+	if script != nil {
+		return script(call)
+	}
+	return reply, nil
+}
+
+func (s *stubClaude) Calls() []claudeCall {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]claudeCall(nil), s.calls...)
+}
+
+// installStubClaude points the runClaude seam at a stubClaude for the
+// duration of the test. Restored in t.Cleanup. Tests using this must not
+// call t.Parallel().
+func installStubClaude(t *testing.T, c *stubClaude) {
+	t.Helper()
+	orig := runClaude
+	runClaude = c.run
+	t.Cleanup(func() { runClaude = orig })
+}
+
+// --- shared fixtures ----------------------------------------------------
+
+// stubHarnessKB scaffolds a minimal KB in a tempdir: the directory
+// layout absorb/deep need, a scribe.yaml with the caller's content, and
+// the env redirects that keep every write inside the sandbox
+// (XDG_CONFIG_HOME for the trust record + user config, HOME for the
+// discovery-path defaults, SCRIBE_KB for kbDir, SCRIBE_SKIP_REINDEX so
+// post-run reindex never re-executes the test binary).
+func stubHarnessKB(t *testing.T, scribeYAML string) string {
+	t.Helper()
+	root := t.TempDir()
+	for _, dir := range []string{"raw/articles", "wiki", "scripts", "output"} {
+		if err := os.MkdirAll(filepath.Join(root, dir), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(root, "scribe.yaml"), []byte(scribeYAML), 0o644); err != nil {
+		t.Fatalf("write scribe.yaml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "scripts", "projects.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatalf("write projects.json: %v", err)
+	}
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("SCRIBE_KB", root)
+	t.Setenv("SCRIBE_SKIP_REINDEX", "1")
+	// Clear the pass-2 A/B env overrides so a developer shell that has
+	// them exported can't flip the mode under the test's scribe.yaml.
+	t.Setenv("SCRIBE_PASS2_MODE", "")
+	t.Setenv("SCRIBE_PASS2_PROVIDER", "")
+	t.Setenv("SCRIBE_PASS2_MODEL", "")
+	return root
+}
+
+// planJSON renders an absorb pass-1 plan document.
+func planJSON(t *testing.T, rawFile, domain string, entities ...absorbEntity) string {
+	t.Helper()
+	b, err := json.Marshal(absorbPlan{RawFile: rawFile, SourceTitle: "Stub Source", Domain: domain, Entities: entities})
+	if err != nil {
+		t.Fatalf("marshal plan: %v", err)
+	}
+	return string(b)
+}
+
+// envelopeJSON renders a minimal valid WikiActionEnvelope creating one
+// article at path. The frontmatter carries every field the clamp seam
+// checks so apply is byte-deterministic.
+func envelopeJSON(t *testing.T, version int, entity, path, body string) string {
+	t.Helper()
+	content := fmt.Sprintf(`---
+title: %s
+type: research
+domain: general
+created: 2026-06-12
+updated: 2026-06-12
+confidence: medium
+tags: []
+---
+
+%s
+`, entity, body)
+	env := WikiActionEnvelope{
+		Version: version,
+		Entity:  entity,
+		Actions: []WikiAction{{Op: "create", Path: path, Content: content}},
+	}
+	b, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("marshal envelope: %v", err)
+	}
+	return string(b)
+}

--- a/cmd/scribe/scan.go
+++ b/cmd/scribe/scan.go
@@ -40,7 +40,7 @@ var (
 	toolsRE    = regexp.MustCompile(`(?i)(uses|integrates with|depends on|powered by|built with|replaced) [A-Z][a-zA-Z]*`)
 )
 
-//nolint:gocognit // LLM-driving path with 0% test coverage — decompose only once a stub-provider harness exists, a blind refactor risks silent behavior drift
+//nolint:gocognit // report contract now pinned by scan_run_test.go (issue #9 harness); decompose in a dedicated change with those tests green
 func (s *ScanCmd) Run() error {
 	projectPath, err := filepath.Abs(s.Path)
 	if err != nil {

--- a/cmd/scribe/scan_run_test.go
+++ b/cmd/scribe/scan_run_test.go
@@ -1,0 +1,207 @@
+// scan_run_test.go — driver tests for ScanCmd.Run. Scan is the one
+// nolint:gocognit driver with no LLM call of its own (it renders the
+// context packet other LLM passes consume), so the tests pin the
+// report's section contract against fixture projects: stack detection,
+// knowledge-tree filtering, root-doc inlining, KB linkage, and drop-file
+// listing. Stdout is the function's only output channel, so the tests
+// capture it.
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// captureStdout runs fn while capturing everything written to
+// os.Stdout, returning the captured text and fn's error.
+func captureStdout(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+	runErr := fn()
+	_ = w.Close()
+	os.Stdout = old
+	out := <-done
+	_ = r.Close()
+	return out, runErr
+}
+
+// scanProject builds a fixture Go project under a stable directory name.
+func scanProject(t *testing.T, name string) string {
+	t.Helper()
+	proj := filepath.Join(t.TempDir(), name)
+	files := map[string]string{
+		"go.mod":           "module example.test/scanfix\n\ngo 1.24\n",
+		"Makefile":         "build:\n\ttrue\n",
+		"README.md":        "# Scan Fixture\n\nWe chose pgvector over qdrant because the stack already runs postgres.\n",
+		"CLAUDE.md":        "# Agent guide\n\nShort guide body.\n",
+		"NOTES.md":         "# Ad-hoc notes\n\nA loose root doc.\n",
+		"docs/notes.md":    "# Docs\n\nThe importer is 3x faster after batching.\n",
+		"test/excluded.md": "# Should not appear\n\nfixture noise\n",
+	}
+	for rel, content := range files {
+		full := filepath.Join(proj, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatalf("mkdir for %s: %v", rel, err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+	return proj
+}
+
+// TestScanRun_ReportSectionsForGoProject: the full report renders every
+// section for a plain (non-git, KB-unlinked) Go project, includes the
+// knowledge files, and filters the /test/ noise.
+func TestScanRun_ReportSectionsForGoProject(t *testing.T) {
+	stubHarnessKB(t, "kb_name: stubkb\n")
+	proj := scanProject(t, "scanfix")
+
+	out, err := captureStdout(t, (&ScanCmd{Path: proj}).Run)
+	if err != nil {
+		t.Fatalf("ScanCmd.Run: %v", err)
+	}
+
+	for _, want := range []string{
+		"# Project Scan: scanfix",
+		"**Path**: `" + proj + "`",
+		"## Stack",
+		"- Go (`go.mod`)",
+		"- Makefile",
+		"## Knowledge File Tree",
+		"./docs/notes.md",
+		"## Directory Summary",
+		"## Key Entities",
+		"chose pgvector over qdrant", // decisions regex hit from README
+		"3x faster",                  // quantitative claim regex hit
+		"### README.md (",            // root doc inlined with line count
+		"### NOTES.md",               // ad-hoc root doc
+		"(not a git repo)",           // git section fallback
+		"### Makefile",               // config files section
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("report missing %q", want)
+		}
+	}
+
+	if strings.Contains(out, "excluded.md") {
+		t.Errorf("knowledge tree leaked a /test/ file")
+	}
+	if strings.Contains(out, "## scribe Link") {
+		t.Errorf("unlinked project must not render the scribe Link section")
+	}
+	if strings.Contains(out, "## scribe Drop Files") {
+		t.Errorf("project without drops must not render the drop-files section")
+	}
+}
+
+// TestScanRun_KBLinkAndDropFiles: a project registered in the KB
+// (projects/<name>/.repo.yaml) gets the scribe Link section with the
+// repo yaml + KB article list, and pending drop files under
+// .claude/<kb_name>/ are surfaced.
+func TestScanRun_KBLinkAndDropFiles(t *testing.T) {
+	root := stubHarnessKB(t, "kb_name: stubkb\n")
+	proj := scanProject(t, "AcmeProj")
+
+	kbProjDir := filepath.Join(root, "projects", "acmeproj")
+	if err := os.MkdirAll(kbProjDir, 0o755); err != nil {
+		t.Fatalf("mkdir kb project dir: %v", err)
+	}
+	repoYAML := "path: " + proj + "\ndomain: general\n"
+	if err := os.WriteFile(filepath.Join(kbProjDir, ".repo.yaml"), []byte(repoYAML), 0o644); err != nil {
+		t.Fatalf("write .repo.yaml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(kbProjDir, "learnings.md"), []byte("# Learnings\n"), 0o644); err != nil {
+		t.Fatalf("write learnings: %v", err)
+	}
+
+	dropDir := filepath.Join(proj, ".claude", "stubkb")
+	if err := os.MkdirAll(dropDir, 0o755); err != nil {
+		t.Fatalf("mkdir drop dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dropDir, "2026-06-01-insight.md"), []byte("---\nscriptorium: true\n---\n"), 0o644); err != nil {
+		t.Fatalf("write drop file: %v", err)
+	}
+
+	out, err := captureStdout(t, (&ScanCmd{Path: proj}).Run)
+	if err != nil {
+		t.Fatalf("ScanCmd.Run: %v", err)
+	}
+
+	for _, want := range []string{
+		"## scribe Link",
+		"domain: general",
+		"KB articles in acmeproj/:",
+		"- learnings.md",
+		"## scribe Drop Files (1 pending)",
+		"2026-06-01-insight.md",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("report missing %q", want)
+		}
+	}
+}
+
+// TestScanRun_MixExsDepsSection: an Elixir project gets its deps block
+// excerpted from mix.exs.
+func TestScanRun_MixExsDepsSection(t *testing.T) {
+	stubHarnessKB(t, "kb_name: stubkb\n")
+	proj := filepath.Join(t.TempDir(), "phoenixapp")
+	if err := os.MkdirAll(proj, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	mixExs := `defmodule Phoenixapp.MixProject do
+  use Mix.Project
+
+  defp deps do
+    [
+      {:phoenix, "~> 1.8"},
+      {:ecto_sql, "~> 3.12"}
+    ]
+  end
+end
+`
+	if err := os.WriteFile(filepath.Join(proj, "mix.exs"), []byte(mixExs), 0o644); err != nil {
+		t.Fatalf("write mix.exs: %v", err)
+	}
+
+	out, err := captureStdout(t, (&ScanCmd{Path: proj}).Run)
+	if err != nil {
+		t.Fatalf("ScanCmd.Run: %v", err)
+	}
+	for _, want := range []string{
+		"- Elixir/Phoenix (`mix.exs`)",
+		"### mix.exs deps",
+		`{:phoenix, "~> 1.8"}`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("report missing %q", want)
+		}
+	}
+}
+
+// TestScanRun_MissingPathErrors: scanning a nonexistent path fails fast.
+func TestScanRun_MissingPathErrors(t *testing.T) {
+	stubHarnessKB(t, "kb_name: stubkb\n")
+	missing := filepath.Join(t.TempDir(), "definitely-not-here")
+
+	_, err := captureStdout(t, (&ScanCmd{Path: missing}).Run)
+	if err == nil || !strings.Contains(err.Error(), "does not exist") {
+		t.Fatalf("err = %v, want does-not-exist error", err)
+	}
+}

--- a/cmd/scribe/sync.go
+++ b/cmd/scribe/sync.go
@@ -430,7 +430,16 @@ func (s *SyncCmd) commitAndPush(root, message string) (bool, error) {
 // callers (dream uses os/exec directly; assess + deep use this helper
 // so a fresh envelope-mode run leaves _index.md and _backlinks.json
 // in sync). Best-effort: any error is logged and discarded.
+//
+// Skipped when SCRIBE_SKIP_REINDEX=1, which tests set to avoid
+// re-executing the compiled test binary (os.Executable() returns the
+// test binary in tests, and running it with "backlinks" as argv
+// re-enters the test suite instead of the production CLI). Same guard
+// as WriteCmd.reindex.
 func rebuildIndexAndBacklinks(root string) {
+	if os.Getenv("SCRIBE_SKIP_REINDEX") == "1" {
+		return
+	}
 	scribeExe, _ := os.Executable()
 	if scribeExe == "" {
 		scribeExe = "scribe"

--- a/cmd/scribe/sync_absorb.go
+++ b/cmd/scribe/sync_absorb.go
@@ -291,7 +291,7 @@ func (s *SyncCmd) absorbSinglePass(root, rawFile string) error {
 // variant labels). If throughput becomes a problem, guard concurrent writes
 // with a per-wiki-path lock and parallelize.
 //
-//nolint:gocognit // concurrent LLM pipeline with stop-the-world rate-limit semantics and 0% test coverage — decompose only once a stub-provider harness exists
+//nolint:gocognit // concurrent LLM pipeline with stop-the-world rate-limit semantics — behavior now pinned by the stub-harness tests in sync_absorb_dense_test.go (issue #9); decompose in a dedicated change with those tests green
 func (s *SyncCmd) absorbDenseTwoPass(root, rawFile, rawName string) error {
 	cfg := loadConfig(root)
 	plansDir := filepath.Join(root, "output", "absorb-plans")

--- a/cmd/scribe/sync_absorb_dense_test.go
+++ b/cmd/scribe/sync_absorb_dense_test.go
@@ -1,0 +1,674 @@
+// sync_absorb_dense_test.go — driver tests for absorbDenseTwoPass (and
+// the absorbRaw checkpoint loop above it) running against the stub LLM
+// harness from llm_stub_test.go. These are the tests the
+// `nolint:gocognit` marker on absorbDenseTwoPass named as the
+// precondition for decomposing the function: they pin the concurrent
+// pipeline's observable semantics — fan-out caps, the stop-the-world
+// rate-limit/budget signals, the corrective retry, per-label write
+// serialization, and partial-progress behavior — without a network or
+// a real LLM.
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// denseAbsorbYAML is the scribe.yaml used by the json-mode dense tests.
+// chapter_aware off keeps pass-1 on the single-shot path (the chaptered
+// fan-out has its own knobs); pass2_mode json routes pass-2 through the
+// provider seam instead of `claude -p`.
+const denseAbsorbYAML = `kb_name: stubkb
+absorb:
+  chapter_aware: false
+  pass2_mode: json
+  pass2_provider: anthropic
+  pass2_parallel: 1
+  pass1_timeout_min: 1
+  pass2_timeout_min: 1
+  single_pass_timeout_min: 1
+  contextualize:
+    enabled: false
+`
+
+// writeDenseRaw drops a raw article fixture and returns (path, name).
+// The body is irrelevant to absorbDenseTwoPass itself (density gating
+// happens in the caller) but carries a unique marker so tests can
+// assert the body was inlined into prompts.
+func writeDenseRaw(t *testing.T, root, name, marker string) (string, string) {
+	t.Helper()
+	body := `---
+title: Stub Article
+source_url: https://example.invalid/a
+domain: general
+density: dense
+---
+
+# Stub Article
+
+` + marker + ` body text for the dense absorb driver test.
+`
+	path := filepath.Join(root, "raw", "articles", name)
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write raw article: %v", err)
+	}
+	return path, name
+}
+
+func entity(label, oneLine string) absorbEntity {
+	return absorbEntity{Label: label, Type: "concept", OneLine: oneLine, KeyClaims: []string{"claim for " + label}}
+}
+
+// withParallel returns denseAbsorbYAML with pass2_parallel swapped.
+func withParallel(t *testing.T, n string) string {
+	t.Helper()
+	out := strings.Replace(denseAbsorbYAML, "pass2_parallel: 1", "pass2_parallel: "+n, 1)
+	if out == denseAbsorbYAML {
+		t.Fatal("pass2_parallel knob not found in fixture yaml")
+	}
+	return out
+}
+
+// TestAbsorbDenseTwoPass_JSONMode_HappyPath: pass-1 plans two entities,
+// pass-2 writes one wiki page per entity through applyWikiActions. The
+// stub also proves the prompt plumbing: entity labels, the inlined raw
+// body, the inlined plan JSON, and the num_ctx context tag all reach
+// the provider.
+func TestAbsorbDenseTwoPass_JSONMode_HappyPath(t *testing.T) {
+	root := stubHarnessKB(t, denseAbsorbYAML)
+	rawFile, rawName := writeDenseRaw(t, root, "2026-06-01-stub.md", "MARKER-HAPPY")
+
+	stub := &stubJSONLLM{}
+	stub.Rules = []*stubRule{
+		{MatchOp: "absorb-pass1-whole", Reply: planJSON(t, rawFile, "general", entity("Alpha", "first"), entity("Beta", "second"))},
+		{MatchOp: "absorb-pass2", MatchPrompt: "- Label: Alpha", Reply: envelopeJSON(t, 1, "Alpha", "wiki/alpha.md", "Alpha body.")},
+		{MatchOp: "absorb-pass2", MatchPrompt: "- Label: Beta", Reply: envelopeJSON(t, 1, "Beta", "wiki/beta.md", "Beta body.")},
+	}
+	installStubLLM(t, stub)
+
+	sc := &SyncCmd{Model: "sonnet"}
+	if err := sc.absorbDenseTwoPass(root, rawFile, rawName); err != nil {
+		t.Fatalf("absorbDenseTwoPass: %v", err)
+	}
+
+	for page, want := range map[string]string{
+		"wiki/alpha.md": "Alpha body.",
+		"wiki/beta.md":  "Beta body.",
+	} {
+		data, err := os.ReadFile(filepath.Join(root, page))
+		if err != nil {
+			t.Fatalf("expected %s to exist: %v", page, err)
+		}
+		if !strings.Contains(string(data), want) {
+			t.Errorf("%s missing body %q:\n%s", page, want, data)
+		}
+	}
+
+	// Plan checkpoint written to output/absorb-plans/<stem>.json.
+	if _, err := os.Stat(filepath.Join(root, "output", "absorb-plans", "2026-06-01-stub.json")); err != nil {
+		t.Errorf("plan file not checkpointed: %v", err)
+	}
+
+	if got := len(stub.CallsWithOp("absorb-pass1-whole")); got != 1 {
+		t.Errorf("pass1 calls = %d, want 1", got)
+	}
+	pass2 := stub.CallsWithOp("absorb-pass2")
+	if len(pass2) != 2 {
+		t.Fatalf("pass2 calls = %d, want 2", len(pass2))
+	}
+	for _, c := range pass2 {
+		if !c.JSONMode {
+			t.Errorf("pass2 call did not use GenerateJSON (jsonModeProvider dispatch broken)")
+		}
+		if !strings.Contains(c.Prompt, "MARKER-HAPPY") {
+			t.Errorf("pass2 prompt missing inlined raw body")
+		}
+		if !strings.Contains(c.Prompt, `"Stub Source"`) {
+			t.Errorf("pass2 prompt missing inlined plan JSON")
+		}
+		if c.NumCtx <= 0 {
+			t.Errorf("pass2 call num_ctx = %d, want >0 (withOllamaNumCtx tag lost)", c.NumCtx)
+		}
+	}
+}
+
+// TestAbsorbDenseTwoPass_RateLimitStopsTheWorld: one rate-limited
+// pass-2 entity cancels the errgroup context, so queued entities exit
+// before ever reaching the provider, and ErrRateLimit surfaces to the
+// caller so the sync loop can stop cleanly and resume next run.
+func TestAbsorbDenseTwoPass_RateLimitStopsTheWorld(t *testing.T) {
+	root := stubHarnessKB(t, denseAbsorbYAML) // pass2_parallel: 1 → deterministic order
+	rawFile, rawName := writeDenseRaw(t, root, "2026-06-01-rl.md", "MARKER-RL")
+
+	stub := &stubLLM{}
+	stub.Rules = []*stubRule{
+		{MatchOp: "absorb-pass1-whole", Reply: planJSON(t, rawFile, "general", entity("Alpha", "a"), entity("Beta", "b"), entity("Gamma", "c"))},
+		{MatchOp: "absorb-pass2", MatchPrompt: "- Label: Alpha", Err: ErrRateLimit},
+		// Beta / Gamma rules intentionally absent: they must never be asked.
+	}
+	installStubLLM(t, stub)
+
+	sc := &SyncCmd{Model: "sonnet"}
+	err := sc.absorbDenseTwoPass(root, rawFile, rawName)
+	if !errors.Is(err, ErrRateLimit) {
+		t.Fatalf("err = %v, want ErrRateLimit", err)
+	}
+	if got := len(stub.CallsWithOp("absorb-pass2")); got != 1 {
+		t.Errorf("pass2 calls = %d, want 1 — rate limit must stop the world before Beta/Gamma run", got)
+	}
+	if _, err := os.Stat(filepath.Join(root, "wiki", "alpha.md")); !os.IsNotExist(err) {
+		t.Errorf("no wiki page should have been written, stat err = %v", err)
+	}
+}
+
+// TestAbsorbDenseTwoPass_BudgetExhaustedStopsDistinctly: the daily
+// budget ceiling uses the same stop-the-world shape as rate limit but
+// must keep its own identity at the function boundary so the caller
+// can log it accurately (json mode tracks it separately).
+func TestAbsorbDenseTwoPass_BudgetExhaustedStopsDistinctly(t *testing.T) {
+	root := stubHarnessKB(t, denseAbsorbYAML)
+	rawFile, rawName := writeDenseRaw(t, root, "2026-06-01-budget.md", "MARKER-BUDGET")
+
+	stub := &stubLLM{}
+	stub.Rules = []*stubRule{
+		{MatchOp: "absorb-pass1-whole", Reply: planJSON(t, rawFile, "general", entity("Alpha", "a"), entity("Beta", "b"))},
+		{MatchOp: "absorb-pass2", MatchPrompt: "- Label: Alpha", Err: ErrDailyBudgetExhausted},
+	}
+	installStubLLM(t, stub)
+
+	sc := &SyncCmd{Model: "sonnet"}
+	err := sc.absorbDenseTwoPass(root, rawFile, rawName)
+	if !errors.Is(err, ErrDailyBudgetExhausted) {
+		t.Fatalf("err = %v, want ErrDailyBudgetExhausted", err)
+	}
+	if errors.Is(err, ErrRateLimit) {
+		t.Errorf("budget exhaustion must not be reported as a rate limit in json mode")
+	}
+	if got := len(stub.CallsWithOp("absorb-pass2")); got != 1 {
+		t.Errorf("pass2 calls = %d, want 1", got)
+	}
+}
+
+// TestAbsorbDenseTwoPass_CorrectiveRetryRecoversMalformedEnvelope: a
+// first pass-2 response that isn't a JSON envelope triggers exactly one
+// corrective retry with the sharper instruction appended; a clean retry
+// response is applied normally.
+func TestAbsorbDenseTwoPass_CorrectiveRetryRecoversMalformedEnvelope(t *testing.T) {
+	root := stubHarnessKB(t, denseAbsorbYAML)
+	rawFile, rawName := writeDenseRaw(t, root, "2026-06-01-retry.md", "MARKER-RETRY")
+
+	stub := &stubLLM{}
+	stub.Rules = []*stubRule{
+		{MatchOp: "absorb-pass1-whole", Reply: planJSON(t, rawFile, "general", entity("Alpha", "a"))},
+		{MatchOp: "absorb-pass2", Once: true, Reply: "sorry, here is some prose instead of an envelope"},
+		{MatchOp: "absorb-pass2", MatchPrompt: "## CORRECTION", Reply: envelopeJSON(t, 1, "Alpha", "wiki/alpha.md", "Alpha body.")},
+	}
+	installStubLLM(t, stub)
+
+	sc := &SyncCmd{Model: "sonnet"}
+	if err := sc.absorbDenseTwoPass(root, rawFile, rawName); err != nil {
+		t.Fatalf("absorbDenseTwoPass: %v", err)
+	}
+
+	pass2 := stub.CallsWithOp("absorb-pass2")
+	if len(pass2) != 2 {
+		t.Fatalf("pass2 calls = %d, want 2 (original + corrective retry)", len(pass2))
+	}
+	if strings.Contains(pass2[0].Prompt, "## CORRECTION") {
+		t.Errorf("first pass2 attempt must not carry the corrective suffix")
+	}
+	if !strings.Contains(pass2[1].Prompt, "## CORRECTION") {
+		t.Errorf("retry prompt missing the corrective instruction")
+	}
+	if _, err := os.Stat(filepath.Join(root, "wiki", "alpha.md")); err != nil {
+		t.Errorf("retry result not applied: %v", err)
+	}
+}
+
+// TestAbsorbDenseTwoPass_RetryFailurePreservesPartialProgress: an
+// entity whose retry also fails is dropped without failing the absorb —
+// the other entities still land. Partial absorb beats losing the source.
+func TestAbsorbDenseTwoPass_RetryFailurePreservesPartialProgress(t *testing.T) {
+	root := stubHarnessKB(t, denseAbsorbYAML) // parallel: 1 → deterministic
+	rawFile, rawName := writeDenseRaw(t, root, "2026-06-01-partial.md", "MARKER-PARTIAL")
+
+	stub := &stubLLM{}
+	stub.Rules = []*stubRule{
+		{MatchOp: "absorb-pass1-whole", Reply: planJSON(t, rawFile, "general", entity("Alpha", "a"), entity("Beta", "b"))},
+		{MatchOp: "absorb-pass2", MatchPrompt: "- Label: Alpha", Reply: "still not an envelope"}, // matches retry too
+		{MatchOp: "absorb-pass2", MatchPrompt: "- Label: Beta", Reply: envelopeJSON(t, 1, "Beta", "wiki/beta.md", "Beta body.")},
+	}
+	installStubLLM(t, stub)
+
+	sc := &SyncCmd{Model: "sonnet"}
+	if err := sc.absorbDenseTwoPass(root, rawFile, rawName); err != nil {
+		t.Fatalf("absorbDenseTwoPass: %v (per-entity failure must not abort the absorb)", err)
+	}
+	if got := len(stub.CallsWithOp("absorb-pass2")); got != 3 {
+		t.Errorf("pass2 calls = %d, want 3 (Alpha twice, Beta once)", got)
+	}
+	if _, err := os.Stat(filepath.Join(root, "wiki", "alpha.md")); !os.IsNotExist(err) {
+		t.Errorf("alpha page should not exist, stat err = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "wiki", "beta.md")); err != nil {
+		t.Errorf("beta page missing — partial progress lost: %v", err)
+	}
+}
+
+// TestAbsorbDenseTwoPass_EmptyPlanFallsBackToSinglePass: a pass-1 plan
+// with zero entities reroutes the article through the single-pass
+// absorb instead of silently doing nothing.
+func TestAbsorbDenseTwoPass_EmptyPlanFallsBackToSinglePass(t *testing.T) {
+	root := stubHarnessKB(t, denseAbsorbYAML)
+	rawFile, rawName := writeDenseRaw(t, root, "2026-06-01-empty.md", "MARKER-EMPTY")
+
+	stub := &stubLLM{}
+	stub.Rules = []*stubRule{
+		{MatchOp: "absorb-pass1-whole", Reply: planJSON(t, rawFile, "general")},
+		{MatchOp: "absorb-single", Reply: envelopeJSON(t, 1, "Single Note", "wiki/single-note.md", "Single body.")},
+	}
+	installStubLLM(t, stub)
+
+	sc := &SyncCmd{Model: "sonnet"}
+	if err := sc.absorbDenseTwoPass(root, rawFile, rawName); err != nil {
+		t.Fatalf("absorbDenseTwoPass: %v", err)
+	}
+	if got := len(stub.CallsWithOp("absorb-pass2")); got != 0 {
+		t.Errorf("pass2 calls = %d, want 0", got)
+	}
+	if got := len(stub.CallsWithOp("absorb-single")); got != 1 {
+		t.Errorf("single-pass calls = %d, want 1", got)
+	}
+	if _, err := os.Stat(filepath.Join(root, "wiki", "single-note.md")); err != nil {
+		t.Errorf("single-pass page missing: %v", err)
+	}
+}
+
+// TestAbsorbDenseTwoPass_Pass1RateLimitPropagates: a rate limit during
+// pass-1 aborts before any pass-2 work and keeps its sentinel identity.
+func TestAbsorbDenseTwoPass_Pass1RateLimitPropagates(t *testing.T) {
+	root := stubHarnessKB(t, denseAbsorbYAML)
+	rawFile, rawName := writeDenseRaw(t, root, "2026-06-01-p1rl.md", "MARKER-P1RL")
+
+	stub := &stubLLM{}
+	stub.Rules = []*stubRule{{MatchOp: "absorb-pass1-whole", Err: ErrRateLimit}}
+	installStubLLM(t, stub)
+
+	sc := &SyncCmd{Model: "sonnet"}
+	err := sc.absorbDenseTwoPass(root, rawFile, rawName)
+	if !errors.Is(err, ErrRateLimit) {
+		t.Fatalf("err = %v, want ErrRateLimit", err)
+	}
+	if got := len(stub.CallsWithOp("absorb-pass2")); got != 0 {
+		t.Errorf("pass2 calls = %d, want 0", got)
+	}
+}
+
+// TestAbsorbDenseTwoPass_Pass1GarbageOutputErrors: pass-1 output with
+// no JSON object is a hard error (nothing to plan from), and pass-2
+// never runs.
+func TestAbsorbDenseTwoPass_Pass1GarbageOutputErrors(t *testing.T) {
+	root := stubHarnessKB(t, denseAbsorbYAML)
+	rawFile, rawName := writeDenseRaw(t, root, "2026-06-01-p1bad.md", "MARKER-P1BAD")
+
+	stub := &stubLLM{DefaultReply: "no json object anywhere in this reply"}
+	installStubLLM(t, stub)
+
+	sc := &SyncCmd{Model: "sonnet"}
+	err := sc.absorbDenseTwoPass(root, rawFile, rawName)
+	if err == nil || !strings.Contains(err.Error(), "no JSON object") {
+		t.Fatalf("err = %v, want pass1 no-JSON error", err)
+	}
+	if got := len(stub.CallsWithOp("absorb-pass2")); got != 0 {
+		t.Errorf("pass2 calls = %d, want 0", got)
+	}
+}
+
+// TestAbsorbDenseTwoPass_ParallelCapRespected: with pass2_parallel=2
+// and four entities, exactly two pass-2 calls run concurrently — the
+// rendezvous in the stub proves the fan-out actually overlaps, and the
+// high-water mark proves SetLimit caps it.
+func TestAbsorbDenseTwoPass_ParallelCapRespected(t *testing.T) {
+	root := stubHarnessKB(t, withParallel(t, "2"))
+	rawFile, rawName := writeDenseRaw(t, root, "2026-06-01-par.md", "MARKER-PAR")
+
+	stub := &stubLLM{
+		RendezvousOp: "absorb-pass2",
+		Rendezvous:   2,
+	}
+	stub.Rules = []*stubRule{
+		{MatchOp: "absorb-pass1-whole", Reply: planJSON(t, rawFile, "general",
+			entity("Alpha", "a"), entity("Beta", "b"), entity("Gamma", "c"), entity("Delta", "d"))},
+		{MatchOp: "absorb-pass2", MatchPrompt: "- Label: Alpha", Reply: envelopeJSON(t, 1, "Alpha", "wiki/alpha.md", "A.")},
+		{MatchOp: "absorb-pass2", MatchPrompt: "- Label: Beta", Reply: envelopeJSON(t, 1, "Beta", "wiki/beta.md", "B.")},
+		{MatchOp: "absorb-pass2", MatchPrompt: "- Label: Gamma", Reply: envelopeJSON(t, 1, "Gamma", "wiki/gamma.md", "G.")},
+		{MatchOp: "absorb-pass2", MatchPrompt: "- Label: Delta", Reply: envelopeJSON(t, 1, "Delta", "wiki/delta.md", "D.")},
+	}
+	installStubLLM(t, stub)
+
+	sc := &SyncCmd{Model: "sonnet"}
+	if err := sc.absorbDenseTwoPass(root, rawFile, rawName); err != nil {
+		t.Fatalf("absorbDenseTwoPass: %v", err)
+	}
+	if got := len(stub.CallsWithOp("absorb-pass2")); got != 4 {
+		t.Errorf("pass2 calls = %d, want 4", got)
+	}
+	if got := stub.MaxInFlight(); got != 2 {
+		t.Errorf("max in-flight = %d, want exactly 2 (SetLimit cap with real overlap)", got)
+	}
+	for _, page := range []string{"alpha", "beta", "gamma", "delta"} {
+		if _, err := os.Stat(filepath.Join(root, "wiki", page+".md")); err != nil {
+			t.Errorf("missing %s.md: %v", page, err)
+		}
+	}
+}
+
+// TestAbsorbDenseTwoPass_SameLabelEntitiesSerialize: two entities with
+// the same label target the same wiki page, so the per-label mutex must
+// serialize their provider calls even when the parallel budget would
+// allow overlap. The Delay gives a broken lock a window to interleave;
+// ActiveAtEntry proves no second same-label call entered while the
+// first was in flight.
+func TestAbsorbDenseTwoPass_SameLabelEntitiesSerialize(t *testing.T) {
+	root := stubHarnessKB(t, withParallel(t, "2"))
+	rawFile, rawName := writeDenseRaw(t, root, "2026-06-01-lock.md", "MARKER-LOCK")
+
+	stub := &stubLLM{Delay: 50 * time.Millisecond}
+	stub.Rules = []*stubRule{
+		{MatchOp: "absorb-pass1-whole", Reply: planJSON(t, rawFile, "general",
+			entity("Alpha", "first occurrence"), entity("Alpha", "variant occurrence"))},
+		{MatchOp: "absorb-pass2", MatchPrompt: "- Label: Alpha", Reply: envelopeJSON(t, 1, "Alpha", "wiki/alpha.md", "Alpha body.")},
+	}
+	installStubLLM(t, stub)
+
+	sc := &SyncCmd{Model: "sonnet"}
+	if err := sc.absorbDenseTwoPass(root, rawFile, rawName); err != nil {
+		t.Fatalf("absorbDenseTwoPass: %v", err)
+	}
+	pass2 := stub.CallsWithOp("absorb-pass2")
+	if len(pass2) != 2 {
+		t.Fatalf("pass2 calls = %d, want 2", len(pass2))
+	}
+	for i, c := range pass2 {
+		for _, active := range c.ActiveAtEntry {
+			if strings.Contains(active, "- Label: Alpha") {
+				t.Errorf("pass2 call %d entered while another Alpha call was in flight — per-label lock broken", i)
+			}
+		}
+	}
+}
+
+// TestAbsorbDenseTwoPass_ToolsModeUsesRunClaude: with pass2_mode=tools
+// pass-2 goes through the runClaude seam — one call per entity carrying
+// the sync model, the file-mutation tool set, and the entity-focused
+// prompt. The wiki write happens inside claude in this mode, so only
+// the call plumbing is asserted.
+func TestAbsorbDenseTwoPass_ToolsModeUsesRunClaude(t *testing.T) {
+	yaml := strings.Replace(denseAbsorbYAML, "pass2_mode: json", "pass2_mode: tools", 1)
+	root := stubHarnessKB(t, yaml)
+	rawFile, rawName := writeDenseRaw(t, root, "2026-06-01-tools.md", "MARKER-TOOLS")
+
+	stub := &stubLLM{}
+	stub.Rules = []*stubRule{
+		{MatchOp: "absorb-pass1-whole", Reply: planJSON(t, rawFile, "general", entity("Alpha", "a"), entity("Beta", "b"))},
+	}
+	installStubLLM(t, stub)
+	claude := &stubClaude{Reply: "done"}
+	installStubClaude(t, claude)
+
+	sc := &SyncCmd{Model: "sonnet"}
+	if err := sc.absorbDenseTwoPass(root, rawFile, rawName); err != nil {
+		t.Fatalf("absorbDenseTwoPass: %v", err)
+	}
+
+	calls := claude.Calls()
+	if len(calls) != 2 {
+		t.Fatalf("runClaude calls = %d, want 2", len(calls))
+	}
+	var sawAlpha, sawBeta bool
+	for _, c := range calls {
+		if c.Model != "sonnet" {
+			t.Errorf("model = %q, want sonnet (inherited from SyncCmd.Model)", c.Model)
+		}
+		if c.Root != root {
+			t.Errorf("root = %q, want %q", c.Root, root)
+		}
+		if c.Op != "absorb-pass2" {
+			t.Errorf("op = %q, want absorb-pass2", c.Op)
+		}
+		if !strings.Contains(strings.Join(c.Tools, ","), "Write") {
+			t.Errorf("tools %v missing Write", c.Tools)
+		}
+		if strings.Contains(c.Prompt, "Entity to write: Alpha") {
+			sawAlpha = true
+		}
+		if strings.Contains(c.Prompt, "Entity to write: Beta") {
+			sawBeta = true
+		}
+	}
+	if !sawAlpha || !sawBeta {
+		t.Errorf("entity prompts incomplete: alpha=%v beta=%v", sawAlpha, sawBeta)
+	}
+}
+
+// TestAbsorbDenseTwoPass_ToolsModeRateLimitStops: rate limit in tools
+// mode is the same stop-the-world signal. Note the documented quirk
+// preserved here: in tools mode ErrDailyBudgetExhausted shares the
+// rateLimited flag, so both sentinels surface as ErrRateLimit — the
+// caller stops cleanly either way.
+func TestAbsorbDenseTwoPass_ToolsModeRateLimitStops(t *testing.T) {
+	yaml := strings.Replace(denseAbsorbYAML, "pass2_mode: json", "pass2_mode: tools", 1)
+	root := stubHarnessKB(t, yaml)
+	rawFile, rawName := writeDenseRaw(t, root, "2026-06-01-toolsrl.md", "MARKER-TOOLSRL")
+
+	stub := &stubLLM{}
+	stub.Rules = []*stubRule{
+		{MatchOp: "absorb-pass1-whole", Reply: planJSON(t, rawFile, "general", entity("Alpha", "a"), entity("Beta", "b"), entity("Gamma", "c"))},
+	}
+	installStubLLM(t, stub)
+	claude := &stubClaude{Script: func(claudeCall) (string, error) {
+		return "", ErrRateLimit
+	}}
+	installStubClaude(t, claude)
+
+	sc := &SyncCmd{Model: "sonnet"}
+	err := sc.absorbDenseTwoPass(root, rawFile, rawName)
+	if !errors.Is(err, ErrRateLimit) {
+		t.Fatalf("err = %v, want ErrRateLimit", err)
+	}
+	if got := len(claude.Calls()); got != 1 {
+		t.Errorf("runClaude calls = %d, want 1 (stop-the-world)", got)
+	}
+}
+
+// chapteredYAML flips the chaptered pass-1 fan-out on with the given
+// chapter parallelism.
+func chapteredYAML(t *testing.T, parallel string) string {
+	t.Helper()
+	out := strings.Replace(denseAbsorbYAML, "chapter_aware: false",
+		"chapter_aware: true\n  chapter_parallel: "+parallel, 1)
+	if out == denseAbsorbYAML {
+		t.Fatal("chapter_aware knob not found in fixture yaml")
+	}
+	return out
+}
+
+// writeChapteredRaw writes a raw article with three >6KB H2 sections so
+// chunkByHeadings yields three chunks (sections under MinChunkBytes
+// would coalesce). Each section carries a unique marker the stub rules
+// key on.
+func writeChapteredRaw(t *testing.T, root, name string) (string, string) {
+	t.Helper()
+	filler := strings.Repeat("filler words for the chapter body keep flowing here. ", 170) // ~9KB
+	body := "---\ntitle: Chaptered Stub\ndensity: dense\n---\n\n" +
+		"## Heading One\n\nCH1-MARKER " + filler + "\n\n" +
+		"## Heading Two\n\nCH2-MARKER " + filler + "\n\n" +
+		"## Heading Three\n\nCH3-MARKER " + filler + "\n"
+	path := filepath.Join(root, "raw", "articles", name)
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write chaptered raw: %v", err)
+	}
+	return path, name
+}
+
+// chapterPlanJSON renders the per-chapter plan document the chapter
+// pass-1 prompt asks for.
+func chapterPlanJSON(t *testing.T, rawFile, chapter string, entities ...absorbEntity) string {
+	t.Helper()
+	b, err := json.Marshal(chapterPlan{RawFile: rawFile, SourceTitle: "Chaptered Stub", Chapter: chapter, Domain: "general", Entities: entities})
+	if err != nil {
+		t.Fatalf("marshal chapter plan: %v", err)
+	}
+	return string(b)
+}
+
+// TestAbsorbDenseTwoPass_ChapteredPass1FansOutAndMerges: with a TOC-less
+// but heading-rich article, pass-1 fans out one call per chapter, the
+// per-chapter plans merge (same-label entities dedup with their key
+// claims folded together), and pass-2 runs once per merged entity.
+func TestAbsorbDenseTwoPass_ChapteredPass1FansOutAndMerges(t *testing.T) {
+	root := stubHarnessKB(t, chapteredYAML(t, "2"))
+	rawFile, rawName := writeChapteredRaw(t, root, "2026-06-01-chapters.md")
+
+	alphaCh1 := absorbEntity{Label: "Alpha", Type: "concept", OneLine: "from ch1", KeyClaims: []string{"claim one"}}
+	alphaCh2 := absorbEntity{Label: "Alpha", Type: "concept", OneLine: "", KeyClaims: []string{"claim variant"}}
+	beta := entity("Beta", "from ch2")
+	gamma := entity("Gamma", "from ch3")
+
+	stub := &stubLLM{}
+	stub.Rules = []*stubRule{
+		{MatchOp: "absorb-pass1-chapter", MatchPrompt: "CH1-MARKER", Reply: chapterPlanJSON(t, rawFile, "Heading One", alphaCh1)},
+		{MatchOp: "absorb-pass1-chapter", MatchPrompt: "CH2-MARKER", Reply: chapterPlanJSON(t, rawFile, "Heading Two", alphaCh2, beta)},
+		{MatchOp: "absorb-pass1-chapter", MatchPrompt: "CH3-MARKER", Reply: chapterPlanJSON(t, rawFile, "Heading Three", gamma)},
+		{MatchOp: "absorb-pass2", MatchPrompt: "- Label: Alpha", Reply: envelopeJSON(t, 1, "Alpha", "wiki/alpha.md", "A.")},
+		{MatchOp: "absorb-pass2", MatchPrompt: "- Label: Beta", Reply: envelopeJSON(t, 1, "Beta", "wiki/beta.md", "B.")},
+		{MatchOp: "absorb-pass2", MatchPrompt: "- Label: Gamma", Reply: envelopeJSON(t, 1, "Gamma", "wiki/gamma.md", "G.")},
+	}
+	installStubLLM(t, stub)
+
+	sc := &SyncCmd{Model: "sonnet"}
+	if err := sc.absorbDenseTwoPass(root, rawFile, rawName); err != nil {
+		t.Fatalf("absorbDenseTwoPass: %v", err)
+	}
+
+	if got := len(stub.CallsWithOp("absorb-pass1-whole")); got != 0 {
+		t.Errorf("whole-article pass1 calls = %d, want 0 (chaptered path active)", got)
+	}
+	if got := len(stub.CallsWithOp("absorb-pass1-chapter")); got != 3 {
+		t.Errorf("chapter pass1 calls = %d, want 3", got)
+	}
+	pass2 := stub.CallsWithOp("absorb-pass2")
+	if len(pass2) != 3 {
+		t.Fatalf("pass2 calls = %d, want 3 (Alpha deduped across chapters)", len(pass2))
+	}
+	var alphaPrompt string
+	for _, c := range pass2 {
+		if strings.Contains(c.Prompt, "- Label: Alpha") {
+			alphaPrompt = c.Prompt
+		}
+	}
+	if !strings.Contains(alphaPrompt, "claim one | claim variant") {
+		t.Errorf("merged Alpha key claims missing from pass2 prompt — chapter dedup didn't fold claims")
+	}
+
+	for _, page := range []string{"alpha", "beta", "gamma"} {
+		if _, err := os.Stat(filepath.Join(root, "wiki", page+".md")); err != nil {
+			t.Errorf("missing %s.md: %v", page, err)
+		}
+	}
+	// Chunk + per-chapter plan checkpoints written for post-mortems.
+	chunks, _ := filepath.Glob(filepath.Join(root, "output", "absorb-chunks", "2026-06-01-chapters", "*.md"))
+	if len(chunks) != 3 {
+		t.Errorf("chunk files = %d, want 3", len(chunks))
+	}
+	plans, _ := filepath.Glob(filepath.Join(root, "output", "absorb-plans", "2026-06-01-chapters-chapters", "*.json"))
+	if len(plans) != 3 {
+		t.Errorf("per-chapter plan files = %d, want 3", len(plans))
+	}
+}
+
+// TestAbsorbDenseTwoPass_ChapteredRateLimitPropagates: a rate limit in
+// the chapter fan-out is stop-the-world too — remaining chapters are
+// never asked and the sentinel reaches the caller unchanged (no
+// whole-article fallback for rate limits).
+func TestAbsorbDenseTwoPass_ChapteredRateLimitPropagates(t *testing.T) {
+	root := stubHarnessKB(t, chapteredYAML(t, "1"))
+	rawFile, rawName := writeChapteredRaw(t, root, "2026-06-01-chrl.md")
+
+	stub := &stubLLM{}
+	stub.Rules = []*stubRule{
+		{MatchOp: "absorb-pass1-chapter", Err: ErrRateLimit},
+	}
+	installStubLLM(t, stub)
+
+	sc := &SyncCmd{Model: "sonnet"}
+	err := sc.absorbDenseTwoPass(root, rawFile, rawName)
+	if !errors.Is(err, ErrRateLimit) {
+		t.Fatalf("err = %v, want ErrRateLimit", err)
+	}
+	if got := len(stub.CallsWithOp("absorb-pass1-chapter")); got != 1 {
+		t.Errorf("chapter pass1 calls = %d, want 1 (stop-the-world)", got)
+	}
+	if got := len(stub.CallsWithOp("absorb-pass1-whole")); got != 0 {
+		t.Errorf("whole-article fallback ran %d times after a rate limit — must not", got)
+	}
+	if got := len(stub.CallsWithOp("absorb-pass2")); got != 0 {
+		t.Errorf("pass2 calls = %d, want 0", got)
+	}
+}
+
+// TestAbsorbRaw_CheckpointsProgressAndStopsOnRateLimit: the absorb loop
+// above absorbDenseTwoPass marks each article in wiki/_absorb_log.json
+// as it lands, so a rate limit mid-run keeps the finished work and
+// resumes with the unfinished article next run.
+func TestAbsorbRaw_CheckpointsProgressAndStopsOnRateLimit(t *testing.T) {
+	root := stubHarnessKB(t, denseAbsorbYAML)
+
+	// Two standard-density articles (60+ words, no headings → not dense,
+	// not a stub) absorbed via the single-pass path, in ReadDir order.
+	longBody := strings.Repeat("knowledge worth keeping flows through this paragraph again and again. ", 12)
+	for name, marker := range map[string]string{
+		"2026-06-01-one.md": "UNIQUE-TOKEN-ONE",
+		"2026-06-02-two.md": "UNIQUE-TOKEN-TWO",
+	} {
+		content := "---\ntitle: " + name + "\nsource_url: https://example.invalid/" + name + "\n---\n\n" + marker + " " + longBody
+		if err := os.WriteFile(filepath.Join(root, "raw", "articles", name), []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	stub := &stubLLM{}
+	stub.Rules = []*stubRule{
+		{MatchOp: "absorb-single", MatchPrompt: "UNIQUE-TOKEN-ONE", Reply: envelopeJSON(t, 1, "One", "wiki/one.md", "One body.")},
+		{MatchOp: "absorb-single", MatchPrompt: "UNIQUE-TOKEN-TWO", Err: ErrRateLimit},
+	}
+	installStubLLM(t, stub)
+
+	sc := &SyncCmd{Model: "sonnet"}
+	absorbed, err := sc.absorbRaw(root)
+	if err != nil {
+		t.Fatalf("absorbRaw: %v (rate limit should stop cleanly, not error)", err)
+	}
+	if absorbed != 1 {
+		t.Errorf("absorbed = %d, want 1", absorbed)
+	}
+	if _, err := os.Stat(filepath.Join(root, "wiki", "one.md")); err != nil {
+		t.Errorf("first article's page missing: %v", err)
+	}
+
+	logData, err := os.ReadFile(filepath.Join(root, "wiki", "_absorb_log.json"))
+	if err != nil {
+		t.Fatalf("read absorb log: %v", err)
+	}
+	if !strings.Contains(string(logData), "2026-06-01-one.md") {
+		t.Errorf("absorb log missing checkpoint for the finished article:\n%s", logData)
+	}
+	if strings.Contains(string(logData), "2026-06-02-two.md") {
+		t.Errorf("absorb log must NOT contain the rate-limited article (it has to retry next run):\n%s", logData)
+	}
+}


### PR DESCRIPTION
Closes #9.

- **Harness** (`llm_stub_test.go`): `newLLMProvider`/`runClaude` become injectable package vars (production behavior unchanged). Scripted responses matched by op-label/prompt, injectable `ErrRateLimit`/`ErrDailyBudgetExhausted`, recorded prompts, and concurrency instrumentation that proves overlap via rendezvous instead of sleeping.
- **Coverage**: `absorbDenseTwoPass` 0% → 84.2%, `ScanCmd.Run` 0% → 84.1%, `DeepCmd.Run` 0% → 78.1% (31 new tests: stop-the-world rate limiting, checkpointed partial progress, corrective retry, parallel cap, chaptered fan-out/merge). Race detector clean.
- **Real bug found & fixed**: `absorbDefaults()`/`ingestDefaults()` shared one `trueV` pointer between knobs; yaml.v3 writes through prefilled pointers, so `absorb.contextualize.enabled: false` silently flipped `chapter_aware` off even when explicitly set `true`. Per-field variables + regression tests. **This fix is a candidate for cherry-picking into PR #1 directly.**

Decomposition of the three drivers deliberately not attempted — the nolint markers now point at their tests, and decomposition is unblocked as a dedicated follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/oliver-kriska/scribe/pull/30">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->