### PR TITLE
fix: mechanical findings from the automated PR #1 review

### DIFF
--- a/cmd/scribe/config_trust_coverage_test.go
+++ b/cmd/scribe/config_trust_coverage_test.go
@@ -1,0 +1,252 @@
+package main
+
+import (
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestSensitiveConfigWiringComplete (config_trust_wiring_test.go)
+// enumerates sensitiveConfig's OWN fields — it catches a field added to
+// sensitiveConfig but mis-wired, not a field added to ScribeConfig and
+// never put into sensitiveConfig at all. This test closes that gap from
+// the other side: every leaf of ScribeConfig must either alter the
+// sensitive view (= trust-locked) or appear in nonSensitiveAllowlist
+// below. Adding any config field now forces a conscious decision; the
+// allowlist entry IS the recorded decision.
+
+// nonSensitiveAllowlist names every ScribeConfig leaf that is
+// deliberately NOT trust-locked. Paths are Go field names, dot-joined.
+//
+// Rationale per group — a pushed change to these can cost tokens or
+// degrade output quality, but it cannot widen what scribe ingests from
+// this machine, redirect file contents to a foreign endpoint, or weaken
+// the credential gate (the three classes sensitiveConfig locks):
+//
+//   - LoadErr: runtime parse-state, yaml:"-", never read from the repo.
+//   - identity/cosmetics (owner, domains, kb_name, owners): display and
+//     routing labels inside content that is already shared.
+//   - provider/model/mode/limits knobs: with every OllamaURL locked, a
+//     pushed provider flip can only route to an already-trusted
+//     endpoint ("Per-op provider flips stay unlocked" — config_trust.go).
+//   - pipeline tuning (sync caps, absorb thresholds, triage weights,
+//     ingest converters, identities stopwords, meta rolling targets,
+//     subscriptions): shapes what the pipeline does with data it was
+//     already allowed to read.
+//
+// If a new field does NOT fit those rationales — it points scribe at a
+// new input path, a new network endpoint, or relaxes a safety gate —
+// it belongs in sensitiveConfig, not here.
+var nonSensitiveAllowlist = map[string]bool{
+	"LoadErr": true,
+
+	// Identity / cosmetics.
+	"OwnerName":    true,
+	"OwnerContext": true,
+	"Domains":      true,
+	"Owners":       true,
+	"KBName":       true,
+	"LockDir":      true,
+	"DefaultModel": true,
+
+	// Top-level LLM routing (URL is locked; the rest is tuning).
+	"LLM.Provider": true,
+	"LLM.Model":    true,
+	"LLM.NumCtx":   true,
+
+	// Sync pipeline caps + git cadence.
+	"Sync.MaxExtractions":                   true,
+	"Sync.MaxSessions":                      true,
+	"Sync.MaxAbsorb":                        true,
+	"Sync.ParallelExtractions":              true,
+	"Sync.CheckpointInterval":               true,
+	"Sync.MaxExtractFiles":                  true,
+	"Sync.CommitDebounceMinutes":            true,
+	"Sync.AutoApprove":                      true,
+	"Sync.AlwaysPullBeforeSync":             true,
+	"Sync.DailyAnthropicOutputTokenCeiling": true,
+
+	"Deep.BatchMax": true,
+
+	// Triage scoring.
+	"Triage.Keywords": true,
+	"Triage.Weights":  true,
+
+	// Absorb pipeline tuning (URL leaves are locked; these shape
+	// chunking/threshold/provider-model routing only).
+	"Absorb.BriefThresholdWords":      true,
+	"Absorb.BriefThresholdHeadings":   true,
+	"Absorb.DenseThresholdWords":      true,
+	"Absorb.DenseThresholdHeadings":   true,
+	"Absorb.MaxPerRun":                true,
+	"Absorb.Strictness":               true,
+	"Absorb.SinglePassProvider":       true,
+	"Absorb.SinglePassModel":          true,
+	"Absorb.SinglePassTimeoutMin":     true,
+	"Absorb.SinglePassNumCtx":         true,
+	"Absorb.Pass1Provider":            true,
+	"Absorb.Pass1Model":               true,
+	"Absorb.Pass1TimeoutMin":          true,
+	"Absorb.Pass2Provider":            true,
+	"Absorb.Pass2Model":               true,
+	"Absorb.Pass2Mode":                true,
+	"Absorb.Pass2TimeoutMin":          true,
+	"Absorb.Pass2Parallel":            true,
+	"Absorb.Pass2NumCtx":              true,
+	"Absorb.ChapterAware":             true,
+	"Absorb.ChapterThreshold":         true,
+	"Absorb.ChapterParallel":          true,
+	"Absorb.AtomicFacts":              true,
+	"Absorb.FactsProvider":            true,
+	"Absorb.FactsModel":               true,
+	"Absorb.FactsTimeoutMin":          true,
+	"Absorb.Contextualize.Enabled":    true,
+	"Absorb.Contextualize.Provider":   true,
+	"Absorb.Contextualize.Model":      true,
+	"Absorb.Contextualize.TimeoutSec": true,
+	"Absorb.Contextualize.MaxPerRun":  true,
+
+	// Ingest converters + routing.
+	"Ingest.InboxPath":                true,
+	"Ingest.Marker.TimeoutSeconds":    true,
+	"Ingest.Marker.MPSFallback":       true,
+	"Ingest.Marker.Device":            true,
+	"Ingest.Converters":               true,
+	"Ingest.SmartRouting.Enabled":     true,
+	"Ingest.SmartRouting.MaxPDFBytes": true,
+	"Ingest.SmartRouting.MaxPDFPages": true,
+
+	// Identity clustering stopwords.
+	"Identities.HandleStopwords":      true,
+	"Identities.EmailDomainStopwords": true,
+
+	// Per-op LLM routing: URLs are locked, the rest is tuning.
+	"Relations.Provider": true,
+	"Relations.Model":    true,
+
+	"SessionMine.Provider":           true,
+	"SessionMine.Model":              true,
+	"SessionMine.Mode":               true,
+	"SessionMine.TranscriptMaxChars": true,
+	"SessionMine.TimeoutMin":         true,
+	"SessionMine.NumCtx":             true,
+
+	// Codex mining tuning (the Mine enable flag itself is locked).
+	"Codex.SessionsMax":   true,
+	"Codex.LookbackHours": true,
+	"Codex.MinScore":      true,
+
+	"Dream.Provider":   true,
+	"Dream.Model":      true,
+	"Dream.Mode":       true,
+	"Dream.TimeoutMin": true,
+	"Dream.NumCtx":     true,
+
+	"Assess.Provider": true,
+	"Assess.Model":    true,
+	"Assess.Mode":     true,
+	"Assess.NumCtx":   true,
+
+	"DeepIngest.Provider": true,
+	"DeepIngest.Model":    true,
+	"DeepIngest.Mode":     true,
+	"DeepIngest.NumCtx":   true,
+
+	"Extract.Provider":      true,
+	"Extract.Model":         true,
+	"Extract.Mode":          true,
+	"Extract.MaxFileChars":  true,
+	"Extract.MaxTotalChars": true,
+	"Extract.TimeoutMin":    true,
+	"Extract.NumCtx":        true,
+
+	// Digest subscriptions + meta side-channel targets.
+	"Subscriptions.Domains": true,
+	"Subscriptions.Tags":    true,
+	"Subscriptions.Notify":  true,
+
+	"Meta.RollingTargets": true,
+}
+
+// configLeaf is one settable leaf of ScribeConfig.
+type configLeaf struct {
+	path  string
+	index []int
+}
+
+// collectConfigLeaves walks struct fields depth-first; anything that is
+// not a struct counts as a leaf (slices/maps/pointers are mutated whole).
+func collectConfigLeaves(typ reflect.Type, prefix string, index []int, out *[]configLeaf) {
+	for i := range typ.NumField() {
+		field := typ.Field(i)
+		path := field.Name
+		if prefix != "" {
+			path = prefix + "." + field.Name
+		}
+		idx := append(append([]int{}, index...), i)
+		if field.Type.Kind() == reflect.Struct {
+			collectConfigLeaves(field.Type, path, idx, out)
+			continue
+		}
+		*out = append(*out, configLeaf{path: path, index: idx})
+	}
+}
+
+func TestScribeConfigSensitiveCoverage(t *testing.T) {
+	var leaves []configLeaf
+	collectConfigLeaves(reflect.TypeOf(ScribeConfig{}), "", nil, &leaves)
+	if len(leaves) < 50 {
+		t.Fatalf("only %d leaves — reflection walk broke?", len(leaves))
+	}
+
+	baseline := sensitiveFrom(&ScribeConfig{})
+	seen := map[string]bool{}
+	var undecided, stale []string
+
+	for _, leaf := range leaves {
+		seen[leaf.path] = true
+
+		cfg := ScribeConfig{}
+		v := reflect.ValueOf(&cfg).Elem().FieldByIndex(leaf.index)
+		if !v.CanSet() || v.Kind() == reflect.Interface || v.Kind() == reflect.Func {
+			// Unfillable (LoadErr's error interface) — still requires an
+			// explicit allowlist decision.
+			if !nonSensitiveAllowlist[leaf.path] {
+				undecided = append(undecided, leaf.path)
+			}
+			continue
+		}
+		fillTrustValue(v)
+		covered := !reflect.DeepEqual(sensitiveFrom(&cfg), baseline)
+
+		switch {
+		case covered && nonSensitiveAllowlist[leaf.path]:
+			stale = append(stale, leaf.path)
+		case !covered && !nonSensitiveAllowlist[leaf.path]:
+			undecided = append(undecided, leaf.path)
+		}
+	}
+
+	sort.Strings(undecided)
+	for _, p := range undecided {
+		t.Errorf("%s: new ScribeConfig leaf is neither trust-locked (sensitiveConfig) nor allowlisted — decide: does a pushed change to it widen ingestion, redirect data, or weaken a gate? Lock it in config_trust.go, or record the decision in nonSensitiveAllowlist", p)
+	}
+	sort.Strings(stale)
+	for _, p := range stale {
+		t.Errorf("%s: allowlisted as non-sensitive but it DOES alter the sensitive view — remove the stale allowlist entry", p)
+	}
+
+	// An allowlist entry for a leaf that no longer exists is a typo or a
+	// leftover from a removed field — either way it must go.
+	var unknown []string
+	for p := range nonSensitiveAllowlist {
+		if !seen[p] {
+			unknown = append(unknown, p)
+		}
+	}
+	sort.Strings(unknown)
+	if len(unknown) > 0 {
+		t.Errorf("nonSensitiveAllowlist entries match no ScribeConfig leaf: %s", strings.Join(unknown, ", "))
+	}
+}

--- a/cmd/scribe/cron.go
+++ b/cmd/scribe/cron.go
@@ -529,11 +529,14 @@ func (c *CronInstallCmd) Run() error {
 			continue
 		}
 
-		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-			return fmt.Errorf("mkdir LaunchAgents: %w", err)
-		}
-		if err := os.WriteFile(path, []byte(plist), 0o644); err != nil {
-			return fmt.Errorf("write %s: %w", path, err)
+		// LaunchAgent plists are machine-global state binding this
+		// machine's schedule to a KB root — route the write through the
+		// shared chokepoint (init.go) so it inherits the throwaway-path
+		// refusal. cron install has no bind override on purpose: a /tmp
+		// KB must never own the schedule (it vanishes on reboot and the
+		// jobs would burn tokens against a dead path).
+		if err := writeGlobalState(root, false, path, []byte(plist), 0o644); err != nil {
+			return err
 		}
 		fmt.Printf("wrote %s\n", path)
 

--- a/cmd/scribe/cron_test.go
+++ b/cmd/scribe/cron_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -144,5 +145,28 @@ func TestOtherKBServedByAgents(t *testing.T) {
 	}
 	if got := otherKBServedByAgents("/Users/u/Projects/kb-b"); got != "/Users/u/Projects/kb-a" {
 		t.Errorf("different root: got %q, want /Users/u/Projects/kb-a", got)
+	}
+}
+
+// TestCronInstallRefusesThrowawayKB: installing LaunchAgents from a
+// temp-path KB would point this machine's whole schedule at a directory
+// that vanishes on reboot — the writeGlobalState chokepoint must refuse
+// before any plist lands or launchctl runs.
+func TestCronInstallRefusesThrowawayKB(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("LaunchAgent install is darwin-only")
+	}
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+	t.Setenv("SCRIBE_KB", t.TempDir()) // under os.TempDir() → throwaway
+
+	c := &CronInstallCmd{}
+	err := c.Run()
+	if err == nil || !strings.Contains(err.Error(), "throwaway") {
+		t.Fatalf("cron install from throwaway KB: want refusal, got %v", err)
+	}
+	entries, _ := os.ReadDir(filepath.Join(fakeHome, "Library", "LaunchAgents"))
+	if len(entries) != 0 {
+		t.Errorf("refusal still wrote %d plist(s)", len(entries))
 	}
 }

--- a/cmd/scribe/gitmerge.go
+++ b/cmd/scribe/gitmerge.go
@@ -21,15 +21,11 @@ import (
 // other clone permanently failing its pulls (rebase aborts on the
 // same conflict forever while local commits pile up).
 
-// semanticMergers maps repo-relative paths to functions that produce
-// merged content from a conflict's two sides. `ours` is the upstream
-// (remote) side during a rebase, `theirs` the local commit being
-// replayed; either may be nil on a delete/modify conflict.
-var semanticMergers = map[string]func(ours, theirs []byte) []byte{
-	"scripts/extraction-ledger.json": mergeLedgerContent,
-	"scripts/dream-lease.json":       mergeLeaseContent,
-	"log.md":                         mergeUnionLines,
-}
+// semanticMergers (special_files.go) maps repo-relative paths to
+// functions that produce merged content from a conflict's two sides.
+// `ours` is the upstream (remote) side during a rebase, `theirs` the
+// local commit being replayed; either may be nil on a delete/modify
+// conflict.
 
 // semanticResolve merges one conflicted path during a rebase and stages
 // the result. Returns false when the blobs can't be read or written —

--- a/cmd/scribe/gitops.go
+++ b/cmd/scribe/gitops.go
@@ -106,16 +106,6 @@ func pullRebase(repoPath string) (ok bool, pulled bool, err error) {
 	return true, beforeSHA != "" && afterSHA != "" && beforeSHA != afterSHA, nil
 }
 
-// derivedRegenerable lists KB files whose content scribe fully rebuilds
-// (wiki index, backlinks, team digest). A merge conflict on them
-// carries no information — both sides go stale the moment any machine
-// regenerates — so pull auto-resolves these instead of failing.
-var derivedRegenerable = map[string]bool{
-	"wiki/_index.md":       true,
-	"wiki/_backlinks.json": true,
-	"wiki/_digest.md":      true,
-}
-
 // rebaseInProgress reports whether repoPath has a rebase mid-flight.
 func rebaseInProgress(repoPath string) bool {
 	for _, sub := range []string{"rebase-merge", "rebase-apply"} {
@@ -288,7 +278,7 @@ func gitAddWiki(root string) bool {
 			args = append(args, d)
 		}
 	}
-	for _, f := range []string{"scripts/projects.json", "scripts/extraction-ledger.json", "log.md"} {
+	for _, f := range autoStagedSpecialFiles() {
 		if fileExists(filepath.Join(root, f)) {
 			args = append(args, f)
 		}

--- a/cmd/scribe/init.go
+++ b/cmd/scribe/init.go
@@ -111,6 +111,33 @@ func allowGlobalStateWrites(force, yes, bind, throwaway bool, existingKBDir, abs
 	return yes && !retarget
 }
 
+// writeGlobalState is the single chokepoint for writing machine-global
+// files — anything outside the KB root that binds this machine to a KB:
+// ~/.config/scribe/config.yaml, the ~/.claude/CLAUDE.md and
+// ~/.codex/AGENTS.md handshake blocks, and the ~/Library/LaunchAgents
+// plists. Every such write MUST route through here so the shared safety
+// logic lives in one place instead of being re-derived per command.
+//
+// Command-specific consent (init's allowGlobalStateWrites, cron
+// install's otherKBServedByAgents guard) stays at the call sites; this
+// is the backstop they all inherit: a throwaway KB root (/tmp, /var/
+// folders, $TMPDIR — the 2026-05-13 incident class) may never own
+// machine-global state unless the caller carries an explicit bind
+// consent (init's --bind). servesRoot is the KB the file will point
+// at; empty means the write is not KB-binding.
+func writeGlobalState(servesRoot string, bound bool, path string, data []byte, perm os.FileMode) error {
+	if !bound && servesRoot != "" && isThrowawayPath(servesRoot) {
+		return fmt.Errorf("refusing to write %s: it would bind this machine's global state to throwaway KB %s (temp paths are smoke tests — `scribe init --bind` is the explicit opt-in when a temp-path KB really is meant to be primary)", path, servesRoot)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, data, perm); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
 // templateVars is what every embedded template receives. One struct is easier
 // to reason about than threading a map through every template call site, and
 // Go's text/template rejects unknown fields at parse time — so a typo fails
@@ -237,14 +264,14 @@ func (c *InitCmd) runBootstrap() error {
 	switch {
 	case uc.KBDir == abs:
 		// Idempotent re-install on the same path — always safe.
-		if err := installUserConfig(abs, c.Check, true); err != nil {
+		if err := installUserConfig(abs, c.Check, true, c.Bind); err != nil {
 			fmt.Printf("  warning: %s\n", err)
 		}
 	case allowUserWrites:
 		if uc.KBDir != "" && uc.KBDir != abs {
 			fmt.Printf("\n~/.config/scribe/config.yaml currently points at %s — switching to %s.\n", uc.KBDir, abs)
 		}
-		if err := installUserConfig(abs, c.Check, true); err != nil {
+		if err := installUserConfig(abs, c.Check, true, c.Bind); err != nil {
 			fmt.Printf("  warning: %s\n", err)
 		}
 	case uc.KBDir != "" && uc.KBDir != abs:
@@ -257,7 +284,7 @@ func (c *InitCmd) runBootstrap() error {
 	case c.NoClaudeMD:
 		fmt.Println("  (--no-claude-md: skipping ~/.claude/CLAUDE.md block)")
 	case allowUserWrites:
-		if err := installClaudeMD(abs, vars, c.Check, true); err != nil {
+		if err := installClaudeMD(abs, vars, c.Check, true, c.Bind); err != nil {
 			fmt.Printf("  warning: %s\n", err)
 		}
 	default:
@@ -267,7 +294,7 @@ func (c *InitCmd) runBootstrap() error {
 	case c.NoCodexMD:
 		fmt.Println("  (--no-codex-md: skipping ~/.codex/AGENTS.md block)")
 	case allowUserWrites:
-		if err := installCodexMD(vars, c.Check, true); err != nil {
+		if err := installCodexMD(vars, c.Check, true, c.Bind); err != nil {
 			fmt.Printf("  warning: %s\n", err)
 		}
 	default:
@@ -599,7 +626,7 @@ func (c *InitCmd) runStatus(root string) error {
 	}
 
 	fmt.Println("\nUser config (~/.config/scribe/config.yaml):")
-	if err := installUserConfig(root, c.Check, c.Yes); err != nil {
+	if err := installUserConfig(root, c.Check, c.Yes, c.Bind); err != nil {
 		fmt.Printf("  warning: %s\n", err)
 	}
 
@@ -624,14 +651,14 @@ func (c *InitCmd) runStatus(root string) error {
 	fmt.Println("\nUser CLAUDE.md (~/.claude/CLAUDE.md):")
 	if c.NoClaudeMD {
 		fmt.Println("  (--no-claude-md: skipping)")
-	} else if err := installClaudeMD(root, agentVars, c.Check, c.Yes); err != nil {
+	} else if err := installClaudeMD(root, agentVars, c.Check, c.Yes, c.Bind); err != nil {
 		fmt.Printf("  warning: %s\n", err)
 	}
 
 	fmt.Println("\nCodex AGENTS.md (~/.codex/AGENTS.md):")
 	if c.NoCodexMD {
 		fmt.Println("  (--no-codex-md: skipping)")
-	} else if err := installCodexMD(agentVars, c.Check, c.Yes); err != nil {
+	} else if err := installCodexMD(agentVars, c.Check, c.Yes, c.Bind); err != nil {
 		fmt.Printf("  warning: %s\n", err)
 	}
 
@@ -767,22 +794,23 @@ func buildAgentMDBlock(tmpl string, vars templateVars) (string, error) {
 }
 
 // installClaudeMD syncs the scribe block in ~/.claude/CLAUDE.md.
-func installClaudeMD(_ string, vars templateVars, check, yes bool) error {
-	return installAgentMD(claudeMDPath(), "templates/claude-md-kb.md", vars, check, yes)
+func installClaudeMD(_ string, vars templateVars, check, yes, bound bool) error {
+	return installAgentMD(claudeMDPath(), "templates/claude-md-kb.md", vars, check, yes, bound)
 }
 
 // installCodexMD syncs the scribe block in ~/.codex/AGENTS.md so Codex
 // CLI sessions get the same KB handshake (query before decisions, write
 // drop files) Claude Code sessions get from ~/.claude/CLAUDE.md.
-func installCodexMD(vars templateVars, check, yes bool) error {
-	return installAgentMD(codexAgentsMDPath(), "templates/codex-agents-md.md", vars, check, yes)
+func installCodexMD(vars templateVars, check, yes, bound bool) error {
+	return installAgentMD(codexAgentsMDPath(), "templates/codex-agents-md.md", vars, check, yes, bound)
 }
 
 // installAgentMD syncs the scribe block in an agent's global
 // instructions file. Four cases: missing, present-without-markers,
 // present-in-sync, present-drifted. User content outside the markers
-// is never touched.
-func installAgentMD(path, tmpl string, vars templateVars, check, yes bool) error {
+// is never touched. `bound` carries the caller's explicit --bind
+// consent through to the writeGlobalState chokepoint.
+func installAgentMD(path, tmpl string, vars templateVars, check, yes, bound bool) error {
 	block, err := buildAgentMDBlock(tmpl, vars)
 	if err != nil {
 		return err
@@ -802,11 +830,8 @@ func installAgentMD(path, tmpl string, vars templateVars, check, yes bool) error
 		if !yes && !promptYesNo("  create with scribe block?", true) {
 			return nil
 		}
-		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-			return fmt.Errorf("mkdir: %w", err)
-		}
-		if err := os.WriteFile(path, []byte(block+"\n"), 0o644); err != nil {
-			return fmt.Errorf("write: %w", err)
+		if err := writeGlobalState(vars.KBDir, bound, path, []byte(block+"\n"), 0o644); err != nil {
+			return err
 		}
 		fmt.Printf("  wrote %s\n", path)
 		return nil
@@ -830,8 +855,8 @@ func installAgentMD(path, tmpl string, vars templateVars, check, yes bool) error
 		case strings.HasSuffix(content, "\n"):
 			sep = "\n"
 		}
-		if err := os.WriteFile(path, []byte(content+sep+block+"\n"), 0o644); err != nil {
-			return fmt.Errorf("write: %w", err)
+		if err := writeGlobalState(vars.KBDir, bound, path, []byte(content+sep+block+"\n"), 0o644); err != nil {
+			return err
 		}
 		fmt.Printf("  appended scribe block to %s\n", path)
 		return nil
@@ -859,8 +884,8 @@ func installAgentMD(path, tmpl string, vars templateVars, check, yes bool) error
 		return nil
 	}
 	updated := content[:beginIdx] + block + content[endIdx:]
-	if err := os.WriteFile(path, []byte(updated), 0o644); err != nil {
-		return fmt.Errorf("write: %w", err)
+	if err := writeGlobalState(vars.KBDir, bound, path, []byte(updated), 0o644); err != nil {
+		return err
 	}
 	fmt.Printf("  refreshed scribe block in %s\n", path)
 	return nil
@@ -868,7 +893,7 @@ func installAgentMD(path, tmpl string, vars templateVars, check, yes bool) error
 
 // installUserConfig writes ~/.config/scribe/config.yaml with kb_dir set to
 // the current KB root. Lets scribe work from any directory without env vars.
-func installUserConfig(root string, check, yes bool) error {
+func installUserConfig(root string, check, yes, bound bool) error {
 	path := userConfigPath()
 	uc := loadUserConfig()
 
@@ -891,12 +916,9 @@ func installUserConfig(root string, check, yes bool) error {
 		return nil
 	}
 
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return fmt.Errorf("mkdir: %w", err)
-	}
 	content := fmt.Sprintf("# scribe user config — written by `scribe init`\nkb_dir: %s\n", root)
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-		return fmt.Errorf("write: %w", err)
+	if err := writeGlobalState(root, bound, path, []byte(content), 0o644); err != nil {
+		return err
 	}
 	fmt.Printf("  wrote %s\n", path)
 	return nil

--- a/cmd/scribe/init_test.go
+++ b/cmd/scribe/init_test.go
@@ -214,11 +214,14 @@ func minimalVars(kbDir string) templateVars {
 func TestInstallCodexMD_Lifecycle(t *testing.T) {
 	fakeHome := t.TempDir()
 	t.Setenv("HOME", fakeHome)
+	// The temp-dir KB root is a throwaway path, so these writes carry
+	// the explicit bind consent (bound=true) the chokepoint requires —
+	// the lifecycle under test is installAgentMD's, not the guard's.
 	vars := minimalVars(t.TempDir())
 	path := filepath.Join(fakeHome, ".codex", "AGENTS.md")
 
 	// 1. Missing file → created with the block + markers.
-	if err := installCodexMD(vars, false, true); err != nil {
+	if err := installCodexMD(vars, false, true, true); err != nil {
 		t.Fatalf("create: %v", err)
 	}
 	data, err := os.ReadFile(path)
@@ -237,7 +240,7 @@ func TestInstallCodexMD_Lifecycle(t *testing.T) {
 
 	// 2. In-sync → byte-identical, no-op.
 	before, _ := os.ReadFile(path)
-	if err := installCodexMD(vars, false, true); err != nil {
+	if err := installCodexMD(vars, false, true, true); err != nil {
 		t.Fatalf("in-sync: %v", err)
 	}
 	after, _ := os.ReadFile(path)
@@ -256,7 +259,7 @@ func TestInstallCodexMD_Lifecycle(t *testing.T) {
 	// Drift the block by changing a rendered var, then refresh.
 	vars2 := vars
 	vars2.OwnerName = "Someone Else"
-	if err := installCodexMD(vars2, false, true); err != nil {
+	if err := installCodexMD(vars2, false, true, true); err != nil {
 		t.Fatalf("refresh: %v", err)
 	}
 	out, _ := os.ReadFile(path)
@@ -277,7 +280,7 @@ func TestInstallCodexMD_CheckModeNeverWrites(t *testing.T) {
 	fakeHome := t.TempDir()
 	t.Setenv("HOME", fakeHome)
 	vars := minimalVars(t.TempDir())
-	if err := installCodexMD(vars, true, true); err != nil {
+	if err := installCodexMD(vars, true, true, false); err != nil {
 		t.Fatalf("check mode: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(fakeHome, ".codex", "AGENTS.md")); err == nil {
@@ -364,5 +367,43 @@ func TestRenderScribeYAML_ProviderThreadsIntoContextualize(t *testing.T) {
 				t.Errorf("contextualize model = %q, want %q", got, tc.wantModel)
 			}
 		})
+	}
+}
+
+// TestWriteGlobalStateThrowawayGuard pins the chokepoint every
+// machine-global write (user config, agent handshake blocks, cron
+// plists) routes through: a throwaway KB root may never own global
+// state without explicit bind consent.
+func TestWriteGlobalStateThrowawayGuard(t *testing.T) {
+	dest := filepath.Join(t.TempDir(), "global", "state.txt")
+	throwawayKB := t.TempDir() // under os.TempDir() → throwaway
+
+	err := writeGlobalState(throwawayKB, false, dest, []byte("x"), 0o644)
+	if err == nil || !strings.Contains(err.Error(), "throwaway") {
+		t.Fatalf("throwaway root without bind: want refusal, got %v", err)
+	}
+	if fileExists(dest) {
+		t.Fatal("refused write still created the file")
+	}
+
+	// Explicit bind consent (init --bind) overrides the refusal.
+	if err := writeGlobalState(throwawayKB, true, dest, []byte("bound"), 0o644); err != nil {
+		t.Fatalf("bound write: %v", err)
+	}
+	data, _ := os.ReadFile(dest)
+	if string(data) != "bound" {
+		t.Errorf("bound write content = %q, want %q", data, "bound")
+	}
+
+	// A permanent KB root needs no bind.
+	dest2 := filepath.Join(t.TempDir(), "state2.txt")
+	if err := writeGlobalState("/Users/u/Projects/kb", false, dest2, []byte("y"), 0o644); err != nil {
+		t.Fatalf("permanent root: %v", err)
+	}
+
+	// Empty servesRoot = the write is not KB-binding.
+	dest3 := filepath.Join(t.TempDir(), "state3.txt")
+	if err := writeGlobalState("", false, dest3, []byte("z"), 0o644); err != nil {
+		t.Fatalf("non-binding write: %v", err)
 	}
 }

--- a/cmd/scribe/promote.go
+++ b/cmd/scribe/promote.go
@@ -52,6 +52,18 @@ func (c *PromoteCmd) Run() error {
 	if !slices.Contains(wikiDirs, topDir) {
 		return fmt.Errorf("%s is not under a wiki content dir (%s)", rel, strings.Join(wikiDirs, ", "))
 	}
+	// Scribe-managed files are never promotion sources: with --force a
+	// `scribe promote wiki/_index.md` would overwrite the target KB's
+	// own derived artifacts with a foreign stale copy. The registry
+	// (special_files.go) catches the known derived/coordination files;
+	// the underscore convention catches the rest of the derived wiki
+	// surface (_hot.md, _sessions_log.json, _duplicates.md, ...).
+	if spec, ok := specialKBFiles[filepath.ToSlash(rel)]; ok {
+		return fmt.Errorf("%s is a scribe-managed %s file, not an article — the target KB maintains its own copy; promote articles only", rel, spec.Class)
+	}
+	if strings.HasPrefix(filepath.Base(rel), "_") {
+		return fmt.Errorf("%s is a derived file (underscore-prefixed) — these regenerate per KB and must not be promoted; promote articles only", rel)
+	}
 
 	srcAbs := filepath.Join(root, rel)
 	raw, err := os.ReadFile(srcAbs)

--- a/cmd/scribe/promote_test.go
+++ b/cmd/scribe/promote_test.go
@@ -125,6 +125,47 @@ func TestPromoteValidation(t *testing.T) {
 	}
 }
 
+// TestPromoteRefusesDerivedFiles covers the guard against promoting
+// scribe-managed/derived files: the topDir check alone accepts
+// wiki/_index.md, and --force would then overwrite the target KB's own
+// derived artifacts with a foreign stale copy.
+func TestPromoteRefusesDerivedFiles(t *testing.T) {
+	src, target := setupPromoteKBs(t)
+
+	// Registry-known derived artifacts (special_files.go).
+	for _, rel := range []string{"wiki/_index.md", "wiki/_backlinks.json", "wiki/_digest.md"} {
+		writeKBFile(t, src, rel, "stale derived content\n")
+		c := &PromoteCmd{Article: rel, To: target, Force: true, NoGit: true}
+		if err := c.Run(); err == nil || !strings.Contains(err.Error(), "scribe-managed") {
+			t.Errorf("%s: expected scribe-managed refusal, got %v", rel, err)
+		}
+	}
+
+	// Underscore convention beyond the registry.
+	for _, rel := range []string{"wiki/_hot.md", "wiki/_sessions_log.json", "patterns/_scratch.md"} {
+		writeKBFile(t, src, rel, "derived\n")
+		c := &PromoteCmd{Article: rel, To: target, Force: true, NoGit: true}
+		if err := c.Run(); err == nil || !strings.Contains(err.Error(), "must not be promoted") {
+			t.Errorf("%s: expected underscore refusal, got %v", rel, err)
+		}
+	}
+
+	// Nothing landed in the target.
+	for _, rel := range []string{"wiki/_index.md", "wiki/_hot.md"} {
+		if fileExists(filepath.Join(target, rel)) {
+			t.Errorf("%s was written to the target despite the refusal", rel)
+		}
+	}
+
+	// Underscore-prefixed DIRECTORIES are fine — only the filename counts.
+	writeKBFile(t, src, "patterns/sub/real-article.md",
+		"---\ntitle: \"Real Article\"\ntype: pattern\ndomain: backend\n---\n\nbody\n")
+	c := &PromoteCmd{Article: "patterns/sub/real-article.md", To: target, NoGit: true}
+	if err := c.Run(); err != nil {
+		t.Errorf("regular nested article refused: %v", err)
+	}
+}
+
 func TestMissingWikilinksIn(t *testing.T) {
 	target := t.TempDir()
 	writeKBFile(t, target, "wiki/known.md", "---\ntitle: \"Known Thing\"\naliases:\n  - \"KT\"\n---\n\nbody\n")

--- a/cmd/scribe/special_files.go
+++ b/cmd/scribe/special_files.go
@@ -1,0 +1,96 @@
+package main
+
+import "sort"
+
+// special_files.go — the single registry of KB files that scribe itself
+// manages and that need special handling somewhere in the git pipeline.
+// Three sites used to hardcode overlapping lists of these files
+// (derivedRegenerable in gitops.go, semanticMergers in gitmerge.go, and
+// an inline staging list in gitAddWiki); they now all derive from this
+// one table, so a new shared file is registered exactly once.
+
+// specialFileClass says how the git pipeline must treat a registered file.
+type specialFileClass string
+
+const (
+	// classDerivedRegenerable — content scribe fully rebuilds (wiki
+	// index, backlinks, team digest). A merge conflict on these carries
+	// no information: either side can win because both go stale the
+	// moment any machine regenerates.
+	classDerivedRegenerable specialFileClass = "derived-regenerable"
+	// classSemanticMerge — committed coordination files that accumulate
+	// state from every machine. Picking a side in a conflict would throw
+	// away a teammate's writes, so each has a semantic merge function.
+	classSemanticMerge specialFileClass = "semantic-merge"
+	// classMachineLocal — per-machine state (the discovery manifest).
+	// Gitignored in team KBs; committed as-is in solo KBs. Never merged.
+	classMachineLocal specialFileClass = "machine-local"
+)
+
+// specialFileSpec describes one registered file.
+type specialFileSpec struct {
+	Class specialFileClass
+	// Merge produces merged content from a conflict's two sides. Set
+	// if and only if Class is classSemanticMerge (asserted by test).
+	Merge func(ours, theirs []byte) []byte
+	// AutoStage marks files gitAddWiki stages explicitly alongside the
+	// wiki content dirs. Files living under a wikiDirs directory (the
+	// derived wiki/_* artifacts) are swept by the directory pathspec
+	// and don't need this; scripts/dream-lease.json deliberately stays
+	// out so only commitDreamLease's pathspec commit ever touches it.
+	AutoStage bool
+}
+
+// specialKBFiles maps repo-relative paths to their handling spec. This
+// is the one place a shared scribe-managed file gets registered.
+var specialKBFiles = map[string]specialFileSpec{
+	"wiki/_index.md":       {Class: classDerivedRegenerable},
+	"wiki/_backlinks.json": {Class: classDerivedRegenerable},
+	"wiki/_digest.md":      {Class: classDerivedRegenerable},
+
+	"scripts/extraction-ledger.json": {Class: classSemanticMerge, Merge: mergeLedgerContent, AutoStage: true},
+	"scripts/dream-lease.json":       {Class: classSemanticMerge, Merge: mergeLeaseContent},
+	"log.md":                         {Class: classSemanticMerge, Merge: mergeUnionLines, AutoStage: true},
+
+	"scripts/projects.json": {Class: classMachineLocal, AutoStage: true},
+}
+
+// derivedRegenerable is the conflict-resolution view: files where either
+// side of a conflict is acceptable because content regenerates after the
+// pull. Derived from specialKBFiles — register new files there.
+var derivedRegenerable = func() map[string]bool {
+	out := map[string]bool{}
+	for path, spec := range specialKBFiles {
+		if spec.Class == classDerivedRegenerable {
+			out[path] = true
+		}
+	}
+	return out
+}()
+
+// semanticMergers is the conflict-resolution view for coordination files
+// that must be MERGED, not side-picked (see gitmerge.go for why). Derived
+// from specialKBFiles — register new files there.
+var semanticMergers = func() map[string]func(ours, theirs []byte) []byte {
+	out := map[string]func(ours, theirs []byte) []byte{}
+	for path, spec := range specialKBFiles {
+		if spec.Class == classSemanticMerge {
+			out[path] = spec.Merge
+		}
+	}
+	return out
+}()
+
+// autoStagedSpecialFiles is the staging view: registered files gitAddWiki
+// adds explicitly because they live outside (or hidden from) the wikiDirs
+// sweep. Sorted for deterministic `git add` argument order.
+func autoStagedSpecialFiles() []string {
+	var out []string
+	for path, spec := range specialKBFiles {
+		if spec.AutoStage {
+			out = append(out, path)
+		}
+	}
+	sort.Strings(out)
+	return out
+}

--- a/cmd/scribe/special_files_test.go
+++ b/cmd/scribe/special_files_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"slices"
+	"testing"
+)
+
+// TestSpecialFileRegistryViews pins the three derived views to the one
+// registry, and the registry to its known contents — so a file can only
+// be added/moved by editing specialKBFiles, and each class keeps its
+// invariants (Merge set iff semantic-merge).
+func TestSpecialFileRegistryViews(t *testing.T) {
+	// Invariants per class.
+	for path, spec := range specialKBFiles {
+		hasMerge := spec.Merge != nil
+		wantMerge := spec.Class == classSemanticMerge
+		if hasMerge != wantMerge {
+			t.Errorf("%s (class %s): Merge set = %v, want %v — Merge belongs to semantic-merge entries only",
+				path, spec.Class, hasMerge, wantMerge)
+		}
+		if spec.Class == classDerivedRegenerable && spec.AutoStage {
+			t.Errorf("%s: derived wiki artifacts are staged by the wikiDirs sweep, not AutoStage", path)
+		}
+	}
+
+	// derivedRegenerable == exactly the derived-regenerable entries.
+	for path, spec := range specialKBFiles {
+		if derivedRegenerable[path] != (spec.Class == classDerivedRegenerable) {
+			t.Errorf("derivedRegenerable[%s] = %v, registry class = %s", path, derivedRegenerable[path], spec.Class)
+		}
+	}
+	for path := range derivedRegenerable {
+		if _, ok := specialKBFiles[path]; !ok {
+			t.Errorf("derivedRegenerable has %s but the registry does not", path)
+		}
+	}
+
+	// semanticMergers == exactly the semantic-merge entries.
+	for path, spec := range specialKBFiles {
+		if (semanticMergers[path] != nil) != (spec.Class == classSemanticMerge) {
+			t.Errorf("semanticMergers[%s] present = %v, registry class = %s", path, semanticMergers[path] != nil, spec.Class)
+		}
+	}
+	for path := range semanticMergers {
+		if _, ok := specialKBFiles[path]; !ok {
+			t.Errorf("semanticMergers has %s but the registry does not", path)
+		}
+	}
+
+	// The staging view == exactly the AutoStage entries.
+	staged := autoStagedSpecialFiles()
+	for path, spec := range specialKBFiles {
+		if slices.Contains(staged, path) != spec.AutoStage {
+			t.Errorf("autoStagedSpecialFiles contains %s = %v, registry AutoStage = %v",
+				path, slices.Contains(staged, path), spec.AutoStage)
+		}
+	}
+	if !slices.IsSorted(staged) {
+		t.Errorf("autoStagedSpecialFiles not sorted: %v", staged)
+	}
+
+	// Pin the historical contents so an accidental removal (which would
+	// silently change conflict/staging behavior) is loud.
+	want := map[string]specialFileClass{
+		"wiki/_index.md":                 classDerivedRegenerable,
+		"wiki/_backlinks.json":           classDerivedRegenerable,
+		"wiki/_digest.md":                classDerivedRegenerable,
+		"scripts/extraction-ledger.json": classSemanticMerge,
+		"scripts/dream-lease.json":       classSemanticMerge,
+		"log.md":                         classSemanticMerge,
+		"scripts/projects.json":          classMachineLocal,
+	}
+	for path, class := range want {
+		if spec, ok := specialKBFiles[path]; !ok || spec.Class != class {
+			t.Errorf("registry missing or misclassifies %s: want %s, got %+v", path, class, spec)
+		}
+	}
+	wantStaged := []string{"log.md", "scripts/extraction-ledger.json", "scripts/projects.json"}
+	if !slices.Equal(staged, wantStaged) {
+		t.Errorf("autoStagedSpecialFiles() = %v, want %v", staged, wantStaged)
+	}
+}


### PR DESCRIPTION
Four verified findings from a multi-agent review of PR #1 (19 candidates, each adversarially verified; full notes in `.claude/research/2026-06-12-pr1-automated-review-findings.md`), one commit each:

1. **`promote` derived-file guard** — `scribe promote wiki/_index.md --force` no longer overwrites the target KB's derived artifacts; registry files and underscore-prefixed filenames rejected before any read/write.
2. **`specialKBFiles` registry** — the derived/coordination file names previously hardcoded in three places (`derivedRegenerable`, `semanticMergers`, `gitAddWiki`'s inline list) now derive from one file→class registry. Behavior byte-identical.
3. **`writeGlobalState` chokepoint** — init's and cron's global-state writes share one gate. Closes a real hole: `scribe cron install` from a temp-path KB used to write 13 LaunchAgents bound to a directory that vanishes on reboot; now refuses. (The second-KB repoint case was already safe via `otherKBServedByAgents` — no redundant gate added.)
4. **Trust coverage test (test-only)** — reflects over all 109 `ScribeConfig` leaves; every new config field must be trust-locked or consciously allowlisted, and stale/unknown allowlist entries fail.

Two review findings deliberately NOT fixed here (maintainer design calls): mixed config snapshot across sync phases, and qmd reindex running before the secret gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/oliver-kriska/scribe/pull/31">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->