### PR TITLE
feat(sync): collapse per-project unchanged-skip lines into one summary

### DIFF
--- a/cmd/scribe/sync_extract.go
+++ b/cmd/scribe/sync_extract.go
@@ -145,6 +145,7 @@ func (s *SyncCmd) projectsNeedingExtraction(root string, manifest *Manifest) []s
 	var result []string
 	ledger := loadLedger(root)
 	manifestDirty := false
+	unchanged := 0
 
 	for pname, entry := range manifest.Projects {
 		// If --extract specified, only consider that project.
@@ -221,7 +222,15 @@ func (s *SyncCmd) projectsNeedingExtraction(root string, manifest *Manifest) []s
 			}
 		}
 
-		logMsg("sync", " [%s] unchanged, skipping", pname)
+		// One summary line after the loop, not one line per project: an
+		// enrolled-but-idle project is steady-state, and re-listing all
+		// of them (~20 identical lines per run on a populated KB) buried
+		// every real event in the sync log.
+		unchanged++
+	}
+
+	if unchanged > 0 {
+		logMsg("sync", "%d project(s) unchanged", unchanged)
 	}
 
 	if manifestDirty && !s.DryRun {

--- a/cmd/scribe/sync_extract_test.go
+++ b/cmd/scribe/sync_extract_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+)
+
+// captureSyncLog swaps the default slog logger for one writing to a buffer,
+// so tests can assert on what logMsg emits. Restored on cleanup.
+func captureSyncLog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return &buf
+}
+
+// TestProjectsNeedingExtractionUnchangedSummary locks the collapsed
+// unchanged-skip output (issue #20): no per-project "unchanged, skipping"
+// lines, one "N project(s) unchanged" summary when anything was skipped —
+// including when ALL projects are unchanged, so cron logs still show the
+// run scanned them.
+func TestProjectsNeedingExtractionUnchangedSummary(t *testing.T) {
+	cases := []struct {
+		name        string
+		unchanged   int
+		changed     int
+		wantSummary string // "" = summary line must be absent
+	}{
+		{name: "no unchanged projects", unchanged: 0, changed: 2, wantSummary: ""},
+		{name: "some unchanged", unchanged: 2, changed: 1, wantSummary: "2 project(s) unchanged"},
+		{name: "all unchanged", unchanged: 3, changed: 0, wantSummary: "3 project(s) unchanged"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &Manifest{Projects: map[string]*ProjectEntry{}}
+			for i := 0; i < tc.unchanged; i++ {
+				// Non-git dir, previously extracted, no .md files newer
+				// than the marker → counted as unchanged.
+				m.Projects[fmt.Sprintf("idle-%d", i)] = &ProjectEntry{
+					Path:          t.TempDir(),
+					LastSHA:       "deadbeef",
+					LastExtracted: time.Now().UTC().Format(time.RFC3339),
+				}
+			}
+			for i := 0; i < tc.changed; i++ {
+				// Never extracted → needs extraction.
+				m.Projects[fmt.Sprintf("busy-%d", i)] = &ProjectEntry{
+					Path: t.TempDir(),
+				}
+			}
+
+			buf := captureSyncLog(t)
+			s := &SyncCmd{}
+			got := s.projectsNeedingExtraction(t.TempDir(), m)
+
+			if len(got) != tc.changed {
+				t.Errorf("projectsNeedingExtraction returned %v, want %d project(s)", got, tc.changed)
+			}
+
+			out := buf.String()
+			if strings.Contains(out, "unchanged, skipping") {
+				t.Errorf("per-project unchanged-skip line should be collapsed, got:\n%s", out)
+			}
+			if tc.wantSummary == "" {
+				if strings.Contains(out, "unchanged") {
+					t.Errorf("no summary expected with 0 unchanged projects, got:\n%s", out)
+				}
+				return
+			}
+			if !strings.Contains(out, tc.wantSummary) {
+				t.Errorf("summary %q missing from output:\n%s", tc.wantSummary, out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #20.

~20 per-project `unchanged, skipping` lines per cron run collapse into one:

```
18 project(s) unchanged
2 projects need extraction (max: 3)
```

- Lives in `sync_extract.go` (`projectsNeedingExtraction`) — the issue's pointer to `sync_discover.go` was off by one phase.
- Mirrors the strictness-hold summary pattern from PR #1 (counter at top, summary after the loop).
- Per-project lines for changed/discovered/deferred projects untouched; the summary still prints when ALL projects are unchanged so cron stdout shows the scan ran.
- No verbose flag invented — sync doesn't have one.

Table-driven test over 0/some/all-unchanged cases. Suite: 1111 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/oliver-kriska/scribe/pull/39">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->