### PR TITLE
feat(lint): group warnings by class; sync relays errors only

### DIFF
--- a/cmd/scribe/lint.go
+++ b/cmd/scribe/lint.go
@@ -11,6 +11,8 @@ import (
 type LintCmd struct {
 	Files   []string `arg:"" optional:"" help:"Files to lint. If empty, lints all wiki articles."`
 	Changed bool     `help:"Lint only uncommitted git changes." short:"c"`
+	Verbose bool     `help:"Print every warning per-file instead of the grouped-by-class summary." short:"v" xor:"output"`
+	Quiet   bool     `help:"Errors and final summary only — suppress phase headers and warnings. Used by sync mid-extract." short:"q" xor:"output"`
 
 	Contradictions bool    `help:"Run LLM-based contradiction check instead of structural lints. Writes wiki/_contradictions.md."`
 	Duplicates     bool    `help:"Structural (no-LLM) content-duplicate scan: exact-body hashes + token overlap. Writes wiki/_duplicates.md. Report-only — never deletes."`
@@ -63,40 +65,47 @@ func (l *LintCmd) Run() error {
 		return nil
 	}
 
-	errors, warnings := 0, 0
-	count := func(e, w int) { errors += e; warnings += w }
+	rep := newLintReport(os.Stdout, l.Verbose, l.Quiet)
+	phase := func(name string) {
+		if !l.Quiet {
+			fmt.Println(name)
+		}
+	}
 
-	fmt.Println("Phase 1: Frontmatter validation")
-	count(lintFrontmatter(root, files), 0)
-	fmt.Println("Phase 2: Size checks")
-	count(0, lintSizes(root, files))
+	phase("Phase 1: Frontmatter validation")
+	lintFrontmatter(rep, root, files)
+	phase("Phase 2: Size checks")
+	lintSizes(rep, root, files)
 
 	// Phases 3-6 are cross-KB structural checks — they only make sense
 	// on a full scan, not a --changed subset.
 	if !l.Changed {
-		fmt.Println("Phase 3: Orphan detection")
-		count(0, lintOrphans(root))
-		fmt.Println("Phase 4: Index consistency")
-		count(0, lintIndexConsistency(root))
-		fmt.Println("Phase 5: Self-ingestion artifacts")
-		count(lintSelfIngestion(root))
-		fmt.Println("Phase 6: Conflict markers")
-		count(lintConflictMarkers(root), 0)
+		phase("Phase 3: Orphan detection")
+		lintOrphans(rep, root)
+		phase("Phase 4: Index consistency")
+		lintIndexConsistency(rep, root)
+		phase("Phase 5: Self-ingestion artifacts")
+		lintSelfIngestion(rep, root)
+		phase("Phase 6: Conflict markers")
+		lintConflictMarkers(rep, root)
 	}
 
 	runStats = map[string]any{
 		"files_checked": len(files),
-		"errors":        errors,
-		"warnings":      warnings,
+		"errors":        rep.errors,
+		"warnings":      rep.warnings,
 	}
 
-	// Summary
-	fmt.Println()
-	if errors > 0 {
-		return fmt.Errorf("FAILED: %d errors, %d warnings", errors, warnings)
+	// Grouped warning summary (default mode only), then verdict.
+	rep.flush()
+	if !l.Quiet {
+		fmt.Println()
 	}
-	if warnings > 0 {
-		fmt.Printf("PASSED with %d warnings\n", warnings)
+	if rep.errors > 0 {
+		return fmt.Errorf("FAILED: %d errors, %d warnings", rep.errors, rep.warnings)
+	}
+	if rep.warnings > 0 {
+		fmt.Printf("PASSED with %d warnings\n", rep.warnings)
 	} else {
 		fmt.Println("PASSED: all checks clean")
 	}
@@ -121,25 +130,25 @@ func (l *LintCmd) targetFiles(root string) ([]string, error) {
 	}
 }
 
-// lintFrontmatter (Phase 1) validates each file's frontmatter. Returns
-// the number of files with at least one error (a file with three
-// problems counts once, matching the historical summary).
-func lintFrontmatter(root string, files []string) (errors int) {
+// lintFrontmatter (Phase 1) validates each file's frontmatter. Counts
+// files with at least one error (a file with three problems counts
+// once, matching the historical summary) while still printing every
+// finding per-file.
+func lintFrontmatter(rep *lintReport, root string, files []string) {
 	for _, path := range files {
 		errs := validateFile(root, path)
 		if len(errs) > 0 {
-			errors++
+			rep.errors++
 			for _, e := range errs {
-				fmt.Printf("  ERROR %s: %s\n", relPath(root, path), e)
+				rep.errorLinef("%s: %s", relPath(root, path), e)
 			}
 		}
 	}
-	return errors
 }
 
 // lintSizes (Phase 2) warns on thin/bloated articles, overgrown rolling
 // files, and missing index_tier frontmatter.
-func lintSizes(root string, files []string) (warnings int) {
+func lintSizes(rep *lintReport, root string, files []string) {
 	for _, path := range files {
 		content, err := os.ReadFile(path)
 		if err != nil {
@@ -158,38 +167,35 @@ func lintSizes(root string, files []string) (warnings int) {
 			base := filepath.Base(rel)
 			isArchive := strings.Contains(base, "-archive-")
 			if !isArchive && lines > 200 {
-				fmt.Printf("  WARN %s: rolling file is %d lines (should archive at 150)\n", rel, lines)
-				warnings++
+				rep.warnf(lintClassRollingOvergrown, "%s: rolling file is %d lines (should archive at 150)", rel, lines)
 			}
 			continue
 		}
 
 		if lines < 15 {
-			fmt.Printf("  WARN %s: thin article (%d lines, minimum 15)\n", rel, lines)
-			warnings++
+			rep.warnf(lintClassThinArticle, "%s: thin article (%d lines, minimum 15)", rel, lines)
 		}
 		if lines > 150 {
-			fmt.Printf("  WARN %s: bloated article (%d lines, should split at 150)\n", rel, lines)
-			warnings++
+			rep.warnf(lintClassBloatedArticle, "%s: bloated article (%d lines, should split at 150)", rel, lines)
 		}
 
 		// Phase 5B: index_tier presence. Warn (not error) when the
 		// computed tier hasn't been written into frontmatter yet, so
 		// the field can roll out without a flag-day migration. Lint
 		// remains green; a follow-up `scribe tier write --missing-only`
-		// resolves the warning. Skip for rolling files (they don't
-		// participate in retrieval ranking the same way).
+		// (hinted via lintHints) resolves the warning. Skip for rolling
+		// files (they don't participate in retrieval ranking the same way).
 		if fm != nil && !fm.Rolling && strings.TrimSpace(fm.IndexTier) == "" {
-			fmt.Printf("  WARN %s: index_tier missing (run `scribe tier write --missing-only`)\n", rel)
-			warnings++
+			rep.warnf(lintClassIndexTierMissing, "%s: index_tier missing", rel)
 		}
 	}
-	return warnings
 }
 
 // lintOrphans (Phase 3) counts articles with no inbound wikilinks and
-// wikilink targets that don't exist.
-func lintOrphans(root string) (warnings int) {
+// wikilink targets that don't exist. Both findings are KB-wide
+// aggregates — already one line per class — so they print inline via
+// warnAggregatef instead of joining the grouped per-file summary.
+func lintOrphans(rep *lintReport, root string) {
 	allTitles := make(map[string]bool)
 	allTargets := make(map[string]bool)
 	inboundCount := make(map[string]int)
@@ -233,8 +239,7 @@ func lintOrphans(root string) (warnings int) {
 		}
 	}
 	if orphanCount > 0 {
-		fmt.Printf("  %d orphan articles (no inbound wikilinks)\n", orphanCount)
-		warnings++
+		rep.warnAggregatef("%d orphan articles (no inbound wikilinks)", orphanCount)
 	}
 
 	missingCount := 0
@@ -244,19 +249,17 @@ func lintOrphans(root string) (warnings int) {
 		}
 	}
 	if missingCount > 0 {
-		fmt.Printf("  %d missing pages (linked but don't exist)\n", missingCount)
-		warnings++
+		rep.warnAggregatef("%d missing pages (linked but don't exist)", missingCount)
 	}
-	return warnings
 }
 
 // lintIndexConsistency (Phase 4) compares wiki/_index.md entry count to
 // the article count on disk; small drift is normal between reindexes.
-func lintIndexConsistency(root string) (warnings int) {
+func lintIndexConsistency(rep *lintReport, root string) {
 	indexPath := filepath.Join(root, "wiki", "_index.md")
 	content, err := os.ReadFile(indexPath)
 	if err != nil {
-		return 0
+		return
 	}
 	// Count lines that *start* with "- [[", not every "- [[" occurrence.
 	// Some one-line summaries contain a second "[[X]]" after a dash
@@ -276,12 +279,10 @@ func lintIndexConsistency(root string) (warnings int) {
 	})
 	diff := diskCount - indexCount
 	if diff > 3 || diff < -3 {
-		fmt.Printf("  WARN index has %d entries but disk has %d articles (diff: %d)\n", indexCount, diskCount, diff)
-		warnings++
+		rep.warnAggregatef("WARN index has %d entries but disk has %d articles (diff: %d)", indexCount, diskCount, diff)
 	} else {
-		fmt.Printf("  index: %d entries, disk: %d articles\n", indexCount, diskCount)
+		rep.infof("index: %d entries, disk: %d articles", indexCount, diskCount)
 	}
-	return warnings
 }
 
 // lintSelfIngestion (Phase 5) flags the artifacts of the
@@ -289,14 +290,12 @@ func lintIndexConsistency(root string) (warnings int) {
 // ".md.md" extensions are always malformed (ERROR); slugified
 // "<x>_md.md" files that shadow an existing "<x>.md" are likely
 // duplicates (WARN). Both are remediated by `scribe lint --fix`.
-func lintSelfIngestion(root string) (errors, warnings int) {
+func lintSelfIngestion(rep *lintReport, root string) {
 	for _, d := range findSelfIngestionDuplicates(root) {
 		if d.Shape == "doubled-ext" {
-			errors++
-			fmt.Printf("  ERROR %s: doubled .md extension — malformed page (run `scribe lint --fix`)\n", d.Rel)
+			rep.errorf("%s: doubled .md extension — malformed page (run `scribe lint --fix`)", d.Rel)
 		} else {
-			warnings++
-			fmt.Printf("  WARN %s: looks like a filename-as-title duplicate of %s (run `scribe lint --fix`)\n", d.Rel, d.CanonicalRel)
+			rep.warnf(lintClassFilenameAsTitle, "%s: looks like a filename-as-title duplicate of %s", d.Rel, d.CanonicalRel)
 		}
 	}
 	// Directories named after the KB itself — the KB filed pages under
@@ -304,22 +303,18 @@ func lintSelfIngestion(root string) (errors, warnings int) {
 	// Contents may hold unique fragments, so this is a review pointer,
 	// not an auto-fix.
 	for _, dir := range findSelfNamedDirs(root) {
-		warnings++
-		fmt.Printf("  WARN %s/: directory named after the KB itself — likely self-ingested pages; review and merge into canonical articles\n", dir)
+		rep.warnf(lintClassSelfNamedDir, "%s/: directory named after the KB itself — likely self-ingested pages; review and merge into canonical articles", dir)
 	}
-	return errors, warnings
 }
 
 // lintConflictMarkers (Phase 6) hard-errors on unresolved merge
 // markers. Team KBs auto-pull, so a botched merge can leave
 // "<<<<<<< HEAD" blocks inside articles where they poison search and
 // LLM context until a human resolves them.
-func lintConflictMarkers(root string) (errors int) {
+func lintConflictMarkers(rep *lintReport, root string) {
 	for _, h := range findConflictMarkers(root) {
-		errors++
-		fmt.Printf("  ERROR %s:%d: unresolved git conflict marker — resolve the merge and recommit\n", h.Rel, h.Line)
+		rep.errorf("%s:%d: unresolved git conflict marker — resolve the merge and recommit", h.Rel, h.Line)
 	}
-	return errors
 }
 
 // runFix collects the file set (--changed, explicit args, or all wiki

--- a/cmd/scribe/lint_report.go
+++ b/cmd/scribe/lint_report.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"sort"
+)
+
+// Warning classes for grouped lint output. Constants keep the warnf call
+// sites and the lintHints table from drifting apart.
+const (
+	lintClassIndexTierMissing = "index_tier missing"
+	lintClassThinArticle      = "thin article"
+	lintClassBloatedArticle   = "bloated article"
+	lintClassRollingOvergrown = "rolling file overgrown"
+	lintClassFilenameAsTitle  = "filename-as-title duplicate"
+	lintClassSelfNamedDir     = "directory named after the KB"
+)
+
+// lintHints maps a warning class to the command that remediates it.
+// Single source of truth for remediation hints: the grouped summary
+// appends "(run: <cmd>)" and verbose per-file lines append
+// "(run `<cmd>`)" from this table — call sites never embed hints in
+// their messages. Add an entry here when a new class gains a fix
+// command; classes without one simply render bare.
+var lintHints = map[string]string{
+	lintClassIndexTierMissing: "scribe tier write --missing-only",
+	lintClassFilenameAsTitle:  "scribe lint --fix",
+}
+
+// lintReport accumulates findings during a structural lint run and
+// controls how they render. Three modes:
+//
+//   - default: per-file warnings are counted by class and printed as a
+//     grouped summary by flush() — a production KB can emit hundreds of
+//     identical "index_tier missing" lines, which is noise per-file but
+//     signal as "412× index_tier missing".
+//   - verbose: every warning prints per-file as it's found (the
+//     pre-grouping behavior); flush() is a no-op.
+//   - quiet: warnings and info lines are suppressed entirely — only
+//     per-file ERROR lines and the caller's final summary line reach
+//     stdout. Used when lint runs inside `scribe sync` so the cron log
+//     isn't flooded mid-extract.
+//
+// ERROR lines always print per-file in every mode: each one is
+// individually actionable, so grouping them would hide the work.
+type lintReport struct {
+	w        io.Writer
+	verbose  bool
+	quiet    bool
+	errors   int
+	warnings int
+
+	classCounts map[string]int
+}
+
+func newLintReport(w io.Writer, verbose, quiet bool) *lintReport {
+	return &lintReport{w: w, verbose: verbose, quiet: quiet, classCounts: make(map[string]int)}
+}
+
+// errorf prints a per-file ERROR line and counts one error. Errors are
+// never grouped or suppressed.
+func (r *lintReport) errorf(format string, args ...any) {
+	r.errors++
+	r.errorLinef(format, args...)
+}
+
+// errorLinef prints a per-file ERROR line without counting — for callers
+// that count errors at a coarser grain (per file, not per finding).
+func (r *lintReport) errorLinef(format string, args ...any) {
+	fmt.Fprintf(r.w, "  ERROR "+format+"\n", args...)
+}
+
+// warnf records a per-file warning of the given class. Verbose mode
+// prints it immediately, with the class's remediation hint appended when
+// lintHints knows one; default mode counts it for the grouped flush;
+// quiet mode only counts.
+func (r *lintReport) warnf(class, format string, args ...any) {
+	r.warnings++
+	if r.quiet {
+		return
+	}
+	if r.verbose {
+		msg := fmt.Sprintf(format, args...)
+		if hint := lintHints[class]; hint != "" {
+			msg += fmt.Sprintf(" (run `%s`)", hint)
+		}
+		fmt.Fprintf(r.w, "  WARN %s\n", msg)
+		return
+	}
+	r.classCounts[class]++
+}
+
+// warnAggregatef records a warning that is already one line per class
+// (orphan totals, index drift). It prints inline in default and verbose
+// modes — there is nothing to group — and is suppressed in quiet mode.
+func (r *lintReport) warnAggregatef(format string, args ...any) {
+	r.warnings++
+	if r.quiet {
+		return
+	}
+	fmt.Fprintf(r.w, "  "+format+"\n", args...)
+}
+
+// infof prints a neutral informational line (suppressed in quiet mode).
+func (r *lintReport) infof(format string, args ...any) {
+	if r.quiet {
+		return
+	}
+	fmt.Fprintf(r.w, "  "+format+"\n", args...)
+}
+
+// flush renders the grouped warning summary in default mode: one line
+// per class, sorted by count descending (ties alphabetical), counts
+// right-aligned and hints column-aligned:
+//
+//	412× index_tier missing          (run: scribe tier write --missing-only)
+//	 23× thin article
+//
+// No-op in verbose mode (warnings already printed per-file), quiet mode,
+// or when no per-file warnings were recorded.
+func (r *lintReport) flush() {
+	if r.verbose || r.quiet || len(r.classCounts) == 0 {
+		return
+	}
+
+	classes := make([]string, 0, len(r.classCounts))
+	for c := range r.classCounts {
+		classes = append(classes, c)
+	}
+	sort.Slice(classes, func(i, j int) bool {
+		ci, cj := r.classCounts[classes[i]], r.classCounts[classes[j]]
+		if ci != cj {
+			return ci > cj
+		}
+		return classes[i] < classes[j]
+	})
+
+	countW := len(fmt.Sprintf("%d", r.classCounts[classes[0]]))
+	nameW := 0
+	for _, c := range classes {
+		if len(c) > nameW {
+			nameW = len(c)
+		}
+	}
+
+	fmt.Fprintln(r.w)
+	for _, c := range classes {
+		if hint := lintHints[c]; hint != "" {
+			fmt.Fprintf(r.w, "%*d× %-*s (run: %s)\n", countW, r.classCounts[c], nameW, c, hint)
+		} else {
+			fmt.Fprintf(r.w, "%*d× %s\n", countW, r.classCounts[c], c)
+		}
+	}
+}

--- a/cmd/scribe/lint_report_test.go
+++ b/cmd/scribe/lint_report_test.go
@@ -1,0 +1,201 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestLintReportGroupedFlush: default mode groups per-file warnings by
+// class — count descending, counts right-aligned, remediation hints from
+// lintHints column-aligned. This is the issue-15 output shape:
+//
+//	412× index_tier missing       (run: scribe tier write --missing-only)
+//	 23× thin article
+func TestLintReportGroupedFlush(t *testing.T) {
+	var buf bytes.Buffer
+	rep := newLintReport(&buf, false, false)
+
+	for range 12 {
+		rep.warnf(lintClassIndexTierMissing, "wiki/a.md: index_tier missing")
+	}
+	for range 3 {
+		rep.warnf(lintClassThinArticle, "wiki/b.md: thin article (4 lines, minimum 15)")
+	}
+	rep.warnf(lintClassFilenameAsTitle, "wiki/c_md.md: looks like a filename-as-title duplicate of wiki/c.md")
+
+	if buf.Len() != 0 {
+		t.Fatalf("default mode must not print warnings per-file, got:\n%s", buf.String())
+	}
+	if rep.warnings != 16 {
+		t.Fatalf("warnings = %d, want 16", rep.warnings)
+	}
+
+	rep.flush()
+	want := "\n" +
+		"12× index_tier missing          (run: scribe tier write --missing-only)\n" +
+		" 3× thin article\n" +
+		" 1× filename-as-title duplicate (run: scribe lint --fix)\n"
+	if got := buf.String(); got != want {
+		t.Errorf("grouped flush mismatch:\ngot:\n%q\nwant:\n%q", got, want)
+	}
+}
+
+// TestLintReportFlushTieBreak: classes with equal counts sort
+// alphabetically so the summary is deterministic run-to-run.
+func TestLintReportFlushTieBreak(t *testing.T) {
+	var buf bytes.Buffer
+	rep := newLintReport(&buf, false, false)
+	rep.warnf(lintClassThinArticle, "x")
+	rep.warnf(lintClassBloatedArticle, "y")
+
+	rep.flush()
+	want := "\n" +
+		"1× bloated article\n" +
+		"1× thin article\n"
+	if got := buf.String(); got != want {
+		t.Errorf("tie-break flush mismatch:\ngot:\n%q\nwant:\n%q", got, want)
+	}
+}
+
+// TestLintReportModes: per-mode visibility of each line kind. Errors are
+// always per-file; per-file warnings print only in verbose; aggregate
+// warnings and info lines print except in quiet; counts accrue in every
+// mode.
+func TestLintReportModes(t *testing.T) {
+	tests := []struct {
+		name    string
+		verbose bool
+		quiet   bool
+
+		wantWarnLine      bool // per-file WARN visible immediately
+		wantAggregateLine bool
+		wantInfoLine      bool
+		wantFlushOutput   bool
+	}{
+		{name: "default", wantAggregateLine: true, wantInfoLine: true, wantFlushOutput: true},
+		{name: "verbose", verbose: true, wantWarnLine: true, wantAggregateLine: true, wantInfoLine: true},
+		{name: "quiet", quiet: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			rep := newLintReport(&buf, tt.verbose, tt.quiet)
+
+			rep.errorf("wiki/e.md: broken frontmatter")
+			rep.warnf(lintClassThinArticle, "wiki/t.md: thin article (3 lines, minimum 15)")
+			rep.warnAggregatef("%d orphan articles (no inbound wikilinks)", 7)
+			rep.infof("index: 10 entries, disk: 10 articles")
+			preFlush := buf.String()
+			rep.flush()
+			postFlush := buf.String()[len(preFlush):]
+
+			if !strings.Contains(preFlush, "ERROR wiki/e.md: broken frontmatter") {
+				t.Errorf("ERROR line must print in %s mode, got:\n%s", tt.name, preFlush)
+			}
+			if got := strings.Contains(preFlush, "WARN wiki/t.md"); got != tt.wantWarnLine {
+				t.Errorf("per-file WARN visible = %v, want %v in %s mode", got, tt.wantWarnLine, tt.name)
+			}
+			if got := strings.Contains(preFlush, "7 orphan articles"); got != tt.wantAggregateLine {
+				t.Errorf("aggregate warning visible = %v, want %v in %s mode", got, tt.wantAggregateLine, tt.name)
+			}
+			if got := strings.Contains(preFlush, "index: 10 entries"); got != tt.wantInfoLine {
+				t.Errorf("info line visible = %v, want %v in %s mode", got, tt.wantInfoLine, tt.name)
+			}
+			if got := strings.Contains(postFlush, "1× thin article"); got != tt.wantFlushOutput {
+				t.Errorf("flush output present = %v, want %v in %s mode", got, tt.wantFlushOutput, tt.name)
+			}
+
+			if rep.errors != 1 {
+				t.Errorf("errors = %d, want 1 in %s mode", rep.errors, tt.name)
+			}
+			if rep.warnings != 2 {
+				t.Errorf("warnings = %d, want 2 in %s mode (per-file + aggregate)", rep.warnings, tt.name)
+			}
+		})
+	}
+}
+
+// TestLintReportVerboseHint: verbose per-file lines carry the remediation
+// hint from lintHints — call sites no longer embed it — and classes
+// without a hint render bare.
+func TestLintReportVerboseHint(t *testing.T) {
+	var buf bytes.Buffer
+	rep := newLintReport(&buf, true, false)
+
+	rep.warnf(lintClassIndexTierMissing, "wiki/a.md: index_tier missing")
+	rep.warnf(lintClassThinArticle, "wiki/b.md: thin article (4 lines, minimum 15)")
+
+	out := buf.String()
+	wantHinted := "  WARN wiki/a.md: index_tier missing (run `scribe tier write --missing-only`)\n"
+	if !strings.Contains(out, wantHinted) {
+		t.Errorf("verbose line missing data-driven hint:\ngot:\n%s\nwant substring:\n%s", out, wantHinted)
+	}
+	if strings.Contains(out, "thin article (4 lines, minimum 15) (run") {
+		t.Errorf("hintless class must not grow a hint:\n%s", out)
+	}
+}
+
+// TestLintSizesGroupsByClass drives the real Phase 2 walker over fixture
+// articles and asserts each size/tier warning lands in its class.
+func TestLintSizesGroupsByClass(t *testing.T) {
+	root := t.TempDir()
+	wiki := filepath.Join(root, "wiki")
+	if err := os.MkdirAll(wiki, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	write := func(name, content string) string {
+		t.Helper()
+		path := filepath.Join(wiki, name)
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+
+	body := func(lines int) string {
+		return strings.Repeat("line\n", lines)
+	}
+
+	files := []string{
+		// thin + index_tier missing (2 warnings, 2 classes)
+		write("thin.md", "---\ntitle: Thin\n---\n"+body(2)),
+		// clean: tiered, between 15 and 150 lines
+		write("ok.md", "---\ntitle: OK\nindex_tier: core\n---\n"+body(40)),
+		// bloated only (tier present)
+		write("bloated.md", "---\ntitle: Big\nindex_tier: core\n---\n"+body(160)),
+		// rolling overgrown (rolling files skip thin/bloated/tier checks)
+		write("rolling.md", "---\ntitle: Roll\nrolling: true\n---\n"+body(210)),
+		// rolling archive: exempt from the size warning entirely
+		write("roll-archive-2025.md", "---\ntitle: Arch\nrolling: true\n---\n"+body(210)),
+	}
+
+	var buf bytes.Buffer
+	rep := newLintReport(&buf, false, false)
+	lintSizes(rep, root, files)
+
+	wantCounts := map[string]int{
+		lintClassThinArticle:      1,
+		lintClassIndexTierMissing: 1,
+		lintClassBloatedArticle:   1,
+		lintClassRollingOvergrown: 1,
+	}
+	for class, want := range wantCounts {
+		if got := rep.classCounts[class]; got != want {
+			t.Errorf("class %q count = %d, want %d", class, got, want)
+		}
+	}
+	if rep.warnings != 4 {
+		t.Errorf("warnings = %d, want 4", rep.warnings)
+	}
+	if rep.errors != 0 {
+		t.Errorf("errors = %d, want 0", rep.errors)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("default mode printed per-file output:\n%s", buf.String())
+	}
+}

--- a/cmd/scribe/sync_absorb.go
+++ b/cmd/scribe/sync_absorb.go
@@ -164,7 +164,7 @@ func (s *SyncCmd) absorbRaw(root string) (int, error) {
 			if scribeExe == "" {
 				scribeExe = "scribe"
 			}
-			_, _ = runCmdErr(root, scribeExe, "lint", "--changed")
+			_, _ = runCmdErr(root, scribeExe, "lint", "--changed", "--quiet")
 		}
 	}
 

--- a/cmd/scribe/sync_extract.go
+++ b/cmd/scribe/sync_extract.go
@@ -353,8 +353,12 @@ func (s *SyncCmd) extractProject(root string, manifest *Manifest, pname string, 
 		}
 	}
 
-	// Post-extraction lint on changed files.
-	lintOut, _ := runCmdErr(root, scribeExe, "lint", "--changed")
+	// Post-extraction lint on changed files. --quiet keeps the
+	// mid-extract relay to per-file ERROR lines plus the one-line
+	// summary ("PASSED with N warnings") — a single noisy project was
+	// observed re-printing 300+ WARN lines into the sync log. The full
+	// grouped warning report belongs to a standalone `scribe lint` run.
+	lintOut, _ := runCmdErr(root, scribeExe, "lint", "--changed", "--quiet")
 	if lintOut != "" {
 		for line := range strings.SplitSeq(lintOut, "\n") {
 			if line != "" {


### PR DESCRIPTION
Closes #15.

Default lint output now groups warnings by class (412 identical `index_tier missing` lines become one):

```
412× index_tier missing       (run: scribe tier write --missing-only)
 23× thin article
```

- `--verbose` restores the old per-file stream byte-for-byte; `--quiet` (new) prints per-file ERRORs + the one-line verdict only. Kong `xor` makes them mutually exclusive.
- ERRORs always stay per-file in every mode (individually actionable).
- Remediation hints are data-driven (`lintHints` map in the new `lint_report.go`), not embedded per call site.
- The 304-WARN mid-extract flood inside `sync`: both sync call sites now pass `--quiet`, so lint owns its output policy and sync surfaces errors only.
- Warning/error count semantics unchanged — run-record stats and `PASSED with N warnings` totals stay comparable.

5 new tests (exact grouped output incl. alignment, tie-breaks, mode matrix, real Phase-2 walker over fixtures). Suite: 1115 green.

Note: merge after `test/coverage-gaps` — its `TestLint*` tests target the pre-grouping `lint.go` and will need reconciling with this refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/oliver-kriska/scribe/pull/35">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->