### PR TITLE
feat(build): split make build from deploy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,11 +43,13 @@ One Go package under `cmd/scribe/`. No internal/ split yet — keep it that way 
 ## Build
 
 ```sh
-make build        # CGO_ENABLED=1, -tags sqlite_fts5
-make install      # builds + drops binary in $HOME/.local/bin
+make build        # CGO_ENABLED=1, -tags sqlite_fts5 → ./bin/scribe (repo-local, gitignored)
+make install      # build + deploy ./bin/scribe to $HOME/.local/bin — the binary cron runs
 make test         # go test ./... -tags sqlite_fts5
 make check        # test + vet
 ```
+
+**Build never deploys.** `make build` writes only to `./bin/scribe`; the live binary at `~/.local/bin/scribe` (executed by cron) changes only on `make install`. On macOS, replacing the deployed binary invalidates the chat.db Full Disk Access grant — re-run `scribe fda` after every `make install`.
 
 **FTS5 is mandatory.** ccrider's `messages_fts` virtual table uses it, and `scribe triage` runs BM25 queries against it. `go-sqlite3` ships without FTS5 — the `sqlite_fts5` build tag is what flips it on. Never drop that tag from the Makefile.
 

--- a/Justfile
+++ b/Justfile
@@ -52,8 +52,15 @@ capture *args:
 test-legacy:
   bats scripts/legacy/tests/
 
+# Both build/install delegate to the Makefile so the build flags can't drift.
+
+# compile to ./bin/scribe (repo-local) — does NOT deploy
 build:
-  CGO_ENABLED=1 go build -tags "sqlite_fts5" -ldflags "-X main.version=$(git describe --tags --always --dirty 2>/dev/null || echo dev)" -o ~/.local/bin/scribe ./cmd/scribe
+  make build
+
+# build + deploy ./bin/scribe to ~/.local/bin (the binary cron runs)
+install:
+  make install
 
 # === Compound ===
 full-cycle: sync dream lint

--- a/Makefile
+++ b/Makefile
@@ -3,32 +3,44 @@
 # FTS5 is required because ccrider's sessions.db uses a `messages_fts` virtual
 # table and triage runs scored BM25 queries against it. go-sqlite3 ships without
 # FTS5 by default; the `sqlite_fts5` build tag enables it.
+#
+# Build vs deploy are split (issue #18): `make build` compiles to ./bin/scribe
+# (repo-local, gitignored) and never touches the live binary; `make install`
+# deploys to $(PREFIX)/bin — the binary cron executes. On macOS, replacing the
+# deployed binary invalidates the chat.db Full Disk Access grant; re-run
+# `scribe fda` after `make install`.
 
 GO      ?= go
 GOFLAGS ?=
 TAGS    ?= sqlite_fts5
 PKG     := ./cmd/scribe/
+BIN     := bin/scribe
 PREFIX  ?= $(HOME)/.local
-BIN     := $(PREFIX)/bin/scribe
+INSTALL_BIN := $(PREFIX)/bin/scribe
 # If the user has GOBIN set (e.g. via mise), shadow that path too so `which
 # scribe` returns the same binary cron uses. Without this, a mise-managed
-# stale binary in $GOBIN will silently shadow the fresh build.
+# stale binary in $GOBIN will silently shadow the fresh deploy.
 GOBIN_DIR := $(shell $(GO) env GOBIN)
 VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 LDFLAGS := -X main.version=$(VERSION)
 
 .PHONY: build install test tidy check fmt race lint vuln ci clean
 
-# Default target builds — matches existing muscle memory. `make ci` runs the
-# full pre-release gate (test+vet+race+lint+vuln).
-build: ## Build the scribe binary (default)
+# Default target builds — matches existing muscle memory, but the output now
+# lands in ./bin/scribe instead of ~/.local/bin (deploy is `make install`).
+# `make ci` runs the full pre-release gate (test+vet+race+lint+vuln).
+build: ## Build the scribe binary to ./bin/scribe (default; does not deploy)
+	@mkdir -p $(dir $(BIN))
 	CGO_ENABLED=1 $(GO) build -tags "$(TAGS)" -ldflags "$(LDFLAGS)" $(GOFLAGS) -o $(BIN) $(PKG)
 
-install: build ## Build and install to $PREFIX/bin (and $GOBIN if set)
-	@if [ -n "$(GOBIN_DIR)" ] && [ "$(GOBIN_DIR)/scribe" != "$(BIN)" ]; then \
+install: build ## Build, then deploy to $(PREFIX)/bin (and $GOBIN if set) — the binary cron runs
+	install -d "$(PREFIX)/bin"
+	install -m 0755 "$(BIN)" "$(INSTALL_BIN)"
+	@if [ -n "$(GOBIN_DIR)" ] && [ "$(GOBIN_DIR)/scribe" != "$(INSTALL_BIN)" ]; then \
 		echo "mirroring binary to $(GOBIN_DIR)/scribe (GOBIN is set — keeps \`which scribe\` in sync)"; \
 		install -m 0755 "$(BIN)" "$(GOBIN_DIR)/scribe"; \
 	fi
+	@echo "deployed $(INSTALL_BIN) — on macOS, re-run \`scribe fda\` (replacing the binary drops the chat.db Full Disk Access grant)"
 
 test: ## Run tests
 	$(GO) test -tags "$(TAGS)" $(GOFLAGS) -count=1 ./...
@@ -54,5 +66,5 @@ check: test ## Run test + vet (quick dev gate)
 
 ci: check race lint vuln ## Full pre-release gate — test+vet+race+lint+vuln
 
-clean: ## Remove built binary
-	rm -f $(BIN)
+clean: ## Remove repo-local build output (never touches the deployed binary)
+	rm -rf bin

--- a/README.md
+++ b/README.md
@@ -133,8 +133,10 @@ Requires Go ≥ 1.26 and a C toolchain (for `go-sqlite3` with FTS5 support):
 ```sh
 git clone https://github.com/oliver-kriska/scribe.git
 cd scribe
-make install    # builds with -tags sqlite_fts5 and drops binary in ~/.local/bin
+make install    # builds with -tags sqlite_fts5 to ./bin/scribe, then deploys to ~/.local/bin
 ```
+
+`make build` alone compiles to the repo-local `./bin/scribe` and never touches `~/.local/bin` — only `make install` replaces the binary cron executes. On macOS, re-run `scribe fda` after `make install`: replacing the deployed binary invalidates its Full Disk Access grant.
 
 ---
 

--- a/cmd/scribe/cron.go
+++ b/cmd/scribe/cron.go
@@ -461,12 +461,12 @@ func probeLaunchAgent(domain, label, plistPath string) string {
 
 // resolveScribeBinary finds the installed scribe binary.
 //
-// Prefer ~/.local/bin/scribe (the canonical install target from the Justfile)
+// Prefer ~/.local/bin/scribe (the canonical deploy target of `make install`)
 // over a PATH lookup. Relying on exec.LookPath means whichever directory comes
 // first in PATH wins — and a stray old build in ~/bin/scribe would silently
-// shadow the fresh one from `just build`, baking the wrong path into the
+// shadow the fresh one from `make install`, baking the wrong path into the
 // installed LaunchAgent plists. If the canonical binary isn't on disk yet
-// (e.g. first install from a freshly cloned repo before `just build`), fall
+// (e.g. first install from a freshly cloned repo before `make install`), fall
 // back to PATH so install still works.
 func resolveScribeBinary() string {
 	canonical := filepath.Join(os.Getenv("HOME"), ".local", "bin", "scribe")


### PR DESCRIPTION
Closes #18. **Muscle-memory change — needs your conscious sign-off, per the issue.**

- `make build` → `./bin/scribe` (repo-local; CGO + `sqlite_fts5` tag preserved byte-for-byte). It can no longer ship a mid-edit binary onto the cron schedule or invalidate the chat.db FDA grant.
- `make install` depends on build, deploys to `$HOME/.local/bin`, and prints a reminder to re-run `scribe fda` on macOS.
- `make clean` now removes `./bin` — it previously deleted `~/.local/bin/scribe`, i.e. the LIVE cron binary.
- `just build`/`just install` delegate to make so flags can't drift; README/CLAUDE.md/cron.go-comment swept.

Verified: `make build` writes only `./bin/scribe` (live binary mtime untouched), `make check` green. Noted follow-up (not implemented): `resolveScribeBinary()` and `fdaTargets()` hardcode `~/.local/bin/scribe` — correct for default PREFIX only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/oliver-kriska/scribe/pull/38">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->