### PR TITLE
test: close worst coverage gaps — package 41.4% → 48.6%

### DIFF
--- a/cmd/scribe/capture_write_test.go
+++ b/cmd/scribe/capture_write_test.go
@@ -1,0 +1,250 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// appleNanos converts a wall-clock time into the chat.db date column unit
+// (nanoseconds since 2001-01-01 UTC).
+func appleNanos(t time.Time) int64 {
+	return (t.UTC().Unix() - appleEpochOffset) * 1_000_000_000
+}
+
+func TestMessageURLs(t *testing.T) {
+	t.Run("text column wins", func(t *testing.T) {
+		m := chatMessage{
+			Text:           "check https://example.com/a and https://example.com/b",
+			AttributedBody: []byte("https://from-blob.example/ignored"),
+		}
+		urls := messageURLs(m)
+		if len(urls) != 2 || urls[0] != "https://example.com/a" || urls[1] != "https://example.com/b" {
+			t.Errorf("urls = %v", urls)
+		}
+	})
+
+	t.Run("attributedBody fallback with WHttpURL sentinel", func(t *testing.T) {
+		blob := append([]byte{0x01, 0x02}, []byte("https://example.com/pathWHttpURL\x01garbage")...)
+		m := chatMessage{Text: "no links here", AttributedBody: blob}
+		urls := messageURLs(m)
+		if len(urls) != 1 || urls[0] != "https://example.com/path" {
+			t.Errorf("urls = %v, want clean URL truncated at sentinel", urls)
+		}
+	})
+
+	t.Run("no urls anywhere", func(t *testing.T) {
+		if urls := messageURLs(chatMessage{Text: "plain note"}); urls != nil {
+			t.Errorf("urls = %v, want nil", urls)
+		}
+	})
+}
+
+func TestSortCapturedMessages(t *testing.T) {
+	ts := appleNanos(time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC))
+	messages := []chatMessage{
+		{Text: "https://example.com/article.", Date: ts},           // trailing punctuation trimmed
+		{Text: "https://example.com/article", Date: ts},            // dup of the above after trim
+		{Text: "https://maps.google.com/place/x", Date: ts},        // skip domain
+		{Text: "https://already.example/seen", Date: ts},           // pre-captured
+		{Text: "Permission request https://x.example/y", Date: ts}, // control message
+		{Text: "an idea worth keeping around", Date: ts},           // note
+		{Text: "Liked an idea worth keeping around", Date: ts},     // reaction noise
+		{Text: "short", Date: ts},                                  // <=10 chars
+	}
+	captured := map[string]bool{"https://already.example/seen": true}
+
+	urls, notes := sortCapturedMessages(messages, captured, []string{"maps.google.com"})
+
+	if len(urls) != 1 {
+		t.Fatalf("urls = %+v, want 1", urls)
+	}
+	u := urls[0]
+	if u.URL != "https://example.com/article" {
+		t.Errorf("URL = %q, want punctuation trimmed", u.URL)
+	}
+	if u.Date != "2026-06-01" {
+		t.Errorf("Date = %q", u.Date)
+	}
+	if !captured["https://example.com/article"] {
+		t.Error("accepted URL not marked captured")
+	}
+
+	if len(notes) != 1 || notes[0].Text != "an idea worth keeping around" {
+		t.Errorf("notes = %+v", notes)
+	}
+}
+
+func TestWriteURLCaptures(t *testing.T) {
+	rawDir := t.TempDir()
+	item := capturedURL{
+		URL:        "https://example.com/some/article",
+		Date:       "2026-06-01",
+		SourceText: "https://example.com/some/article",
+	}
+
+	t.Run("writes a stub article", func(t *testing.T) {
+		c := &CaptureCmd{}
+		saved := c.writeURLCaptures(rawDir, []capturedURL{item})
+		if len(saved) != 1 {
+			t.Fatalf("saved = %v", saved)
+		}
+		wantName := "2026-06-01-imessage-example-com-some-article.md"
+		if saved[0] != wantName {
+			t.Errorf("filename = %q, want %q", saved[0], wantName)
+		}
+		data, err := os.ReadFile(filepath.Join(rawDir, wantName))
+		if err != nil {
+			t.Fatal(err)
+		}
+		content := string(data)
+		for _, want := range []string{
+			`source_url: "https://example.com/some/article"`,
+			"fetched_via: stub",
+			"captured: 2026-06-01",
+			"tags: [imessage]",
+			"Captured from iMessage self-chat on 2026-06-01.",
+		} {
+			if !strings.Contains(content, want) {
+				t.Errorf("missing %q in:\n%s", want, content)
+			}
+		}
+	})
+
+	t.Run("existing file is not overwritten", func(t *testing.T) {
+		c := &CaptureCmd{}
+		saved := c.writeURLCaptures(rawDir, []capturedURL{item})
+		if len(saved) != 0 {
+			t.Errorf("second pass saved %v, want none", saved)
+		}
+	})
+
+	t.Run("dry run writes nothing", func(t *testing.T) {
+		dryDir := t.TempDir()
+		c := &CaptureCmd{DryRun: true}
+		var saved []string
+		out := captureLintStdout(t, func() {
+			saved = c.writeURLCaptures(dryDir, []capturedURL{item})
+		})
+		if len(saved) != 0 {
+			t.Errorf("dry run saved %v", saved)
+		}
+		entries, _ := os.ReadDir(dryDir)
+		if len(entries) != 0 {
+			t.Errorf("dry run created files: %v", entries)
+		}
+		if !strings.Contains(out, "WOULD CAPTURE") {
+			t.Errorf("dry run output:\n%s", out)
+		}
+	})
+}
+
+func TestWriteNoteCaptures(t *testing.T) {
+	rawDir := t.TempDir()
+	long := strings.Repeat("idea ", 30) // >80 chars, title must truncate
+	notes := []capturedNote{
+		{Text: long, Date: "2026-06-02"},
+	}
+
+	c := &CaptureCmd{}
+	saved := c.writeNoteCaptures(rawDir, notes)
+	if len(saved) != 1 {
+		t.Fatalf("saved = %v", saved)
+	}
+	if !strings.HasPrefix(saved[0], "2026-06-02-imessage-note-") {
+		t.Errorf("filename = %q", saved[0])
+	}
+	data, err := os.ReadFile(filepath.Join(rawDir, saved[0]))
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "fetched_via: imessage-note") {
+		t.Errorf("missing via marker:\n%s", content)
+	}
+	if !strings.Contains(content, "tags: [imessage, note]") {
+		t.Errorf("missing tags:\n%s", content)
+	}
+	// Title is clipped to 80 chars; body keeps the full text.
+	titleLine := ""
+	for line := range strings.SplitSeq(content, "\n") {
+		if strings.HasPrefix(line, "title:") {
+			titleLine = line
+			break
+		}
+	}
+	if len(titleLine) > len(`title: ""`)+80 {
+		t.Errorf("title not truncated: %q", titleLine)
+	}
+	if !strings.Contains(content, strings.TrimSpace(long)) {
+		t.Errorf("full note text missing from body:\n%s", content)
+	}
+
+	// Existing note is skipped on a second run.
+	if again := c.writeNoteCaptures(rawDir, notes); len(again) != 0 {
+		t.Errorf("second pass saved %v", again)
+	}
+}
+
+func TestWriteCaptureFile_CreatesParents(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "deep", "nested", "file.md")
+	if err := writeCaptureFile(path, "content\n"); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil || string(data) != "content\n" {
+		t.Errorf("read back: %q, %v", data, err)
+	}
+}
+
+func TestCaptureStateRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "scripts", "imessage-state.json")
+
+	t.Run("missing file yields zero state", func(t *testing.T) {
+		st, err := loadCaptureState(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if st.LastCapture != nil || st.CapturedCount != 0 || len(st.CapturedURLs) != 0 {
+			t.Errorf("zero state = %+v", st)
+		}
+	})
+
+	t.Run("save creates parents and round-trips", func(t *testing.T) {
+		last := "2026-06-01"
+		st := &captureState{
+			LastCapture:   &last,
+			CapturedURLs:  []string{"https://example.com/a"},
+			CapturedCount: 7,
+		}
+		if err := saveCaptureState(path, st); err != nil {
+			t.Fatal(err)
+		}
+		if fileExists(path + ".tmp") {
+			t.Error("tmp file left behind")
+		}
+		got, err := loadCaptureState(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.LastCapture == nil || *got.LastCapture != "2026-06-01" {
+			t.Errorf("LastCapture = %v", got.LastCapture)
+		}
+		if got.CapturedCount != 7 || len(got.CapturedURLs) != 1 {
+			t.Errorf("round-trip lost data: %+v", got)
+		}
+	})
+
+	t.Run("malformed JSON is an error not a reset", func(t *testing.T) {
+		bad := filepath.Join(dir, "bad.json")
+		if err := os.WriteFile(bad, []byte("{nope"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := loadCaptureState(bad); err == nil {
+			t.Error("want parse error — silently resetting state would re-capture everything")
+		}
+	})
+}

--- a/cmd/scribe/estimate_test.go
+++ b/cmd/scribe/estimate_test.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestHumanTokens(t *testing.T) {
+	tests := []struct {
+		n    int
+		want string
+	}{
+		{0, "0"},
+		{999, "999"},
+		{1000, "1.0K"},
+		{1500, "1.5K"},
+		{999_999, "1000.0K"},
+		{1_000_000, "1.0M"},
+		{2_500_000, "2.5M"},
+	}
+	for _, tt := range tests {
+		if got := humanTokens(tt.n); got != tt.want {
+			t.Errorf("humanTokens(%d) = %q, want %q", tt.n, got, tt.want)
+		}
+	}
+}
+
+// estimateTestKB scaffolds raw/articles + wiki for the queue scanners.
+func estimateTestKB(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "scribe.yaml"), []byte("domains: [acme]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, d := range []string{"raw/articles", "wiki"} {
+		if err := os.MkdirAll(filepath.Join(root, d), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+func TestUnprocessedForContextualize(t *testing.T) {
+	root := estimateTestKB(t)
+	writeKBFile(t, root, "raw/articles/fresh.md", "# Fresh\n\nbody\n")
+	writeKBFile(t, root, "raw/articles/logged.md", "# Logged\n\nbody\n")
+	writeKBFile(t, root, "raw/articles/marked.md",
+		"# Marked\n\n"+retrievalContextMarker+"\nContext paragraph.\n")
+	writeKBFile(t, root, "raw/articles/notes.txt", "not markdown")
+	if err := os.MkdirAll(filepath.Join(root, "raw", "articles", "subdir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeKBFile(t, root, "wiki/_contextualized_log.json", `{"logged.md": "2026-06-01"}`)
+
+	got := unprocessedForContextualize(root)
+	if len(got) != 1 || filepath.Base(got[0]) != "fresh.md" {
+		t.Errorf("queue = %v, want only fresh.md", got)
+	}
+
+	if got := unprocessedForContextualize(t.TempDir()); got != nil {
+		t.Errorf("missing raw dir should yield nil, got %v", got)
+	}
+}
+
+func TestUnprocessedForAbsorb(t *testing.T) {
+	root := estimateTestKB(t)
+	writeKBFile(t, root, "raw/articles/fresh.md", "# Fresh\n\nbody\n")
+	writeKBFile(t, root, "raw/articles/done.md", "# Done\n\nbody\n")
+	writeKBFile(t, root, "wiki/_absorb_log.json", `{"done.md": {"at": "2026-06-01T00:00:00Z"}}`)
+
+	got := unprocessedForAbsorb(root)
+	if len(got) != 1 || filepath.Base(got[0]) != "fresh.md" {
+		t.Errorf("queue = %v, want only fresh.md", got)
+	}
+
+	// Legacy v1 log shape (filename → timestamp string) still counts as done.
+	writeKBFile(t, root, "wiki/_absorb_log.json", `{"done.md": "2026-06-01T00:00:00Z", "fresh.md": "2026-06-02T00:00:00Z"}`)
+	if got := unprocessedForAbsorb(root); len(got) != 0 {
+		t.Errorf("v1 log entries ignored: %v", got)
+	}
+}
+
+func TestEstimateSync(t *testing.T) {
+	root := estimateTestKB(t)
+	// One standard source and one dense source in the absorb queue; both
+	// also uncontextualized.
+	writeKBFile(t, root, "raw/articles/standard.md",
+		"---\ntitle: \"Std\"\ndensity: standard\n---\n\n"+strings.Repeat("word ", 300)+"\n")
+	writeKBFile(t, root, "raw/articles/dense.md",
+		"---\ntitle: \"Dense\"\ndensity: dense\n---\n\n"+strings.Repeat("word ", 500)+"\n")
+
+	cfg := loadConfig(root) // defaults: contextualize enabled
+	estimates := estimateSync(root, cfg)
+
+	notes := make([]string, 0, len(estimates))
+	for _, e := range estimates {
+		notes = append(notes, e.Note)
+		if e.InputTokens <= 0 || e.OutputTokens <= 0 {
+			t.Errorf("estimate %q has non-positive tokens: %+v", e.Note, e)
+		}
+	}
+	joined := strings.Join(notes, "; ")
+	if !strings.Contains(joined, "2 source(s) × contextualize") {
+		t.Errorf("contextualize phase missing or wrong: %v", notes)
+	}
+	if !strings.Contains(joined, "1 brief/standard source(s)") {
+		t.Errorf("single-pass phase missing: %v", notes)
+	}
+	if !strings.Contains(joined, "1 dense source(s)") {
+		t.Errorf("dense phase missing: %v", notes)
+	}
+}
+
+func TestEstimateSync_OllamaContextualizeIsLabeledFree(t *testing.T) {
+	root := estimateTestKB(t)
+	yaml := `domains: [acme]
+absorb:
+  contextualize:
+    provider: ollama
+    model: gemma3
+`
+	if err := os.WriteFile(filepath.Join(root, "scribe.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeKBFile(t, root, "raw/articles/one.md", "# One\n\nbody text\n")
+
+	cfg := loadConfig(root)
+	estimates := estimateSync(root, cfg)
+	found := false
+	for _, e := range estimates {
+		if strings.Contains(e.Note, "contextualize") {
+			found = true
+			if !strings.Contains(e.Model, "ollama:gemma3") || !strings.Contains(e.Model, "free") {
+				t.Errorf("ollama contextualize not labeled free: %q", e.Model)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("no contextualize estimate: %+v", estimates)
+	}
+}
+
+func TestEstimateSync_EmptyQueues(t *testing.T) {
+	root := estimateTestKB(t)
+	cfg := loadConfig(root)
+	if got := estimateSync(root, cfg); len(got) != 0 {
+		t.Errorf("empty KB should produce no estimates, got %+v", got)
+	}
+}
+
+func TestPrintEstimate(t *testing.T) {
+	t.Run("empty is a no-op message", func(t *testing.T) {
+		out := captureLintStdout(t, func() { printEstimate(nil) })
+		if !strings.Contains(out, "nothing queued") {
+			t.Errorf("output:\n%s", out)
+		}
+	})
+
+	t.Run("totals are summed", func(t *testing.T) {
+		out := captureLintStdout(t, func() {
+			printEstimate([]tokenEstimate{
+				{InputTokens: 1000, OutputTokens: 100, Model: "haiku", Note: "a"},
+				{InputTokens: 2000, OutputTokens: 400, Model: "sonnet", Note: "b"},
+			})
+		})
+		if !strings.Contains(out, "total") {
+			t.Errorf("missing total row:\n%s", out)
+		}
+		if !strings.Contains(out, "3.0K") || !strings.Contains(out, "500") {
+			t.Errorf("totals not summed (want 3.0K in / 500 out):\n%s", out)
+		}
+	})
+}

--- a/cmd/scribe/identities_apply_test.go
+++ b/cmd/scribe/identities_apply_test.go
@@ -1,0 +1,319 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const sampleProposals = `# Identity proposals — scanned 2026-06-01T00:00:00Z
+
+### Jane Doe
+
+- Existing page: people/jane-doe.md
+- Surface forms:
+  - jane@corp.example
+  - @janedoe
+- Confidence: high
+- Suggested action: add-aliases
+
+---
+
+### Maybe Person
+
+- Existing page: people/maybe.md
+- Surface forms:
+  - maybe@corp.example
+- Confidence: low
+- Suggested action: add-aliases
+
+---
+
+### New Face
+
+- Surface forms:
+  - new@corp.example
+- Confidence: high
+- Suggested action: create-new
+`
+
+func TestParseIdentityBlocks(t *testing.T) {
+	blocks := parseIdentityBlocks(sampleProposals)
+	// "New Face" has no Existing page line → dropped at flush.
+	if len(blocks) != 2 {
+		t.Fatalf("want 2 blocks, got %d: %+v", len(blocks), blocks)
+	}
+
+	jane := blocks[0]
+	if jane.Page != "people/jane-doe.md" {
+		t.Errorf("page = %q", jane.Page)
+	}
+	if jane.Action != "add-aliases" || !strings.EqualFold(jane.Confidence, "high") {
+		t.Errorf("action/confidence = %q/%q", jane.Action, jane.Confidence)
+	}
+	if len(jane.SurfaceForms) != 2 || jane.SurfaceForms[0] != "jane@corp.example" || jane.SurfaceForms[1] != "@janedoe" {
+		t.Errorf("surface forms = %v", jane.SurfaceForms)
+	}
+
+	if blocks[1].Page != "people/maybe.md" || !strings.EqualFold(blocks[1].Confidence, "low") {
+		t.Errorf("second block parsed wrong: %+v", blocks[1])
+	}
+}
+
+func TestParseIdentityBlocks_Resilience(t *testing.T) {
+	t.Run("empty input", func(t *testing.T) {
+		if got := parseIdentityBlocks(""); len(got) != 0 {
+			t.Errorf("want no blocks, got %v", got)
+		}
+	})
+
+	t.Run("page path with leading ./ normalized", func(t *testing.T) {
+		body := "### X Y\n- Existing page: ./people/x.md\n- Suggested action: add-aliases\n"
+		blocks := parseIdentityBlocks(body)
+		if len(blocks) != 1 || blocks[0].Page != "people/x.md" {
+			t.Errorf("got %+v", blocks)
+		}
+	})
+
+	t.Run("non-indented line ends surface forms list", func(t *testing.T) {
+		body := "### X Y\n- Existing page: people/x.md\n- Surface forms:\n  - one\nplain text line\n  - not-captured\n"
+		blocks := parseIdentityBlocks(body)
+		if len(blocks) != 1 {
+			t.Fatalf("got %+v", blocks)
+		}
+		if len(blocks[0].SurfaceForms) != 1 || blocks[0].SurfaceForms[0] != "one" {
+			t.Errorf("surface forms = %v, want just [one]", blocks[0].SurfaceForms)
+		}
+	})
+}
+
+func TestExistingAliases(t *testing.T) {
+	tests := []struct {
+		name string
+		fm   string
+		want []string
+	}{
+		{
+			name: "inline array",
+			fm:   "\ntitle: \"X\"\naliases: [a, \"B C\", 'd']\n",
+			want: []string{"a", "b c", "d"},
+		},
+		{
+			name: "block list",
+			fm:   "\ntitle: \"X\"\naliases:\n  - a\n  - \"B C\"\nother: 1\n",
+			want: []string{"a", "b c"},
+		},
+		{
+			name: "no aliases key",
+			fm:   "\ntitle: \"X\"\n",
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := existingAliases(tt.fm)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+			for _, w := range tt.want {
+				if !got[w] {
+					t.Errorf("missing %q in %v", w, got)
+				}
+			}
+		})
+	}
+}
+
+func TestInsertOrExtendAliases(t *testing.T) {
+	t.Run("creates key when absent", func(t *testing.T) {
+		got := insertOrExtendAliases("\ntitle: \"X\"", []string{"new one"})
+		if !strings.Contains(got, "aliases:\n  - \"new one\"") &&
+			!strings.Contains(got, "aliases:\n  - new one") {
+			t.Errorf("aliases block not appended:\n%s", got)
+		}
+	})
+
+	t.Run("extends existing block list", func(t *testing.T) {
+		fm := "\ntitle: \"X\"\naliases:\n  - old\nstatus: active"
+		got := insertOrExtendAliases(fm, []string{"fresh"})
+		oldIdx := strings.Index(got, "- old")
+		freshIdx := strings.Index(got, "- fresh")
+		statusIdx := strings.Index(got, "status: active")
+		if oldIdx < 0 || freshIdx < 0 {
+			t.Fatalf("entries missing:\n%s", got)
+		}
+		if oldIdx >= freshIdx || freshIdx >= statusIdx {
+			t.Errorf("new alias not inserted inside the list:\n%s", got)
+		}
+	})
+
+	t.Run("converts inline form to block form", func(t *testing.T) {
+		fm := "\ntitle: \"X\"\naliases: [a, b]"
+		got := insertOrExtendAliases(fm, []string{"c"})
+		for _, want := range []string{"aliases:", "  - a", "  - b", "  - c"} {
+			if !strings.Contains(got, want) {
+				t.Errorf("missing %q in:\n%s", want, got)
+			}
+		}
+		if strings.Contains(got, "[a, b]") {
+			t.Errorf("inline form should be gone:\n%s", got)
+		}
+	})
+}
+
+func TestAppendAliasesToPeopleFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "jane.md")
+	content := "---\ntitle: \"Jane Doe\"\naliases: [jd]\n---\n\nBody.\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	added, err := appendAliasesToPeopleFile(path, []string{"jane@corp.example", "JD", ""}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// "JD" is a case-insensitive dup of jd; "" is dropped.
+	if added != 1 {
+		t.Errorf("added = %d, want 1", added)
+	}
+	data, _ := os.ReadFile(path)
+	if !strings.Contains(string(data), "jane@corp.example") {
+		t.Errorf("new alias not written:\n%s", data)
+	}
+	if !strings.HasSuffix(strings.TrimSpace(string(data)), "Body.") {
+		t.Errorf("body lost:\n%s", data)
+	}
+
+	// Idempotent: second pass adds nothing.
+	added, err = appendAliasesToPeopleFile(path, []string{"jane@corp.example"}, false)
+	if err != nil || added != 0 {
+		t.Errorf("second pass added=%d err=%v, want 0/nil", added, err)
+	}
+}
+
+func TestAppendAliasesToPeopleFile_DryRunAndErrors(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("dry run reports but does not write", func(t *testing.T) {
+		path := filepath.Join(dir, "dry.md")
+		content := "---\ntitle: \"X\"\n---\n\nBody.\n"
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		added, err := appendAliasesToPeopleFile(path, []string{"new"}, true)
+		if err != nil || added != 1 {
+			t.Fatalf("added=%d err=%v", added, err)
+		}
+		data, _ := os.ReadFile(path)
+		if string(data) != content {
+			t.Errorf("dry run modified the file:\n%s", data)
+		}
+	})
+
+	t.Run("no frontmatter", func(t *testing.T) {
+		path := filepath.Join(dir, "plain.md")
+		if err := os.WriteFile(path, []byte("just text"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := appendAliasesToPeopleFile(path, []string{"x"}, false); err == nil {
+			t.Error("want error for missing frontmatter")
+		}
+	})
+
+	t.Run("unclosed frontmatter", func(t *testing.T) {
+		path := filepath.Join(dir, "unclosed.md")
+		if err := os.WriteFile(path, []byte("---\ntitle: x\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := appendAliasesToPeopleFile(path, []string{"x"}, false); err == nil {
+			t.Error("want error for unclosed frontmatter")
+		}
+	})
+}
+
+func TestRunApplyIdentities(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "scribe.yaml"), []byte("domains: [acme]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SCRIBE_KB", root)
+	writeKBFile(t, root, "people/jane-doe.md",
+		"---\ntitle: \"Jane Doe\"\n---\n\nBody.\n")
+	// people/maybe.md exists too, but its block is low-confidence.
+	writeKBFile(t, root, "people/maybe.md",
+		"---\ntitle: \"Maybe Person\"\n---\n\nBody.\n")
+	writeKBFile(t, root, "wiki/_identity-proposals.md", sampleProposals)
+
+	var err error
+	out := captureLintStdout(t, func() { err = runApplyIdentities("", false, false) })
+	if err != nil {
+		t.Fatalf("runApplyIdentities: %v", err)
+	}
+	if !strings.Contains(out, "touched 1 file(s)") {
+		t.Errorf("expected 1 touched file:\n%s", out)
+	}
+
+	jane, _ := os.ReadFile(filepath.Join(root, "people", "jane-doe.md"))
+	for _, want := range []string{"jane@corp.example", "@janedoe"} {
+		if !strings.Contains(string(jane), want) {
+			t.Errorf("jane missing alias %q:\n%s", want, jane)
+		}
+	}
+	maybe, _ := os.ReadFile(filepath.Join(root, "people", "maybe.md"))
+	if strings.Contains(string(maybe), "maybe@corp.example") {
+		t.Errorf("low-confidence block applied without --apply-low:\n%s", maybe)
+	}
+
+	// --apply-low picks up the low-confidence block on a second pass.
+	out = captureLintStdout(t, func() { err = runApplyIdentities("", true, false) })
+	if err != nil {
+		t.Fatalf("apply-low pass: %v", err)
+	}
+	maybe, _ = os.ReadFile(filepath.Join(root, "people", "maybe.md"))
+	if !strings.Contains(string(maybe), "maybe@corp.example") {
+		t.Errorf("--apply-low did not apply:\n%s", maybe)
+	}
+	// Jane's block is now a no-op — only maybe.md counts as touched.
+	if !strings.Contains(out, "touched 1 file(s)") {
+		t.Errorf("re-run should be idempotent for already-applied blocks:\n%s", out)
+	}
+}
+
+func TestRunApplyIdentities_MissingInputs(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "scribe.yaml"), []byte("domains: [acme]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SCRIBE_KB", root)
+
+	t.Run("no proposals file", func(t *testing.T) {
+		err := runApplyIdentities("", false, false)
+		if err == nil || !strings.Contains(err.Error(), "no identity proposals") {
+			t.Errorf("want guidance error, got %v", err)
+		}
+	})
+
+	t.Run("page not found is skipped, not fatal", func(t *testing.T) {
+		writeKBFile(t, root, "wiki/_identity-proposals.md",
+			"### Ghost Person\n- Existing page: people/ghost.md\n- Surface forms:\n  - g@x.io\n- Confidence: high\n- Suggested action: add-aliases\n")
+		var err error
+		out := captureLintStdout(t, func() { err = runApplyIdentities("", false, false) })
+		if err != nil {
+			t.Fatalf("missing page should skip, not fail: %v", err)
+		}
+		if !strings.Contains(out, "touched 0 file(s), skipped 1") {
+			t.Errorf("expected skip accounting:\n%s", out)
+		}
+	})
+}
+
+func TestDryRunSuffix(t *testing.T) {
+	if got := dryRunSuffix(false); got != "" {
+		t.Errorf("got %q", got)
+	}
+	if got := dryRunSuffix(true); !strings.Contains(got, "dry-run") {
+		t.Errorf("got %q", got)
+	}
+}

--- a/cmd/scribe/identities_test.go
+++ b/cmd/scribe/identities_test.go
@@ -1,0 +1,211 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLooksLikePersonTarget(t *testing.T) {
+	tests := []struct {
+		target string
+		want   bool
+	}{
+		{"Lisa Chen", true},
+		{"Jean-Pierre Dupont", true},
+		{"O'Brien Smith", true},
+		{"Anna Maria Della Rosa", true}, // 4 tokens — upper bound
+		{"Lisa", false},                 // single token
+		{"lisa chen", false},            // lowercase lead
+		{"Lisa von Chen", false},        // lowercase preposition
+		{"Phoenix LiveView", false},     // CamelCase token
+		{"LLM Agents", false},           // ALL-CAPS acronym
+		{"One Two Three Four Five", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.target, func(t *testing.T) {
+			if got := looksLikePersonTarget(tt.target); got != tt.want {
+				t.Errorf("looksLikePersonTarget(%q) = %v, want %v", tt.target, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestKnownIdentities(t *testing.T) {
+	people := []existingPerson{
+		{Title: "Lisa Chen", Aliases: []string{"lchen", "Lisa C."}},
+		{Title: "", Aliases: []string{"ghost"}},
+	}
+	set := knownIdentities(people)
+	for _, want := range []string{"lisa chen", "lchen", "lisa c.", "ghost"} {
+		if !set[want] {
+			t.Errorf("missing %q in known set: %v", want, set)
+		}
+	}
+	if set[""] {
+		t.Error("empty title must not enter the set")
+	}
+}
+
+func TestCollectExistingPeople(t *testing.T) {
+	root := t.TempDir()
+	writeKBFile(t, root, "people/lisa-chen.md",
+		"---\ntitle: \"Lisa Chen\"\naliases: [lchen]\n---\n\nBody.\n")
+	writeKBFile(t, root, "people/_template.md",
+		"---\ntitle: \"Skip Me\"\n---\n")
+	writeKBFile(t, root, "people/notes.txt", "not markdown")
+	writeKBFile(t, root, "people/broken.md", "---\ntitle: [unclosed\n")
+
+	people := collectExistingPeople(root)
+	if len(people) != 1 {
+		t.Fatalf("want 1 person, got %d: %+v", len(people), people)
+	}
+	p := people[0]
+	if p.Title != "Lisa Chen" || p.PagePath != "people/lisa-chen.md" {
+		t.Errorf("unexpected entry: %+v", p)
+	}
+	if len(p.Aliases) != 1 || p.Aliases[0] != "lchen" {
+		t.Errorf("aliases not collected: %v", p.Aliases)
+	}
+
+	if got := collectExistingPeople(filepath.Join(root, "missing")); got != nil {
+		t.Errorf("missing people dir should yield nil, got %v", got)
+	}
+}
+
+func TestHarvestMentions(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "scribe.yaml"), []byte("domains: [acme]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Non-person wiki page whose title must be prefiltered from wikilink hits.
+	writeKBFile(t, root, "tools/plugin.md",
+		"---\ntitle: \"Claude Plugin\"\n---\n\nA tool page.\n")
+	// Wiki article with every mention shape.
+	writeKBFile(t, root, "wiki/notes.md", `---
+title: "Notes"
+---
+
+Mail from jane@corp.example and noise@example.com (stopword domain).
+Handle @janedoe appears here; module attribute @moduledoc must not.
+Linked person [[Mark Webber]] and [[Mark Webber]] again and [[Mark Webber]] once more.
+Known [[Lisa Chen]] is already cataloged. Tool page [[Claude Plugin]] is not a person.
+Rare name [[Once Only]] appears a single time.
+
+`+"```\ncode-fence@corp.example must be ignored\n@fencehandle too\n```\n")
+	// Raw articles are scanned too.
+	writeKBFile(t, root, "raw/articles/cap.md", "Raw capture mentions raw@corp.example.\n")
+
+	existing := []existingPerson{{Title: "Lisa Chen", Aliases: nil}}
+	mentions := harvestMentions(root, existing)
+
+	wantPresent := map[string]int{
+		"jane@corp.example": 1,
+		"@janedoe":          1,
+		"Mark Webber":       3,
+		"raw@corp.example":  1,
+	}
+	for k, n := range wantPresent {
+		if mentions[k] != n {
+			t.Errorf("mentions[%q] = %d, want %d (all: %v)", k, mentions[k], n, mentions)
+		}
+	}
+	for _, absent := range []string{
+		"noise@example.com",       // stopword email domain
+		"@moduledoc",              // stopword handle
+		"Lisa Chen",               // known person
+		"Claude Plugin",           // non-person wiki title
+		"Once Only",               // below the 3-occurrence bare-name floor
+		"code-fence@corp.example", // inside code fence
+		"@fencehandle",            // inside code fence
+	} {
+		if _, ok := mentions[absent]; ok {
+			t.Errorf("%q should have been filtered out", absent)
+		}
+	}
+}
+
+func TestRenderPeopleBlock(t *testing.T) {
+	if got := renderPeopleBlock(nil); got != "(none)" {
+		t.Errorf("empty people = %q, want (none)", got)
+	}
+	got := renderPeopleBlock([]existingPerson{
+		{Title: "Zed Zee", PagePath: "people/zed.md"},
+		{Title: "Amy Aye", PagePath: "people/amy.md", Aliases: []string{"aa", "amy"}},
+	})
+	lines := strings.Split(got, "\n")
+	if len(lines) != 2 {
+		t.Fatalf("want 2 lines, got %q", got)
+	}
+	if !strings.HasPrefix(lines[0], "- Amy Aye") {
+		t.Errorf("lines not sorted: %q", got)
+	}
+	if !strings.Contains(lines[0], "aliases: aa, amy") {
+		t.Errorf("aliases not rendered: %q", lines[0])
+	}
+}
+
+func TestRenderMentionsBlock(t *testing.T) {
+	t.Run("sorted by frequency then name", func(t *testing.T) {
+		got := renderMentionsBlock(map[string]int{
+			"bob@x.io": 2, "@alice": 5, "Zed Zee": 5,
+		})
+		want := "- @alice (×5)\n- Zed Zee (×5)\n- bob@x.io (×2)"
+		if got != want {
+			t.Errorf("got:\n%s\nwant:\n%s", got, want)
+		}
+	})
+
+	t.Run("truncates at the prompt cap", func(t *testing.T) {
+		counts := make(map[string]int, maxMentionsForIdentityPrompt+10)
+		for i := 0; i < maxMentionsForIdentityPrompt+10; i++ {
+			counts[fmt.Sprintf("Person%04d Mention", i)] = 1
+		}
+		got := renderMentionsBlock(counts)
+		if n := len(strings.Split(got, "\n")); n != maxMentionsForIdentityPrompt {
+			t.Errorf("rendered %d lines, want %d", n, maxMentionsForIdentityPrompt)
+		}
+	})
+}
+
+func TestRunIdentitiesCheck_NoMentions(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "scribe.yaml"), []byte("domains: [acme]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SCRIBE_KB", root)
+
+	var err error
+	out := captureLintStdout(t, func() { err = runIdentitiesCheck("", false) })
+	if err != nil {
+		t.Fatalf("runIdentitiesCheck: %v", err)
+	}
+	if !strings.Contains(out, "no unmatched person-mentions") {
+		t.Errorf("expected empty-KB message, got:\n%s", out)
+	}
+}
+
+func TestRunIdentitiesCheck_DryRunPrintsWithoutWriting(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "scribe.yaml"), []byte("domains: [acme]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SCRIBE_KB", root)
+	writeKBFile(t, root, "wiki/notes.md",
+		"---\ntitle: \"Notes\"\n---\n\nPing jane@corp.example today.\n")
+
+	var err error
+	out := captureLintStdout(t, func() { err = runIdentitiesCheck("", true) })
+	if err != nil {
+		t.Fatalf("dry run: %v", err)
+	}
+	if !strings.Contains(out, "jane@corp.example") {
+		t.Errorf("dry run should list mentions:\n%s", out)
+	}
+	if fileExists(filepath.Join(root, "wiki", "_identity-proposals.md")) {
+		t.Error("dry run must not write the proposals file")
+	}
+}

--- a/cmd/scribe/index_test.go
+++ b/cmd/scribe/index_test.go
@@ -1,0 +1,344 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestTruncateOutsideWikilink(t *testing.T) {
+	tests := []struct {
+		name  string
+		s     string
+		limit int
+		want  string
+	}{
+		{"short string unchanged", "hello world", 80, "hello world"},
+		{"plain cut adds ellipsis", strings.Repeat("a", 100), 10, strings.Repeat("a", 7) + "..."},
+		{
+			name:  "cut mid-wikilink backs up to before the opener",
+			s:     "see the [[Very Long Article Title Goes Here]] for details and more words after",
+			limit: 20,
+			want:  "see the...",
+		},
+		{
+			name:  "closed wikilink inside head survives",
+			s:     "[[Short]] then a lot of extra text that goes well past the cut limit here",
+			limit: 30,
+			want:  "[[Short]] then a lot of ext...",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := truncateOutsideWikilink(tt.s, tt.limit); got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractBody(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{"with frontmatter", "---\ntitle: x\n---\n\nThe body.\n", "The body."},
+		{"no frontmatter", "Just text.", "Just text."},
+		{"unclosed frontmatter", "---\ntitle: x\n", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := extractBody([]byte(tt.content)); got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFirstSentence(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"empty", "", ""},
+		{"skips headings", "# Heading\n\nReal content here.\n", "Real content here."},
+		{"first sentence only", "One sentence. Second sentence.", "One sentence."},
+		{"short line as-is", "No terminal period here", "No terminal period here"},
+		{"only headings", "# A\n## B\n", ""},
+		{
+			name: "long line truncated outside wikilink",
+			body: strings.Repeat("x", 100) + " [[Some Linked Article Title That Is Long]] tail",
+			want: strings.Repeat("x", 100) + "...",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := firstSentence(tt.body); got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// graphTestKB builds a tiny linked KB:
+//
+//	wiki/a.md      "A Article" → links to [[B Article]] and [[Ghost Page]]
+//	wiki/b.md      "B Article" → links to itself (must not count)
+//	tools/c.md     "C Tool"    → no links in or out (orphan)
+//	wiki/_index.md hub         → links to [[A Article]]
+func graphTestKB(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "scribe.yaml"), []byte("domains: [acme]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SCRIBE_KB", root)
+	writeKBFile(t, root, "wiki/a.md",
+		"---\ntitle: \"A Article\"\ntype: solution\ndomain: general\n---\n\nFirst sentence about A. More.\n\nSee [[B Article]] and [[Ghost Page]].\n")
+	writeKBFile(t, root, "wiki/b.md",
+		"---\ntitle: \"B Article\"\ntype: solution\ndomain: general\n---\n\nB body refers to [[B Article]] itself.\n")
+	writeKBFile(t, root, "tools/c.md",
+		"---\ntitle: \"C Tool\"\ntype: tool\ndomain: general\n---\n\nA tool nobody links to.\n")
+	writeKBFile(t, root, "wiki/_index.md", "- [[A Article]] -- s\n")
+	return root
+}
+
+func TestIndexCmdRun(t *testing.T) {
+	root := graphTestKB(t)
+
+	var err error
+	captureLintStdout(t, func() { err = (&IndexCmd{}).Run() })
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(root, "wiki", "_index.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "article_count: 3") {
+		t.Errorf("article_count wrong:\n%s", content)
+	}
+	for _, want := range []string{
+		"## tools/",
+		"## wiki/",
+		"- [[A Article]] -- First sentence about A. (solution, general)",
+		"- [[C Tool]] -- A tool nobody links to. (tool, general)",
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("missing %q in:\n%s", want, content)
+		}
+	}
+	// Groups are sorted: tools/ section before wiki/.
+	if strings.Index(content, "## tools/") > strings.Index(content, "## wiki/") {
+		t.Errorf("directory groups not sorted:\n%s", content)
+	}
+	if strings.Contains(content, "%d") {
+		t.Errorf("count placeholder not substituted:\n%s", content)
+	}
+}
+
+func TestIndexCmdDryRun(t *testing.T) {
+	root := graphTestKB(t)
+	// Remove the seeded index so dry-run hits the would-create path.
+	if err := os.Remove(filepath.Join(root, "wiki", "_index.md")); err != nil {
+		t.Fatal(err)
+	}
+
+	var err error
+	out := captureLintStdout(t, func() { err = (&IndexCmd{DryRun: true}).Run() })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "would create _index.md with 3 articles") {
+		t.Errorf("unexpected dry-run output:\n%s", out)
+	}
+	if fileExists(filepath.Join(root, "wiki", "_index.md")) {
+		t.Error("dry run wrote the index")
+	}
+
+	// Write the real index, then dry-run again: up to date.
+	captureLintStdout(t, func() { err = (&IndexCmd{}).Run() })
+	if err != nil {
+		t.Fatal(err)
+	}
+	out = captureLintStdout(t, func() { err = (&IndexCmd{DryRun: true}).Run() })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "up to date") {
+		t.Errorf("expected up-to-date message:\n%s", out)
+	}
+}
+
+func TestBacklinksCmdRun(t *testing.T) {
+	root := graphTestKB(t)
+
+	var err error
+	captureLintStdout(t, func() { err = (&BacklinksCmd{}).Run() })
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(root, "wiki", "_backlinks.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var backlinks map[string][]string
+	if err := json.Unmarshal(data, &backlinks); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := backlinks["B Article"]; len(got) != 1 || got[0] != "A Article" {
+		t.Errorf("B Article backlinks = %v, want [A Article]", got)
+	}
+	// Self-link from b.md must not appear.
+	for _, src := range backlinks["B Article"] {
+		if src == "B Article" {
+			t.Error("self-link counted as backlink")
+		}
+	}
+	// Hub _index.md links are attributed by relative path.
+	if got := backlinks["A Article"]; len(got) != 1 || got[0] != "wiki/_index.md" {
+		t.Errorf("A Article backlinks = %v, want [wiki/_index.md]", got)
+	}
+	// Ghost Page is linked even though it doesn't exist — backlinks
+	// records inbound edges regardless of target existence.
+	if got := backlinks["Ghost Page"]; len(got) != 1 || got[0] != "A Article" {
+		t.Errorf("Ghost Page backlinks = %v", got)
+	}
+}
+
+func TestBacklinksCmdJSONAndDryRun(t *testing.T) {
+	root := graphTestKB(t)
+
+	var err error
+	out := captureLintStdout(t, func() { err = (&BacklinksCmd{JSON: true}).Run() })
+	if err != nil {
+		t.Fatal(err)
+	}
+	var backlinks map[string][]string
+	if err := json.Unmarshal([]byte(out), &backlinks); err != nil {
+		t.Fatalf("stdout not JSON: %v\n%s", err, out)
+	}
+	if fileExists(filepath.Join(root, "wiki", "_backlinks.json")) {
+		t.Error("--json must not write the file")
+	}
+
+	out = captureLintStdout(t, func() { err = (&BacklinksCmd{DryRun: true}).Run() })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "would create _backlinks.json") {
+		t.Errorf("dry-run output:\n%s", out)
+	}
+	if fileExists(filepath.Join(root, "wiki", "_backlinks.json")) {
+		t.Error("dry run wrote the file")
+	}
+}
+
+func TestOrphansCmdRun(t *testing.T) {
+	root := graphTestKB(t)
+	_ = root
+
+	var err error
+	out := captureLintStdout(t, func() { err = (&OrphansCmd{JSON: true}).Run() })
+	if err != nil {
+		t.Fatal(err)
+	}
+	var report orphanReport
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatalf("bad JSON: %v\n%s", err, out)
+	}
+
+	// C Tool has no inbound links; A Article is linked from the hub
+	// index; B Article is linked from A.
+	if len(report.Orphans) != 1 || report.Orphans[0] != "C Tool" {
+		t.Errorf("orphans = %v, want [C Tool]", report.Orphans)
+	}
+	if len(report.Missing) != 1 || report.Missing[0] != "Ghost Page" {
+		t.Errorf("missing = %v, want [Ghost Page]", report.Missing)
+	}
+}
+
+func TestOrphansCmdFilters(t *testing.T) {
+	graphTestKB(t)
+
+	t.Run("orphans only", func(t *testing.T) {
+		var err error
+		out := captureLintStdout(t, func() {
+			err = (&OrphansCmd{JSON: true, OrphansOnly: true}).Run()
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		var report orphanReport
+		if err := json.Unmarshal([]byte(out), &report); err != nil {
+			t.Fatal(err)
+		}
+		if len(report.Orphans) != 1 || report.Missing != nil {
+			t.Errorf("orphans-only report = %+v", report)
+		}
+	})
+
+	t.Run("missing only", func(t *testing.T) {
+		var err error
+		out := captureLintStdout(t, func() {
+			err = (&OrphansCmd{JSON: true, MissingOnly: true}).Run()
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		var report orphanReport
+		if err := json.Unmarshal([]byte(out), &report); err != nil {
+			t.Fatal(err)
+		}
+		if len(report.Missing) != 1 || report.Orphans != nil {
+			t.Errorf("missing-only report = %+v", report)
+		}
+	})
+
+	t.Run("text output lists both sections", func(t *testing.T) {
+		var err error
+		out := captureLintStdout(t, func() { err = (&OrphansCmd{}).Run() })
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(out, "Orphan articles (1)") || !strings.Contains(out, "C Tool") {
+			t.Errorf("orphan section wrong:\n%s", out)
+		}
+		if !strings.Contains(out, "Missing pages (1)") || !strings.Contains(out, "[[Ghost Page]]") {
+			t.Errorf("missing section wrong:\n%s", out)
+		}
+	})
+}
+
+func TestOrphansCmd_AliasCountsAsTitle(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "scribe.yaml"), []byte("domains: [acme]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SCRIBE_KB", root)
+	writeKBFile(t, root, "wiki/a.md",
+		"---\ntitle: \"A Article\"\n---\n\nLinks to [[Bee]].\n")
+	writeKBFile(t, root, "wiki/b.md",
+		"---\ntitle: \"B Article\"\naliases: [Bee]\n---\n\nLinks to [[A Article]].\n")
+
+	var err error
+	out := captureLintStdout(t, func() { err = (&OrphansCmd{JSON: true}).Run() })
+	if err != nil {
+		t.Fatal(err)
+	}
+	var report orphanReport
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatal(err)
+	}
+	if len(report.Missing) != 0 {
+		t.Errorf("alias link reported missing: %v", report.Missing)
+	}
+}

--- a/cmd/scribe/lint_test.go
+++ b/cmd/scribe/lint_test.go
@@ -1,0 +1,405 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// lintTestKB scaffolds a KB root that kbDir() resolves via SCRIBE_KB and
+// that lint's structural phases can walk: scribe.yaml marker + wiki dirs.
+func lintTestKB(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "scribe.yaml"), []byte("domains: [acme]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, d := range []string{"wiki", "solutions", "scripts"} {
+		if err := os.MkdirAll(filepath.Join(root, d), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("SCRIBE_KB", root)
+	return root
+}
+
+// lintValidArticle renders a frontmatter-complete article that passes
+// validateFile with no size warnings (>=15 lines, <=150, index_tier set).
+func lintValidArticle(title string, bodyLines int, extra ...string) string {
+	var sb strings.Builder
+	sb.WriteString("---\n")
+	fmt.Fprintf(&sb, "title: %q\n", title)
+	sb.WriteString("type: solution\n")
+	sb.WriteString("created: 2026-04-10\n")
+	sb.WriteString("updated: 2026-04-10\n")
+	sb.WriteString("domain: general\n")
+	sb.WriteString("confidence: high\n")
+	sb.WriteString("tags: [tag1]\n")
+	sb.WriteString("related: []\n")
+	sb.WriteString(`sources: ["source1"]` + "\n")
+	sb.WriteString(`problem: "p"` + "\n")
+	sb.WriteString("index_tier: standard\n")
+	for _, e := range extra {
+		sb.WriteString(e + "\n")
+	}
+	sb.WriteString("---\n\n")
+	for i := 0; i < bodyLines; i++ {
+		fmt.Fprintf(&sb, "Body line %d of %s.\n", i, title)
+	}
+	return sb.String()
+}
+
+// captureLintStdout runs fn with os.Stdout redirected into a pipe and
+// returns everything it printed.
+func captureLintStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	orig := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+	fn()
+	_ = w.Close()
+	os.Stdout = orig
+	data, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+func TestLintTargetFiles(t *testing.T) {
+	root := lintTestKB(t)
+	writeKBFile(t, root, "wiki/a.md", lintValidArticle("A Article", 20))
+	writeKBFile(t, root, "solutions/b.md", lintValidArticle("B Article", 20))
+	writeKBFile(t, root, "wiki/_index.md", "- [[A Article]]\n")
+
+	t.Run("explicit args win", func(t *testing.T) {
+		l := &LintCmd{Files: []string{"/some/explicit.md"}}
+		files, err := l.targetFiles(root)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(files) != 1 || files[0] != "/some/explicit.md" {
+			t.Errorf("explicit files not passed through: %v", files)
+		}
+	})
+
+	t.Run("default walks articles, skipping meta", func(t *testing.T) {
+		l := &LintCmd{}
+		files, err := l.targetFiles(root)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(files) != 2 {
+			t.Fatalf("want 2 articles, got %d: %v", len(files), files)
+		}
+		for _, f := range files {
+			if strings.Contains(f, "_index") {
+				t.Errorf("underscore meta file leaked into scope: %s", f)
+			}
+		}
+	})
+}
+
+func TestLintFrontmatter(t *testing.T) {
+	root := lintTestKB(t)
+	good := filepath.Join(root, "wiki", "good.md")
+	bad := filepath.Join(root, "wiki", "bad.md")
+	writeKBFile(t, root, "wiki/good.md", lintValidArticle("Good", 20))
+	writeKBFile(t, root, "wiki/bad.md", "---\ntitle: \"Bad\"\ntype: solution\n---\n\nBody.\n")
+
+	var errors int
+	out := captureLintStdout(t, func() {
+		errors = lintFrontmatter(root, []string{good, bad})
+	})
+	// A file with several missing fields still counts once.
+	if errors != 1 {
+		t.Errorf("want 1 file with errors, got %d", errors)
+	}
+	if !strings.Contains(out, "wiki/bad.md") {
+		t.Errorf("error output missing offending file:\n%s", out)
+	}
+	if strings.Contains(out, "good.md") {
+		t.Errorf("clean file flagged:\n%s", out)
+	}
+}
+
+func TestLintSizes(t *testing.T) {
+	root := lintTestKB(t)
+
+	cases := []struct {
+		name     string
+		rel      string
+		content  string
+		warnings int
+		wantMsg  string
+	}{
+		{
+			name: "thin article",
+			rel:  "wiki/thin.md",
+			// Size phase counts total lines including frontmatter, so a
+			// minimal frontmatter keeps the file under the 15-line floor.
+			content:  "---\ntitle: \"Thin\"\nindex_tier: stub\n---\n\nOne line.\n",
+			warnings: 1,
+			wantMsg:  "thin article",
+		},
+		{
+			name:     "bloated article",
+			rel:      "wiki/bloat.md",
+			content:  lintValidArticle("Bloat", 160),
+			warnings: 1,
+			wantMsg:  "bloated article",
+		},
+		{
+			name:     "good article clean",
+			rel:      "wiki/good.md",
+			content:  lintValidArticle("Good", 30),
+			warnings: 0,
+		},
+		{
+			name:     "missing index_tier warns",
+			rel:      "wiki/notier.md",
+			content:  strings.Replace(lintValidArticle("NoTier", 30), "index_tier: standard\n", "", 1),
+			warnings: 1,
+			wantMsg:  "index_tier missing",
+		},
+		{
+			name:     "overgrown rolling file warns",
+			rel:      "wiki/learnings.md",
+			content:  "---\ntitle: \"Learnings\"\nrolling: true\n---\n\n" + strings.Repeat("entry\n", 210),
+			warnings: 1,
+			wantMsg:  "rolling file",
+		},
+		{
+			name:     "rolling archive exempt from size warning",
+			rel:      "wiki/learnings-archive-2025.md",
+			content:  "---\ntitle: \"Learnings Archive\"\nrolling: true\n---\n\n" + strings.Repeat("entry\n", 210),
+			warnings: 0,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			writeKBFile(t, root, tt.rel, tt.content)
+			var got int
+			out := captureLintStdout(t, func() {
+				got = lintSizes(root, []string{filepath.Join(root, tt.rel)})
+			})
+			if got != tt.warnings {
+				t.Errorf("warnings = %d, want %d\noutput:\n%s", got, tt.warnings, out)
+			}
+			if tt.wantMsg != "" && !strings.Contains(out, tt.wantMsg) {
+				t.Errorf("output missing %q:\n%s", tt.wantMsg, out)
+			}
+		})
+	}
+}
+
+func TestLintOrphans(t *testing.T) {
+	root := lintTestKB(t)
+	// A links to B and to a missing page D. C has no inbound links.
+	writeKBFile(t, root, "wiki/a.md", lintValidArticle("A Article", 14)+"\nSee [[B Article]] and [[Missing Page]].\n")
+	writeKBFile(t, root, "wiki/b.md", lintValidArticle("B Article", 20))
+	writeKBFile(t, root, "wiki/c.md", lintValidArticle("C Article", 20))
+
+	var warnings int
+	out := captureLintStdout(t, func() {
+		warnings = lintOrphans(root)
+	})
+	// One warning for orphans (A + C have no inbound links), one for the
+	// missing page.
+	if warnings != 2 {
+		t.Errorf("warnings = %d, want 2\noutput:\n%s", warnings, out)
+	}
+	if !strings.Contains(out, "2 orphan articles") {
+		t.Errorf("expected 2 orphan articles, output:\n%s", out)
+	}
+	if !strings.Contains(out, "1 missing pages") {
+		t.Errorf("expected 1 missing page, output:\n%s", out)
+	}
+}
+
+func TestLintOrphans_AliasResolvesLink(t *testing.T) {
+	root := lintTestKB(t)
+	// B is referenced only by its alias — must not count as a missing page,
+	// and the alias-targeted link gives the alias entry an inbound link.
+	writeKBFile(t, root, "wiki/a.md", lintValidArticle("A Article", 14)+"\nSee [[Bee]].\n")
+	writeKBFile(t, root, "wiki/b.md", lintValidArticle("B Article", 20, "aliases: [Bee]"))
+
+	out := captureLintStdout(t, func() {
+		lintOrphans(root)
+	})
+	if strings.Contains(out, "missing pages") {
+		t.Errorf("alias-linked page reported missing:\n%s", out)
+	}
+}
+
+func TestLintIndexConsistency(t *testing.T) {
+	root := lintTestKB(t)
+	writeKBFile(t, root, "wiki/a.md", lintValidArticle("A Article", 20))
+	writeKBFile(t, root, "wiki/b.md", lintValidArticle("B Article", 20))
+
+	t.Run("no index file is silent", func(t *testing.T) {
+		var w int
+		captureLintStdout(t, func() { w = lintIndexConsistency(root) })
+		if w != 0 {
+			t.Errorf("warnings = %d, want 0 when index missing", w)
+		}
+	})
+
+	t.Run("small drift tolerated", func(t *testing.T) {
+		writeKBFile(t, root, "wiki/_index.md", "- [[A Article]] -- s\n")
+		var w int
+		out := captureLintStdout(t, func() { w = lintIndexConsistency(root) })
+		if w != 0 {
+			t.Errorf("warnings = %d, want 0 for diff of 1\noutput:\n%s", w, out)
+		}
+	})
+
+	t.Run("large drift warns", func(t *testing.T) {
+		// 6 index entries vs 2 disk articles → diff -4.
+		var sb strings.Builder
+		for i := 0; i < 6; i++ {
+			fmt.Fprintf(&sb, "- [[Article %d]] -- s\n", i)
+		}
+		writeKBFile(t, root, "wiki/_index.md", sb.String())
+		var w int
+		out := captureLintStdout(t, func() { w = lintIndexConsistency(root) })
+		if w != 1 {
+			t.Errorf("warnings = %d, want 1\noutput:\n%s", w, out)
+		}
+		if !strings.Contains(out, "diff: -4") {
+			t.Errorf("expected diff -4 in output:\n%s", out)
+		}
+	})
+
+	t.Run("second wikilink on a line not double counted", func(t *testing.T) {
+		writeKBFile(t, root, "wiki/_index.md",
+			"- [[A Article]] -- relates to [[B Article]] closely\n- [[B Article]] -- s\n")
+		out := captureLintStdout(t, func() { lintIndexConsistency(root) })
+		if !strings.Contains(out, "index: 2 entries, disk: 2 articles") {
+			t.Errorf("inline second wikilink miscounted:\n%s", out)
+		}
+	})
+}
+
+func TestLintConflictMarkers(t *testing.T) {
+	root := lintTestKB(t)
+	writeKBFile(t, root, "wiki/clean.md", lintValidArticle("Clean", 20))
+	writeKBFile(t, root, "wiki/broken.md", "# B\n<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> origin/main\n")
+
+	var errors int
+	out := captureLintStdout(t, func() { errors = lintConflictMarkers(root) })
+	if errors != 1 {
+		t.Errorf("errors = %d, want 1\noutput:\n%s", errors, out)
+	}
+	if !strings.Contains(out, "wiki/broken.md:2") {
+		t.Errorf("expected file:line in output:\n%s", out)
+	}
+}
+
+func TestLintRun_StructuralPassAndFail(t *testing.T) {
+	t.Run("clean KB passes", func(t *testing.T) {
+		root := lintTestKB(t)
+		writeKBFile(t, root, "wiki/a.md", lintValidArticle("A Article", 14)+"\nSee [[B Article]].\n")
+		writeKBFile(t, root, "wiki/b.md", lintValidArticle("B Article", 14)+"\nSee [[A Article]].\n")
+		writeKBFile(t, root, "wiki/_index.md", "- [[A Article]] -- s\n- [[B Article]] -- s\n")
+
+		l := &LintCmd{}
+		var err error
+		out := captureLintStdout(t, func() { err = l.Run() })
+		if err != nil {
+			t.Fatalf("Run on clean KB: %v\noutput:\n%s", err, out)
+		}
+		if !strings.Contains(out, "PASSED") {
+			t.Errorf("expected PASSED summary:\n%s", out)
+		}
+	})
+
+	t.Run("frontmatter error fails the run", func(t *testing.T) {
+		root := lintTestKB(t)
+		writeKBFile(t, root, "wiki/bad.md", "---\ntitle: \"Bad\"\n---\n\nBody.\n")
+
+		l := &LintCmd{}
+		var err error
+		captureLintStdout(t, func() { err = l.Run() })
+		if err == nil {
+			t.Fatal("Run should fail on frontmatter errors")
+		}
+		if !strings.Contains(err.Error(), "FAILED") {
+			t.Errorf("error should carry FAILED summary, got: %v", err)
+		}
+	})
+
+	t.Run("changed with no changes is a no-op", func(t *testing.T) {
+		root := lintTestKB(t)
+		gitQuick(t, root, "init")
+		l := &LintCmd{Changed: true}
+		var err error
+		out := captureLintStdout(t, func() { err = l.Run() })
+		if err != nil {
+			t.Fatalf("Run --changed on empty repo: %v", err)
+		}
+		if !strings.Contains(out, "no changed wiki files") {
+			t.Errorf("expected no-op message:\n%s", out)
+		}
+	})
+}
+
+// gitQuick runs a git command in dir, failing the test on error.
+func gitQuick(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...) //nolint:noctx // test fixture, no cancellation needed
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=t@t",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=t@t",
+		"HOME="+dir, // ignore user gitconfig (hooks, signing)
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+func TestChangedWikiFiles(t *testing.T) {
+	root := lintTestKB(t)
+	writeKBFile(t, root, "wiki/tracked.md", lintValidArticle("Tracked", 20))
+	gitQuick(t, root, "init")
+	gitQuick(t, root, "add", ".")
+	gitQuick(t, root, "commit", "-m", "seed")
+
+	// Modify the tracked file, add an untracked one, and an underscore
+	// meta file that must be filtered out.
+	writeKBFile(t, root, "wiki/tracked.md", lintValidArticle("Tracked", 22))
+	writeKBFile(t, root, "wiki/untracked.md", lintValidArticle("Untracked", 20))
+	writeKBFile(t, root, "wiki/_index.md", "- [[Tracked]]\n")
+	writeKBFile(t, root, "wiki/notes.txt", "not markdown")
+
+	files, err := changedWikiFiles(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := make(map[string]bool, len(files))
+	for _, f := range files {
+		got[relPath(root, f)] = true
+	}
+	if !got["wiki/tracked.md"] {
+		t.Errorf("modified tracked file missing: %v", files)
+	}
+	if !got["wiki/untracked.md"] {
+		t.Errorf("untracked file missing: %v", files)
+	}
+	if got["wiki/_index.md"] {
+		t.Errorf("underscore meta file should be filtered: %v", files)
+	}
+	if len(files) != 2 {
+		t.Errorf("want exactly 2 files, got %d: %v", len(files), files)
+	}
+}

--- a/cmd/scribe/resilience_test.go
+++ b/cmd/scribe/resilience_test.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeNetError implements net.Error with a configurable Timeout answer.
+type fakeNetError struct{ timeout bool }
+
+func (e *fakeNetError) Error() string   { return "fake net error" }
+func (e *fakeNetError) Timeout() bool   { return e.timeout }
+func (e *fakeNetError) Temporary() bool { return e.timeout }
+
+// fastRetry keeps test wall time negligible.
+func fastRetry(attempts int) RetryConfig {
+	return RetryConfig{
+		MaxAttempts:   attempts,
+		InitialDelay:  time.Millisecond,
+		MaxDelay:      5 * time.Millisecond,
+		BackoffFactor: 2.0,
+	}
+}
+
+func TestDefaultRetryConfig(t *testing.T) {
+	cfg := defaultRetryConfig()
+	if cfg.MaxAttempts != 3 {
+		t.Errorf("MaxAttempts = %d", cfg.MaxAttempts)
+	}
+	if cfg.InitialDelay != 200*time.Millisecond || cfg.MaxDelay != 10*time.Second {
+		t.Errorf("delays = %v / %v", cfg.InitialDelay, cfg.MaxDelay)
+	}
+	if cfg.BackoffFactor != 2.0 || !cfg.Jitter {
+		t.Errorf("factor/jitter = %v / %v", cfg.BackoffFactor, cfg.Jitter)
+	}
+}
+
+func TestWithRetry(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("first-try success calls fn once", func(t *testing.T) {
+		calls := 0
+		err := WithRetry(ctx, fastRetry(3), func() error {
+			calls++
+			return nil
+		})
+		if err != nil || calls != 1 {
+			t.Errorf("err=%v calls=%d", err, calls)
+		}
+	})
+
+	t.Run("non-retryable error returns immediately and unwrapped", func(t *testing.T) {
+		boom := errors.New("boom")
+		calls := 0
+		err := WithRetry(ctx, fastRetry(3), func() error {
+			calls++
+			return boom
+		})
+		if !errors.Is(err, boom) || calls != 1 {
+			t.Errorf("err=%v calls=%d, want unwrapped boom after 1 call", err, calls)
+		}
+	})
+
+	t.Run("retryable error retries to exhaustion and wraps", func(t *testing.T) {
+		calls := 0
+		timeoutErr := &fakeNetError{timeout: true}
+		err := WithRetry(ctx, fastRetry(3), func() error {
+			calls++
+			return timeoutErr
+		})
+		if calls != 3 {
+			t.Errorf("calls = %d, want 3", calls)
+		}
+		if err == nil || !errors.Is(err, timeoutErr) {
+			t.Errorf("exhaustion error should wrap the last error: %v", err)
+		}
+		if got := err.Error(); !strings.Contains(got, "after 3 attempts") {
+			t.Errorf("error = %q, want attempt count", got)
+		}
+	})
+
+	t.Run("recovers when a later attempt succeeds", func(t *testing.T) {
+		calls := 0
+		err := WithRetry(ctx, fastRetry(3), func() error {
+			calls++
+			if calls < 3 {
+				return &fakeNetError{timeout: true}
+			}
+			return nil
+		})
+		if err != nil || calls != 3 {
+			t.Errorf("err=%v calls=%d", err, calls)
+		}
+	})
+
+	t.Run("canceled context stops before calling fn", func(t *testing.T) {
+		canceled, cancel := context.WithCancel(context.Background())
+		cancel()
+		calls := 0
+		err := WithRetry(canceled, fastRetry(3), func() error {
+			calls++
+			return nil
+		})
+		if !errors.Is(err, context.Canceled) || calls != 0 {
+			t.Errorf("err=%v calls=%d", err, calls)
+		}
+	})
+
+	t.Run("zero config picks up defaults", func(t *testing.T) {
+		// MaxAttempts == 0 must not mean "never run fn".
+		calls := 0
+		err := WithRetry(ctx, RetryConfig{}, func() error {
+			calls++
+			return errors.New("non-retryable")
+		})
+		if err == nil || calls != 1 {
+			t.Errorf("err=%v calls=%d", err, calls)
+		}
+	})
+}
+
+func TestIsRetryable(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"context canceled", context.Canceled, false},
+		{"deadline exceeded", context.DeadlineExceeded, false},
+		{"net timeout", &fakeNetError{timeout: true}, true},
+		{"net non-timeout", &fakeNetError{timeout: false}, false},
+		{"plain error", errors.New("x"), false},
+		{"wrapped net timeout", errors.Join(errors.New("ctx"), &fakeNetError{timeout: true}), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isRetryable(tt.err); got != tt.want {
+				t.Errorf("isRetryable(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAddJitter(t *testing.T) {
+	if got := addJitter(0); got != 0 {
+		t.Errorf("addJitter(0) = %v", got)
+	}
+	if got := addJitter(-time.Second); got != -time.Second {
+		t.Errorf("addJitter(-1s) = %v", got)
+	}
+	base := 100 * time.Millisecond
+	for i := 0; i < 50; i++ {
+		got := addJitter(base)
+		if got < base || got >= base+base/2 {
+			t.Fatalf("addJitter(%v) = %v, want [d, d+d/2)", base, got)
+		}
+	}
+}

--- a/cmd/scribe/sessions_test.go
+++ b/cmd/scribe/sessions_test.go
@@ -1,0 +1,521 @@
+package main
+
+import (
+	"database/sql"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// newCcriderDB creates an on-disk SQLite fixture using the minimal
+// ccrider schema in testdata/ccrider_schema.sql. Tests must never touch
+// the real ~/.config/ccrider/sessions.db.
+func newCcriderDB(t *testing.T) (*sql.DB, string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "sessions.db")
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+	schema, err := os.ReadFile(filepath.Join("testdata", "ccrider_schema.sql"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(string(schema)); err != nil { //nolint:noctx // test fixture
+		t.Fatalf("apply schema: %v", err)
+	}
+	return db, path
+}
+
+// insertFixtureSession adds a sessions row and returns its rowid.
+func insertFixtureSession(t *testing.T, db *sql.DB, sessionID, projectPath string, msgCount int, createdAt, updatedAt, summary string) int64 {
+	t.Helper()
+	//nolint:noctx // test fixture
+	res, err := db.Exec(`INSERT INTO sessions (session_id, project_path, message_count, created_at, updated_at, summary)
+		VALUES (?, ?, ?, ?, ?, ?)`, sessionID, projectPath, msgCount, createdAt, updatedAt, summary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	id, _ := res.LastInsertId()
+	return id
+}
+
+// insertFixtureMessage adds a messages row, mirrored into the FTS tables.
+func insertFixtureMessage(t *testing.T, db *sql.DB, sessionRowID int64, msgType, text string, code bool) {
+	t.Helper()
+	//nolint:noctx // test fixture
+	res, err := db.Exec(`INSERT INTO messages (session_id, type, text_content) VALUES (?, ?, ?)`,
+		sessionRowID, msgType, text)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rowid, _ := res.LastInsertId()
+	if _, err := db.Exec(`INSERT INTO messages_fts (rowid, text_content) VALUES (?, ?)`, rowid, text); err != nil { //nolint:noctx // test fixture
+		t.Fatal(err)
+	}
+	if code {
+		if _, err := db.Exec(`INSERT INTO messages_fts_code (rowid, text_content) VALUES (?, ?)`, rowid, text); err != nil { //nolint:noctx // test fixture
+			t.Fatal(err)
+		}
+	}
+}
+
+// sessionsTestKB scaffolds a KB whose scribe.yaml points ccrider_db at
+// the fixture database.
+func sessionsTestKB(t *testing.T, ccriderDB string) string {
+	t.Helper()
+	root := t.TempDir()
+	yaml := "domains: [acme]\n"
+	if ccriderDB != "" {
+		yaml += "ccrider_db: " + ccriderDB + "\n"
+	}
+	if err := os.WriteFile(filepath.Join(root, "scribe.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "wiki"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SCRIBE_KB", root)
+	return root
+}
+
+func TestFilterVerdict(t *testing.T) {
+	tests := []struct {
+		name  string
+		stats sessionFilterStats
+		want  string
+	}{
+		{"lookup error keeps", sessionFilterStats{Found: false}, ""},
+		{"no user turns", sessionFilterStats{Found: true, UserMsgs: 0, TotalChars: 9000}, "empty"},
+		{"under 500 chars", sessionFilterStats{Found: true, UserMsgs: 5, TotalChars: 499}, "empty"},
+		{"short and shallow", sessionFilterStats{Found: true, UserMsgs: 2, TotalChars: 1999}, "thin"},
+		{"short but rich one-shot", sessionFilterStats{Found: true, UserMsgs: 1, TotalChars: 2000}, ""},
+		{"three user turns", sessionFilterStats{Found: true, UserMsgs: 3, TotalChars: 600}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.stats.filterVerdict(); got != tt.want {
+				t.Errorf("filterVerdict() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestQuerySessionStats(t *testing.T) {
+	db, _ := newCcriderDB(t)
+	sid := insertFixtureSession(t, db, "rich", "/p/alpha", 10, "2026-06-01T10:00:00", "2026-06-01T12:00:00", "did things")
+	insertFixtureMessage(t, db, sid, "user", strings.Repeat("q", 300), false)
+	insertFixtureMessage(t, db, sid, "user", strings.Repeat("w", 300), false)
+	insertFixtureMessage(t, db, sid, "assistant", strings.Repeat("a", 1500), false)
+
+	st := querySessionStats(db, "rich")
+	if !st.Found {
+		t.Fatal("Found = false")
+	}
+	if st.UserMsgs != 2 {
+		t.Errorf("UserMsgs = %d, want 2", st.UserMsgs)
+	}
+	if st.TotalChars != 2100 {
+		t.Errorf("TotalChars = %d, want 2100", st.TotalChars)
+	}
+	if st.ProjectPath != "/p/alpha" {
+		t.Errorf("ProjectPath = %q", st.ProjectPath)
+	}
+
+	// Aggregate queries always return one row: an unknown session reads
+	// as Found with zeros, i.e. verdict "empty" — not a lookup error.
+	unknown := querySessionStats(db, "nope")
+	if !unknown.Found || unknown.filterVerdict() != "empty" {
+		t.Errorf("unknown session: %+v verdict=%q", unknown, unknown.filterVerdict())
+	}
+}
+
+func TestPreFilterSessions(t *testing.T) {
+	db, dbPath := newCcriderDB(t)
+	root := sessionsTestKB(t, dbPath)
+	pendingProj := filepath.Join(t.TempDir(), "pending-proj")
+
+	seed := func(sessionID, project string, userMsgs int, charsPerMsg int) {
+		rowid := insertFixtureSession(t, db, sessionID, project, userMsgs+1,
+			"2026-06-01T10:00:00", "2026-06-01T12:00:00", "s")
+		for i := 0; i < userMsgs; i++ {
+			insertFixtureMessage(t, db, rowid, "user", strings.Repeat("x", charsPerMsg), false)
+		}
+	}
+	seed("rich", "/p/alpha", 3, 800)
+	seed("thin", "/p/alpha", 2, 400)
+	seed("empty", "/p/alpha", 0, 0)
+	seed("inkb", root, 3, 800)
+	seed("pending", pendingProj, 3, 800)
+
+	manifest := `{"projects": {"pending-proj": {"path": ` + jsonQuote(pendingProj) + `, "status": "pending"}}}`
+	writeKBFile(t, root, "scripts/projects.json", manifest)
+
+	kept, skipped := preFilterSessions(root, dbPath,
+		[]string{"rich", "thin", "empty", "inkb", "pending"})
+
+	if len(kept) != 1 || kept[0] != "rich" {
+		t.Errorf("kept = %v, want [rich]", kept)
+	}
+	// thin + empty are marked skipped (recorded as processed); KB and
+	// pending-project sessions are dropped silently so they can resurface.
+	if len(skipped) != 2 {
+		t.Errorf("skipped = %v, want [thin empty] in some order", skipped)
+	}
+	for _, s := range skipped {
+		if s == "inkb" || s == "pending" {
+			t.Errorf("%s must be dropped silently, not marked skipped", s)
+		}
+	}
+}
+
+func TestPreFilterSessions_MissingDBKeepsAll(t *testing.T) {
+	root := sessionsTestKB(t, "")
+	ids := []string{"a", "b"}
+	kept, skipped := preFilterSessions(root, filepath.Join(t.TempDir(), "no.db"), ids)
+	if len(kept) != 2 || len(skipped) != 0 {
+		t.Errorf("kept=%v skipped=%v, want all kept on DB error", kept, skipped)
+	}
+}
+
+func jsonQuote(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
+
+func TestQueryRelatedSessions(t *testing.T) {
+	db, dbPath := newCcriderDB(t)
+	longSummary := strings.Repeat("s", 150)
+	insertFixtureSession(t, db, "target", "/p/alpha", 10, "2026-06-01T10:00:00", "2026-06-10T12:00:00", "target work")
+	insertFixtureSession(t, db, "near", "/p/alpha", 10, "2026-06-01T10:00:00", "2026-06-09T12:00:00", longSummary)
+	insertFixtureSession(t, db, "far", "/p/alpha", 10, "2026-04-01T10:00:00", "2026-04-01T12:00:00", "ancient")
+	insertFixtureSession(t, db, "other", "/p/beta", 10, "2026-06-01T10:00:00", "2026-06-10T11:00:00", "different project")
+	db.Close() // queryRelatedSessions opens its own handle
+
+	related := queryRelatedSessions(dbPath, "target", 7, 10)
+	if len(related) != 1 {
+		t.Fatalf("related = %+v, want exactly the near sibling", related)
+	}
+	r := related[0]
+	if r.SessionID != "near" {
+		t.Errorf("SessionID = %q", r.SessionID)
+	}
+	if len(r.Summary) != 140+len("…") || !strings.HasSuffix(r.Summary, "…") {
+		t.Errorf("summary not truncated to 140+ellipsis: %d chars", len(r.Summary))
+	}
+
+	if got := queryRelatedSessions(filepath.Join(t.TempDir(), "no.db"), "target", 7, 10); got != nil {
+		t.Errorf("missing DB should return nil, got %v", got)
+	}
+	if got := queryRelatedSessions(dbPath, "unknown", 7, 10); got != nil {
+		t.Errorf("unknown target should return nil, got %v", got)
+	}
+}
+
+func TestFormatRelatedSessions(t *testing.T) {
+	if got := formatRelatedSessions(nil); !strings.Contains(got, "none") {
+		t.Errorf("empty list = %q", got)
+	}
+	got := formatRelatedSessions([]relatedSession{
+		{SessionID: "s1", Date: "2026-06-09", Summary: "line one\nline two"},
+		{SessionID: "s2", Date: "2026-06-08", Summary: ""},
+	})
+	if !strings.Contains(got, "- s1 (2026-06-09): line one line two") {
+		t.Errorf("newlines not flattened: %q", got)
+	}
+	if !strings.Contains(got, "- s2 (2026-06-08): (no summary)") {
+		t.Errorf("missing-summary placeholder absent: %q", got)
+	}
+	if strings.HasSuffix(got, "\n") {
+		t.Errorf("trailing newline not trimmed: %q", got)
+	}
+}
+
+func TestLargeSessionBudget(t *testing.T) {
+	tests := []struct {
+		max  int
+		skip bool
+		want int
+	}{
+		{9, false, 3},
+		{1, false, 1}, // floor of 1
+		{0, false, 1},
+		{30, true, 0}, // --skip-large
+	}
+	for _, tt := range tests {
+		s := &SyncCmd{SessionsMax: tt.max, SkipLarge: tt.skip}
+		if got := s.largeSessionBudget(); got != tt.want {
+			t.Errorf("largeSessionBudget(max=%d skip=%v) = %d, want %d", tt.max, tt.skip, got, tt.want)
+		}
+	}
+}
+
+// --- sessions.go: log view + subcommands ---
+
+const sessionsLogFixture = `{
+  "processed": {
+    "s1": {"extracted": "2026-06-01T10:00:00Z", "project": "alpha"},
+    "s2": {"extracted": "2026-06-02T10:00:00Z", "project": "alpha"},
+    "s3": {"skipped": true, "reason": "mechanical", "extracted": "2026-06-03T00:00:00Z"}
+  },
+  "last_scan": "2026-06-03T12:00:00Z"
+}`
+
+func TestSessionsLogView(t *testing.T) {
+	root := sessionsTestKB(t, "")
+	writeKBFile(t, root, "wiki/_sessions_log.json", sessionsLogFixture)
+
+	view, err := loadSessionsLogView(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(view.processed) != 3 {
+		t.Fatalf("processed = %d entries, want 3", len(view.processed))
+	}
+	if !entryIsSkipped(view.processed["s3"]) {
+		t.Error("s3 should be skipped")
+	}
+	if entryIsSkipped(view.processed["s1"]) {
+		t.Error("s1 should not be skipped")
+	}
+	if entryProject(view.processed["s1"]) != "alpha" {
+		t.Errorf("project = %q", entryProject(view.processed["s1"]))
+	}
+	if entryExtracted(view.processed["s2"]) != "2026-06-02T10:00:00Z" {
+		t.Errorf("extracted = %q", entryExtracted(view.processed["s2"]))
+	}
+	// Non-map entries are tolerated.
+	if entryIsSkipped("garbage") || entryProject(42) != "" || entryExtracted(nil) != "" {
+		t.Error("non-map entries must read as zero values")
+	}
+
+	delete(view.processed, "s3")
+	if err := view.save(); err != nil {
+		t.Fatal(err)
+	}
+	again, err := loadSessionsLogView(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := again.processed["s3"]; ok {
+		t.Error("save did not persist the deletion")
+	}
+	if lastScan, _ := again.raw["last_scan"].(string); lastScan != "2026-06-03T12:00:00Z" {
+		t.Errorf("save dropped sibling keys: last_scan = %q", lastScan)
+	}
+}
+
+func TestSortedCountKeys(t *testing.T) {
+	got := sortedCountKeys(map[string]int{"b": 2, "a": 2, "z": 9, "m": 1})
+	want := []string{"z", "a", "b", "m"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v", got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("order[%d] = %q, want %q (full: %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+func TestSessionsStatsCmd_JSON(t *testing.T) {
+	root := sessionsTestKB(t, "")
+	writeKBFile(t, root, "wiki/_sessions_log.json", sessionsLogFixture)
+
+	var err error
+	out := captureLintStdout(t, func() {
+		err = (&SessionsStatsCmd{JSON: true}).Run()
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload struct {
+		Total        int            `json:"total"`
+		Extracted    int            `json:"extracted"`
+		Skipped      int            `json:"skipped"`
+		ByProject    map[string]int `json:"by_project"`
+		FirstExtract string         `json:"first_extract"`
+		LastExtract  string         `json:"last_extract"`
+		LastScan     string         `json:"last_scan"`
+	}
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("bad JSON output: %v\n%s", err, out)
+	}
+	if payload.Total != 3 || payload.Extracted != 2 || payload.Skipped != 1 {
+		t.Errorf("counts = %+v", payload)
+	}
+	if payload.ByProject["alpha"] != 2 {
+		t.Errorf("by_project = %v", payload.ByProject)
+	}
+	if payload.FirstExtract != "2026-06-01T10:00:00Z" || payload.LastExtract != "2026-06-02T10:00:00Z" {
+		t.Errorf("extract range = %q..%q", payload.FirstExtract, payload.LastExtract)
+	}
+	if payload.LastScan != "2026-06-03T12:00:00Z" {
+		t.Errorf("last_scan = %q", payload.LastScan)
+	}
+}
+
+func TestSessionsUnskipCmd(t *testing.T) {
+	db, dbPath := newCcriderDB(t)
+	// "wasrich" now passes the filter; "stillempty" doesn't.
+	rich := insertFixtureSession(t, db, "wasrich", "/p/alpha", 10, "2026-06-01T10:00:00", "2026-06-01T12:00:00", "s")
+	for i := 0; i < 3; i++ {
+		insertFixtureMessage(t, db, rich, "user", strings.Repeat("x", 800), false)
+	}
+	insertFixtureSession(t, db, "stillempty", "/p/alpha", 2, "2026-06-01T10:00:00", "2026-06-01T12:00:00", "s")
+
+	root := sessionsTestKB(t, dbPath)
+	logJSON := `{"processed": {
+		"wasrich": {"skipped": true, "reason": "mechanical"},
+		"stillempty": {"skipped": true, "reason": "mechanical"},
+		"extracted-one": {"extracted": "2026-06-01T00:00:00Z"}
+	}, "last_scan": null}`
+	writeKBFile(t, root, "wiki/_sessions_log.json", logJSON)
+
+	t.Run("dry run reports without writing", func(t *testing.T) {
+		var err error
+		out := captureLintStdout(t, func() {
+			err = (&SessionsUnskipCmd{DryRun: true}).Run()
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(out, "would unskip : 1") {
+			t.Errorf("expected 1 unskippable:\n%s", out)
+		}
+		view, _ := loadSessionsLogView(root)
+		if len(view.processed) != 3 {
+			t.Errorf("dry run modified the log: %d entries", len(view.processed))
+		}
+	})
+
+	t.Run("real run removes only passing entries", func(t *testing.T) {
+		var err error
+		captureLintStdout(t, func() {
+			err = (&SessionsUnskipCmd{}).Run()
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		view, _ := loadSessionsLogView(root)
+		if _, ok := view.processed["wasrich"]; ok {
+			t.Error("wasrich should have been unskipped")
+		}
+		if _, ok := view.processed["stillempty"]; !ok {
+			t.Error("stillempty must stay skipped")
+		}
+		if _, ok := view.processed["extracted-one"]; !ok {
+			t.Error("extracted entries must never be touched")
+		}
+	})
+
+	t.Run("all flag removes every skipped entry", func(t *testing.T) {
+		writeKBFile(t, root, "wiki/_sessions_log.json", logJSON)
+		var err error
+		captureLintStdout(t, func() {
+			err = (&SessionsUnskipCmd{All: true}).Run()
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		view, _ := loadSessionsLogView(root)
+		if len(view.processed) != 1 {
+			t.Errorf("want only the extracted entry left, got %v", view.processed)
+		}
+	})
+}
+
+func TestSessionsInspectCmd_JSON(t *testing.T) {
+	db, dbPath := newCcriderDB(t)
+	rich := insertFixtureSession(t, db, "abc-123", "/p/alpha", 12, "2026-06-01T10:00:00", "2026-06-01T12:00:00", "built a thing")
+	for i := 0; i < 3; i++ {
+		insertFixtureMessage(t, db, rich, "user", strings.Repeat("x", 800), false)
+	}
+
+	root := sessionsTestKB(t, dbPath)
+	writeKBFile(t, root, "wiki/_sessions_log.json",
+		`{"processed": {"skipped-one": {"skipped": true}}, "last_scan": null}`)
+
+	var err error
+	out := captureLintStdout(t, func() {
+		err = (&SessionsInspectCmd{ID: "abc-123", JSON: true}).Run()
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("bad JSON: %v\n%s", err, out)
+	}
+	if payload["in_db"] != true || payload["in_log"] != false {
+		t.Errorf("in_db/in_log = %v/%v", payload["in_db"], payload["in_log"])
+	}
+	if payload["filter_verdict"] != "keep" {
+		t.Errorf("filter_verdict = %v", payload["filter_verdict"])
+	}
+	if payload["project_path"] != "/p/alpha" {
+		t.Errorf("project_path = %v", payload["project_path"])
+	}
+	if payload["message_count"] != float64(12) {
+		t.Errorf("message_count = %v", payload["message_count"])
+	}
+}
+
+// --- hook.go DB query helpers (same fixture schema) ---
+
+func TestHookQueryHelpers(t *testing.T) {
+	db, _ := newCcriderDB(t)
+	insertFixtureSession(t, db, "older", "/p/alpha", 8, "2026-06-01T10:00:00", "2026-06-05T10:00:00", "real work")
+	insertFixtureSession(t, db, "newest", "/p/beta", 4, "2026-06-01T10:00:00", "2026-06-09T10:00:00", "more work")
+	insertFixtureSession(t, db, "bootstrap", "/p/beta", 9, "2026-06-01T10:00:00", "2026-06-10T10:00:00", "You are working in a directory")
+	insertFixtureSession(t, db, "empty-one", "/p/beta", 0, "2026-06-01T10:00:00", "2026-06-11T10:00:00", "x")
+
+	t.Run("queryMostRecentSessionID skips bootstrap and empty", func(t *testing.T) {
+		if got := queryMostRecentSessionID(db); got != "newest" {
+			t.Errorf("got %q, want newest", got)
+		}
+	})
+
+	t.Run("queryMessageCount", func(t *testing.T) {
+		if n, ok := queryMessageCount(db, "older"); !ok || n != 8 {
+			t.Errorf("got (%d, %v)", n, ok)
+		}
+		if _, ok := queryMessageCount(db, "ghost"); ok {
+			t.Error("unknown session should not be found")
+		}
+	})
+
+	t.Run("querySessionProjectPath", func(t *testing.T) {
+		if got := querySessionProjectPath(db, "older"); got != "/p/alpha" {
+			t.Errorf("got %q", got)
+		}
+		if got := querySessionProjectPath(db, "ghost"); got != "" {
+			t.Errorf("unknown session = %q, want empty", got)
+		}
+	})
+}
+
+func TestQuickScoreSession(t *testing.T) {
+	db, _ := newCcriderDB(t)
+	sid := insertFixtureSession(t, db, "scored", "/p/alpha", 5, "2026-06-01T10:00:00", "2026-06-01T12:00:00", "s")
+	// One decision hit (weight 3), one research hit (weight 3), one code
+	// pattern hit (weight 1) → 7. A message matching a category twice
+	// still counts once per row.
+	insertFixtureMessage(t, db, sid, "user", "we decided to ship it", false)
+	insertFixtureMessage(t, db, sid, "assistant", "research notes from the paper", false)
+	insertFixtureMessage(t, db, sid, "assistant", "defmodule MyApp.Worker uses GenServer", true)
+
+	// The code message also lands in messages_fts; make sure it carries
+	// no keyword from the six prose categories (it doesn't), so the
+	// expected total stays 3 + 3 + 1.
+	if got := quickScoreSession(db, "scored"); got != 7 {
+		t.Errorf("score = %d, want 7", got)
+	}
+
+	if got := quickScoreSession(db, "ghost"); got != 0 {
+		t.Errorf("unknown session score = %d, want 0", got)
+	}
+}

--- a/cmd/scribe/testdata/ccrider_schema.sql
+++ b/cmd/scribe/testdata/ccrider_schema.sql
@@ -1,0 +1,36 @@
+-- Minimal ccrider sessions.db fixture schema for tests.
+-- Mirrors only the columns scribe actually queries (sessions.go,
+-- sync_sessions.go, hook.go, triage.go). Never point tests at the real
+-- ~/.config/ccrider/sessions.db.
+CREATE TABLE sessions (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id    TEXT UNIQUE,
+    project_path  TEXT,
+    message_count INTEGER DEFAULT 0,
+    created_at    TEXT,
+    updated_at    TEXT,
+    summary       TEXT,
+    llm_summary   TEXT
+);
+
+CREATE TABLE messages (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id   INTEGER REFERENCES sessions(id),
+    type         TEXT,
+    text_content TEXT
+);
+
+-- External-content FTS5 tables; tests insert rows manually with
+-- INSERT INTO messages_fts(rowid, text_content) so the rowid matches
+-- messages.id, the join key scribe's queries rely on.
+CREATE VIRTUAL TABLE messages_fts USING fts5(
+    text_content,
+    content='messages',
+    content_rowid='id'
+);
+
+CREATE VIRTUAL TABLE messages_fts_code USING fts5(
+    text_content,
+    content='messages',
+    content_rowid='id'
+);


### PR DESCRIPTION
~160 new behavior-focused, error-path-heavy tests across the six worst-covered deterministic areas (one commit each):

| Target | Before → after |
|---|---|
| `lint.go` | 0% → 77.3% |
| `identities.go` / `identities_apply.go` | 0% → 79.9% / 92.1% |
| `sessions.go` / `sync_sessions.go` / `hook.go` | 0/0/34% → 53/25/50% |
| `index.go` / `backlinks.go` / `orphans.go` | 0% → 89/83/86% |
| `capture.go` | 24% → 49% |
| `estimate.go` / `resilience.go` | 0% → 95.0% / 87.2% |

Adds `testdata/ccrider_schema.sql` — a minimal sessions/messages/FTS5 fixture so session tests never touch the real ccrider DB.

Three real quirks found and documented in tests (not fixed — judgment calls):
1. `querySessionStats` can never report "not in DB" (aggregate always returns a row → `Found=true` with zeros; the `notInDB` counter in `sessions unskip` is unreachable).
2. Alias-only-linked articles still count as orphans in `lintOrphans` and `orphans.go`, even though missing-page detection resolves aliases.
3. The "thin article" floor counts frontmatter lines (~14 by itself), so a frontmatter-complete article can never trigger it.

Heads-up: `TestLint*` here targets current `lint.go` and will need reconciling with the #15 lint-grouping PR — merge that one last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/oliver-kriska/scribe/pull/34">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->