### PR TITLE
feat(status): split held-by-policy from genuinely-pending backlog

### DIFF
--- a/cmd/scribe/status.go
+++ b/cmd/scribe/status.go
@@ -310,17 +310,27 @@ func qmdIndexSize() (string, error) {
 //     pre-filter ceiling so mechanical/short sessions don't inflate
 //     the backlog.
 //  3. Pending drop files staged inside other projects'
-//     `.claude/scriptorium/` directories — these get collected at
+//     `.claude/<kb-name>/` directories — these get collected at
 //     the start of `scribe sync` but show up here too so the user
 //     can spot accumulated drops without running a full sync.
+//
+// "Pending" means the next sync will actually process it. Work a
+// policy gate holds back forever — drop files without an absorb
+// opt-in under strictness=high, projects over sync.max_extract_files
+// — is reported separately as "held" so the backlog never promises
+// work sync won't do. The classification reuses the same rules sync
+// itself applies (strictnessHoldsFile, exceedsExtractFileCap), so
+// status and the sync-time hold summary can't drift apart.
 //
 // Each subsection is silenced if the underlying state file is
 // missing — a fresh KB shouldn't get a wall of "0 pending" lines.
 func renderBacklog(w io.Writer, root string, cfg *ScribeConfig) {
 	type backlog struct {
-		label string
-		done  int
-		todo  int
+		label    string
+		done     int
+		todo     int
+		held     int
+		heldNote string
 	}
 	var rows []backlog
 
@@ -328,29 +338,44 @@ func renderBacklog(w io.Writer, root string, cfg *ScribeConfig) {
 	if manifest, err := loadManifest(root); err == nil {
 		total := 0
 		needing := 0
+		capped := 0
 		for _, entry := range manifest.Projects {
 			if !dirExists(entry.Path) {
 				continue
 			}
 			total++
-			if entry.LastSHA == "" {
-				needing++
-				continue
-			}
-			if hasGit(entry.Path) {
+			needs := false
+			switch {
+			case entry.LastSHA == "":
+				needs = true
+			case hasGit(entry.Path):
 				cur := gitSHA(entry.Path)
-				if cur != "" && cur != entry.LastSHA {
-					needing++
-				}
+				needs = cur != "" && cur != entry.LastSHA
+			default:
+				// Non-git projects: stat-walk fallback, conservative.
+				needs = entry.LastExtracted == ""
+			}
+			if !needs {
 				continue
 			}
-			// Non-git projects: stat-walk fallback, conservative.
-			if entry.LastExtracted == "" {
+			// Same size gate sync applies: a project over
+			// sync.max_extract_files is skipped every run until the user
+			// runs `scribe deep`, so it's held, not pending.
+			if cfg.Sync.MaxExtractFiles > 0 &&
+				exceedsExtractFileCap(cfg, len(gitChangedFiles(entry.Path, entry.LastSHA, extractScanPatterns))) {
+				capped++
+			} else {
 				needing++
 			}
 		}
 		if total > 0 {
-			rows = append(rows, backlog{label: "projects (extract):", done: total - needing, todo: needing})
+			rows = append(rows, backlog{
+				label:    "projects (extract):",
+				done:     total - needing - capped,
+				todo:     needing,
+				held:     capped,
+				heldNote: ">max_extract_files — run `scribe deep`",
+			})
 		}
 	}
 
@@ -371,9 +396,23 @@ func renderBacklog(w io.Writer, root string, cfg *ScribeConfig) {
 		}
 	}
 
-	// Drop files staged in other projects.
-	if pending := countPendingDropFiles(root); pending > 0 {
-		rows = append(rows, backlog{label: "drop files:", done: 0, todo: pending})
+	// Drop files staged in other projects, split by the same strictness
+	// gate sync's absorb applies: under strictness=high a drop without
+	// an opt-in (`absorb: true` or a named domain) never drains, so
+	// it's held, not pending.
+	if drops := pendingDropFiles(root); len(drops) > 0 {
+		held := 0
+		for _, f := range drops {
+			if strictnessHoldsFile(cfg.Absorb.Strictness, f) {
+				held++
+			}
+		}
+		rows = append(rows, backlog{
+			label:    "drop files:",
+			todo:     len(drops) - held,
+			held:     held,
+			heldNote: "strictness=high — need opt-in",
+		})
 	}
 
 	if len(rows) == 0 {
@@ -382,11 +421,15 @@ func renderBacklog(w io.Writer, root string, cfg *ScribeConfig) {
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "  backlog (run `scribe sync` to process):")
 	for _, r := range rows {
-		if r.done == 0 {
-			fmt.Fprintf(w, "    %-22s %d pending\n", r.label, r.todo)
-		} else {
-			fmt.Fprintf(w, "    %-22s %d done, %d pending\n", r.label, r.done, r.todo)
+		parts := make([]string, 0, 3)
+		if r.done > 0 {
+			parts = append(parts, fmt.Sprintf("%d done", r.done))
 		}
+		if r.held > 0 {
+			parts = append(parts, fmt.Sprintf("%d held (%s)", r.held, r.heldNote))
+		}
+		parts = append(parts, fmt.Sprintf("%d pending", r.todo))
+		fmt.Fprintf(w, "    %-22s %s\n", r.label, strings.Join(parts, ", "))
 	}
 }
 
@@ -408,32 +451,25 @@ func countSessionsInDB(dbPath string) (int, bool) {
 	return n, true
 }
 
-// countPendingDropFiles walks the manifest's project paths and
-// counts unprocessed `.claude/scriptorium/*.md` drop files. A drop
-// file is "pending" if it exists; the sync sweep moves processed
-// files to `.claude/scriptorium/.processed/` so anything still at
-// the top level is awaiting absorption.
-func countPendingDropFiles(root string) int {
+// pendingDropFiles lists the unprocessed drop files staged inside
+// other projects' `.claude/<kb-name>/` directories — the exact set the
+// next sync's collect phase would pick up (same enumeration via
+// unprocessedDropFiles: approved projects only, main checkout plus
+// worktrees, newer than last_drop_processed). Returns paths, not a
+// count, so the caller can classify each file against the strictness
+// gate.
+func pendingDropFiles(root string) []string {
 	manifest, err := loadManifest(root)
 	if err != nil {
-		return 0
+		return nil
 	}
-	total := 0
+	kb := kbName(root)
+	var files []string
 	for _, entry := range manifest.Projects {
-		dropDir := filepath.Join(entry.Path, ".claude", "scriptorium")
-		if !dirExists(dropDir) {
+		if !entry.IsApproved() {
 			continue
 		}
-		files, err := os.ReadDir(dropDir)
-		if err != nil {
-			continue
-		}
-		for _, f := range files {
-			if f.IsDir() || !strings.HasSuffix(f.Name(), ".md") {
-				continue
-			}
-			total++
-		}
+		files = append(files, unprocessedDropFiles(kb, entry)...)
 	}
-	return total
+	return files
 }

--- a/cmd/scribe/status_test.go
+++ b/cmd/scribe/status_test.go
@@ -1,0 +1,215 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestStrictnessHoldsFile pins the shared hold-classification rule used by
+// both sync's absorb gate and the status backlog: strictness=high holds a
+// file unless its frontmatter opts in via `absorb: true` or a named domain.
+func TestStrictnessHoldsFile(t *testing.T) {
+	cases := []struct {
+		name       string
+		strictness string
+		content    string
+		held       bool
+	}{
+		{"high absorb opt-in", "high", "---\nabsorb: true\n---\nbody\n", false},
+		{"high named domain", "high", "---\ndomain: widgets\n---\nbody\n", false},
+		{"high general domain", "high", "---\ndomain: general\n---\nbody\n", true},
+		{"high empty domain", "high", "---\ndomain: \"\"\n---\nbody\n", true},
+		{"high absorb false", "high", "---\nabsorb: false\n---\nbody\n", true},
+		{"high no frontmatter", "high", "just a body\n", true},
+		{"high malformed frontmatter", "high", "---\n: [unbalanced\n", true},
+		{"medium general domain", "medium", "---\ndomain: general\n---\nbody\n", false},
+		{"low no frontmatter", "low", "just a body\n", false},
+	}
+	dir := t.TempDir()
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(dir, fmt.Sprintf("f%d.md", i))
+			if err := os.WriteFile(path, []byte(tc.content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if got := strictnessHoldsFile(tc.strictness, path); got != tc.held {
+				t.Errorf("strictnessHoldsFile(%q, %s) = %v, want %v", tc.strictness, tc.name, got, tc.held)
+			}
+		})
+	}
+}
+
+// statusBacklogFixture builds a minimal KB plus external project dirs for
+// renderBacklog tests. Drop files land in one non-git "dropper" project
+// (marked extracted so it doesn't pollute the projects row); mdProjects
+// are never-extracted projects holding N markdown files each so the
+// max_extract_files gate has something to measure.
+type statusBacklogFixture struct {
+	strictness string
+	maxExtract int
+	drops      map[string]string // drop filename → content
+	mdProjects map[string]int    // project name → number of .md files
+}
+
+func (f statusBacklogFixture) build(t *testing.T) (root string, cfg *ScribeConfig) {
+	t.Helper()
+	root = t.TempDir()
+
+	yaml := fmt.Sprintf("kb_name: testkb\nabsorb:\n  strictness: %s\nsync:\n  max_extract_files: %d\n",
+		f.strictness, f.maxExtract)
+	if err := os.WriteFile(filepath.Join(root, "scribe.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	projects := map[string]map[string]string{}
+
+	if len(f.drops) > 0 {
+		pdir := t.TempDir()
+		dropDir := filepath.Join(pdir, ".claude", "testkb")
+		if err := os.MkdirAll(dropDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		for name, content := range f.drops {
+			if err := os.WriteFile(filepath.Join(dropDir, name), []byte(content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+		// last_sha + last_extracted set, non-git dir → counts as done in
+		// the projects row, so drop assertions stay isolated.
+		projects["dropper"] = map[string]string{
+			"path":           pdir,
+			"domain":         "general",
+			"last_sha":       "abc123",
+			"last_extracted": "2026-01-01T00:00:00Z",
+		}
+	}
+
+	for name, n := range f.mdProjects {
+		pdir := t.TempDir()
+		for i := range n {
+			file := filepath.Join(pdir, fmt.Sprintf("doc%d.md", i))
+			if err := os.WriteFile(file, []byte("# doc\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+		// last_sha empty → "never extracted" → needs extraction without
+		// any git subprocess (gitChangedFiles falls back to findFiles).
+		projects[name] = map[string]string{"path": pdir, "domain": "general"}
+	}
+
+	scriptsDir := filepath.Join(root, "scripts")
+	if err := os.MkdirAll(scriptsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := json.Marshal(map[string]any{"projects": projects})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(scriptsDir, "projects.json"), manifest, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg = loadConfig(root)
+	cfg.CcriderDB = "" // never touch a real sessions DB from tests
+	return root, cfg
+}
+
+// TestRenderBacklogHeldSplit covers the held-by-policy vs genuinely-pending
+// split in the status backlog (issue #17): drop files held by the
+// strictness gate and projects held by the max_extract_files cap must not
+// read as work the next sync will do.
+func TestRenderBacklogHeldSplit(t *testing.T) {
+	optIn := "---\nabsorb: true\n---\nbody\n"
+	namedDomain := "---\ndomain: widgets\n---\nbody\n"
+	generalDomain := "---\ndomain: general\n---\nbody\n"
+	noFrontmatter := "just a body\n"
+
+	cases := []struct {
+		name    string
+		fixture statusBacklogFixture
+		want    []string
+	}{
+		{
+			name: "strictness high splits drops into held and pending",
+			fixture: statusBacklogFixture{
+				strictness: "high",
+				maxExtract: 100,
+				drops: map[string]string{
+					"a.md": optIn,
+					"b.md": namedDomain,
+					"c.md": generalDomain,
+					"d.md": noFrontmatter,
+				},
+			},
+			want: []string{
+				"drop files: 2 held (strictness=high — need opt-in), 2 pending",
+			},
+		},
+		{
+			name: "strictness medium leaves all drops pending",
+			fixture: statusBacklogFixture{
+				strictness: "medium",
+				maxExtract: 100,
+				drops: map[string]string{
+					"a.md": optIn,
+					"c.md": generalDomain,
+					"d.md": noFrontmatter,
+				},
+			},
+			want: []string{
+				"drop files: 3 pending",
+			},
+		},
+		{
+			name: "project over max_extract_files is held not pending",
+			fixture: statusBacklogFixture{
+				strictness: "medium",
+				maxExtract: 2,
+				mdProjects: map[string]int{"big": 3, "small": 1},
+			},
+			want: []string{
+				"projects (extract): 1 held (>max_extract_files — run `scribe deep`), 1 pending",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root, cfg := tc.fixture.build(t)
+			var buf bytes.Buffer
+			renderBacklog(&buf, root, cfg)
+			lines := normalizeLines(buf.String())
+			for _, want := range tc.want {
+				if !containsLine(lines, want) {
+					t.Errorf("backlog missing line %q\ngot:\n%s", want, buf.String())
+				}
+			}
+		})
+	}
+}
+
+// normalizeLines collapses each non-empty output line's whitespace to
+// single spaces so assertions don't encode the %-22s column padding.
+func normalizeLines(out string) []string {
+	var lines []string
+	for line := range strings.SplitSeq(out, "\n") {
+		if fields := strings.Fields(line); len(fields) > 0 {
+			lines = append(lines, strings.Join(fields, " "))
+		}
+	}
+	return lines
+}
+
+func containsLine(lines []string, want string) bool {
+	for _, l := range lines {
+		if l == want {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/scribe/sync_absorb.go
+++ b/cmd/scribe/sync_absorb.go
@@ -109,7 +109,7 @@ func (s *SyncCmd) absorbRaw(root string) (int, error) {
 		}
 
 		// Strictness gate: high = explicit opt-in required.
-		if strictness == "high" && !rawArticleOptsIntoAbsorb(rawFile) {
+		if strictnessHoldsFile(strictness, rawFile) {
 			// One summary line after the loop, not one line per file:
 			// a held backlog is steady-state under strictness=high and
 			// re-listing it (80+ identical lines on scriptorium) buried
@@ -604,6 +604,15 @@ type absorbEntity struct {
 	// Pointer so we can distinguish "chapter 0" from "no chapter
 	// info" — the legacy whole-article pass-1 path leaves it nil.
 	SourceChapter *int `json:"source_chapter,omitempty"`
+}
+
+// strictnessHoldsFile reports whether the absorb policy holds a file back
+// instead of processing it: strictness=high with no explicit opt-in in the
+// file's frontmatter. Single source of truth for the hold rule — sync's
+// absorb loop and `scribe status` both call this, so the sync-time "held N
+// back" summary and the status held count can't drift apart.
+func strictnessHoldsFile(strictness, path string) bool {
+	return strictness == "high" && !rawArticleOptsIntoAbsorb(path)
 }
 
 // rawArticleOptsIntoAbsorb returns true if a raw article's frontmatter

--- a/cmd/scribe/sync_discover.go
+++ b/cmd/scribe/sync_discover.go
@@ -253,6 +253,29 @@ func ensureRepoYAML(root, projectPath, pname, domain string) {
 	logMsg("sync", "   created %s", repoYAML)
 }
 
+// unprocessedDropFiles returns the drop files in a project's checkout(s)
+// that the next sync would collect: top-level *.md under .claude/<kb>/
+// in the main checkout plus recorded worktrees (drop files written in a
+// worktree can be branch-specific and never appear in the main checkout),
+// filtered to those newer than last_drop_processed. Shared by
+// collectDropFiles and `scribe status` so the status backlog counts
+// exactly the set sync will pick up.
+func unprocessedDropFiles(kb string, entry *ProjectEntry) []string {
+	var unprocessed []string
+	for _, base := range entry.collectionPaths() {
+		dropDir := filepath.Join(base, ".claude", kb)
+		if !dirExists(dropDir) {
+			continue
+		}
+		drops, err := filepath.Glob(filepath.Join(dropDir, "*.md"))
+		if err != nil || len(drops) == 0 {
+			continue
+		}
+		unprocessed = append(unprocessed, filterNewerThan(drops, entry.LastDropProcessed)...)
+	}
+	return unprocessed
+}
+
 // collectDropFiles gathers unprocessed drop files from each project's
 // .claude/<kb-name>/ dir (e.g. .claude/scribe/, or a renamed KB's own
 // folder). Returns total count of collected drops.
@@ -264,23 +287,7 @@ func (s *SyncCmd) collectDropFiles(root string, manifest *Manifest) int {
 		if !entry.IsApproved() {
 			continue
 		}
-		// Scan the main checkout plus recorded worktrees — drop files
-		// written in a worktree can be branch-specific and never appear
-		// in the main checkout.
-		var unprocessed []string
-		for _, base := range entry.collectionPaths() {
-			dropDir := filepath.Join(base, ".claude", kb)
-			if !dirExists(dropDir) {
-				continue
-			}
-			drops, err := filepath.Glob(filepath.Join(dropDir, "*.md"))
-			if err != nil || len(drops) == 0 {
-				continue
-			}
-			// Filter to unprocessed drops (newer than last_drop_processed).
-			unprocessed = append(unprocessed, filterNewerThan(drops, entry.LastDropProcessed)...)
-		}
-
+		unprocessed := unprocessedDropFiles(kb, entry)
 		if len(unprocessed) == 0 {
 			continue
 		}

--- a/cmd/scribe/sync_extract.go
+++ b/cmd/scribe/sync_extract.go
@@ -17,6 +17,19 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+// extractScanPatterns is the glob set sync scans for changed files when
+// sizing an extraction. `scribe status` reuses it so its held-by-cap
+// classification counts exactly the files sync will.
+var extractScanPatterns = []string{"*.md", "*.txt", "*.exs", "*.ex"}
+
+// exceedsExtractFileCap reports whether a changed-file count trips the
+// sync.max_extract_files size gate — the rule that makes sync skip a
+// project and point at `scribe deep`. Shared by sync (skip + log) and
+// `scribe status` (held classification) so the two surfaces can't drift.
+func exceedsExtractFileCap(cfg *ScribeConfig, changedCount int) bool {
+	return cfg.Sync.MaxExtractFiles > 0 && changedCount > cfg.Sync.MaxExtractFiles
+}
+
 // extract processes projects that need extraction.
 // Projects run concurrently up to s.Parallel (default 3, capped at 5 to
 // avoid Anthropic rate limits). A rate-limit error cancels pending work
@@ -51,8 +64,7 @@ func (s *SyncCmd) extract(root string, manifest *Manifest) (int, error) {
 	if s.DryRun {
 		for _, pname := range toExtract {
 			entry := manifest.Projects[pname]
-			patterns := []string{"*.md", "*.txt", "*.exs", "*.ex"}
-			changed := gitChangedFiles(entry.Path, entry.LastSHA, patterns)
+			changed := gitChangedFiles(entry.Path, entry.LastSHA, extractScanPatterns)
 			logMsg("sync", " [%s] DRY RUN -- changed files (%d):", pname, len(changed))
 			limit := min(len(changed), 20)
 			for _, f := range changed[:limit] {
@@ -80,8 +92,7 @@ func (s *SyncCmd) extract(root string, manifest *Manifest) (int, error) {
 				return err
 			}
 
-			patterns := []string{"*.md", "*.txt", "*.exs", "*.ex"}
-			changed := gitChangedFiles(entry.Path, entry.LastSHA, patterns)
+			changed := gitChangedFiles(entry.Path, entry.LastSHA, extractScanPatterns)
 
 			// Size gate: one `claude -p` pass reliably blows the 10-min
 			// timeout above ~100 changed files. Rather than eat the
@@ -89,7 +100,7 @@ func (s *SyncCmd) extract(root string, manifest *Manifest) (int, error) {
 			// sync (where it will just fail again), skip the project in
 			// normal sync and point the user at `scribe deep <name>`,
 			// which batches-by-directory and fits in the timeout.
-			if cfg.Sync.MaxExtractFiles > 0 && len(changed) > cfg.Sync.MaxExtractFiles {
+			if exceedsExtractFileCap(cfg, len(changed)) {
 				logMsg("sync", " [%s] SKIP: %d files > sync.max_extract_files (%d). Run: scribe deep %s",
 					pname, len(changed), cfg.Sync.MaxExtractFiles, pname)
 				return nil


### PR DESCRIPTION
Closes #17.

```
projects (extract):    1 done, 1 held (>max_extract_files — run `scribe deep`), 1 pending
drop files:            2 held (strictness=high — need opt-in), 1 pending
```

When nothing is held, output is byte-identical to before.

Status and sync share the SAME gate functions so they can't drift: `strictnessHoldsFile` (the exact gate behind PR #1's sync-time hold summary), `exceedsExtractFileCap` + `extractScanPatterns`, and `unprocessedDropFiles` (extracted from `collectDropFiles`).

Bonus fix: the old status drop-file counter hardcoded the KB name `"scriptorium"` (broken for any other KB) and counted already-processed drops forever — a second source of the never-draining "pending" lie. Replaced by the shared helper.

Tests: 9-case opt-in matrix for the strictness gate + table-driven backlog-split rendering. `make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/oliver-kriska/scribe/pull/37">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->