### PR TITLE
Reland accidentally-closed PRs #32, #34, #35–#39

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,6 +45,9 @@ linters:
     - rowserrcheck # sql.Rows iterations must check rows.Err (silent truncation)
     - sqlclosecheck # sql.Rows/Stmt closed via defer
     - gocritic # diagnostics + two cheap performance checks (see settings)
+    - intrange # for i := 0; i < n → for i := range n
+    - usetesting # t.Chdir/t.TempDir/t.Setenv over raw os equivalents in tests
+    - dupword # duplicated words in comments/strings
 
   settings:
     errcheck:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -49,6 +49,12 @@ linters:
     - usetesting # t.Chdir/t.TempDir/t.Setenv over raw os equivalents in tests
     - dupword # duplicated words in comments/strings
     - nolintlint # every nolint must name its linter and carry a reason
+    # Follow-up (2026-06): three analyzers are fixed tree-wide but NOT yet
+    # enabled because their last hits sit in files frozen for a parallel
+    # work stream — enable each after fixing:
+    #   errchkjson    — 1 hit: llm.go:339
+    #   usestdlibvars — 3 hits: llm.go:276/344/470
+    #   perfsprint    — 6 hits: claude.go:23, llm.go:391, sync_absorb.go:235-238
 
   settings:
     errcheck:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -48,6 +48,7 @@ linters:
     - intrange # for i := 0; i < n → for i := range n
     - usetesting # t.Chdir/t.TempDir/t.Setenv over raw os equivalents in tests
     - dupword # duplicated words in comments/strings
+    - nolintlint # every nolint must name its linter and carry a reason
 
   settings:
     errcheck:
@@ -73,6 +74,11 @@ linters:
         - stringXbytes
     misspell:
       locale: US
+    # Codifies the repo convention that every nolint is specific and
+    # justified inline ("//nolint:<linter> // reason").
+    nolintlint:
+      require-explanation: true
+      require-specific: true
     gosec:
       excludes:
         - G104 # handled by errcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -49,12 +49,9 @@ linters:
     - usetesting # t.Chdir/t.TempDir/t.Setenv over raw os equivalents in tests
     - dupword # duplicated words in comments/strings
     - nolintlint # every nolint must name its linter and carry a reason
-    # Follow-up (2026-06): three analyzers are fixed tree-wide but NOT yet
-    # enabled because their last hits sit in files frozen for a parallel
-    # work stream — enable each after fixing:
-    #   errchkjson    — 1 hit: llm.go:339
-    #   usestdlibvars — 3 hits: llm.go:276/344/470
-    #   perfsprint    — 6 hits: claude.go:23, llm.go:391, sync_absorb.go:235-238
+    - errchkjson # json encode error checks (and the types that make them needed)
+    - usestdlibvars # http.Method*/Status* constants over string/int literals
+    - perfsprint # cheaper fmt.Sprintf/Errorf equivalents (errors.New, strconv)
 
   settings:
     errcheck:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,6 +30,18 @@ linters:
     - revive
     - dupl
     - gocognit
+    # 2026-06 ratchet expansion — bug-class analyzers that were clean at
+    # enablement time; they exist to stay clean.
+    - asasalint # []any passed as any to variadic ...any
+    - bidichk # trojan-source bidi control characters
+    - exptostd # x/exp calls with std equivalents
+    - gocheckcompilerdirectives # malformed //go: directives (silently ignored by the compiler)
+    - mirror # wrong bytes/strings counterpart funcs (extra conversions)
+    - nilnesserr # err != nil checked but a different nil err returned
+    - nosprintfhostport # Sprintf-built host:port URLs (breaks on IPv6)
+    - predeclared # shadowing of Go predeclared identifiers
+    - recvcheck # mixed pointer/value receivers on one type
+    - wastedassign # assignments whose value is never used
 
   settings:
     errcheck:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -44,6 +44,7 @@ linters:
     - wastedassign # assignments whose value is never used
     - rowserrcheck # sql.Rows iterations must check rows.Err (silent truncation)
     - sqlclosecheck # sql.Rows/Stmt closed via defer
+    - gocritic # diagnostics + two cheap performance checks (see settings)
 
   settings:
     errcheck:
@@ -56,6 +57,17 @@ linters:
     # decompose at write time instead.
     gocognit:
       min-complexity: 60
+    # Diagnostic tag = the bug-finders (weakCond, appendAssign, badCond, …).
+    # The performance tag as a whole is deliberately NOT enabled: it is
+    # dominated by hugeParam/rangeValCopy micro-copy churn that doesn't pay
+    # its diff cost in a CLI. The two cherry-picks below are the cheap,
+    # always-correct subset.
+    gocritic:
+      enabled-tags:
+        - diagnostic
+      enabled-checks:
+        - appendCombine
+        - stringXbytes
     misspell:
       locale: US
     gosec:
@@ -85,6 +97,13 @@ linters:
           - forcetypeassert
           - gosec
         path: _test\.go
+
+issues:
+  # No caps on repeated/identical findings — the defaults (50 per linter,
+  # 3 per identical message) silently hid hits during the 2026-06 ratchet
+  # expansion. A ratchet that hides hits isn't one.
+  max-issues-per-linter: 0
+  max-same-issues: 0
 
 formatters:
   enable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,6 +42,8 @@ linters:
     - predeclared # shadowing of Go predeclared identifiers
     - recvcheck # mixed pointer/value receivers on one type
     - wastedassign # assignments whose value is never used
+    - rowserrcheck # sql.Rows iterations must check rows.Err (silent truncation)
+    - sqlclosecheck # sql.Rows/Stmt closed via defer
 
   settings:
     errcheck:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,11 +43,13 @@ One Go package under `cmd/scribe/`. No internal/ split yet — keep it that way 
 ## Build
 
 ```sh
-make build        # CGO_ENABLED=1, -tags sqlite_fts5
-make install      # builds + drops binary in $HOME/.local/bin
+make build        # CGO_ENABLED=1, -tags sqlite_fts5 → ./bin/scribe (repo-local, gitignored)
+make install      # build + deploy ./bin/scribe to $HOME/.local/bin — the binary cron runs
 make test         # go test ./... -tags sqlite_fts5
 make check        # test + vet
 ```
+
+**Build never deploys.** `make build` writes only to `./bin/scribe`; the live binary at `~/.local/bin/scribe` (executed by cron) changes only on `make install`. On macOS, replacing the deployed binary invalidates the chat.db Full Disk Access grant — re-run `scribe fda` after every `make install`.
 
 **FTS5 is mandatory.** ccrider's `messages_fts` virtual table uses it, and `scribe triage` runs BM25 queries against it. `go-sqlite3` ships without FTS5 — the `sqlite_fts5` build tag is what flips it on. Never drop that tag from the Makefile.
 

--- a/Justfile
+++ b/Justfile
@@ -52,8 +52,15 @@ capture *args:
 test-legacy:
   bats scripts/legacy/tests/
 
+# Both build/install delegate to the Makefile so the build flags can't drift.
+
+# compile to ./bin/scribe (repo-local) — does NOT deploy
 build:
-  CGO_ENABLED=1 go build -tags "sqlite_fts5" -ldflags "-X main.version=$(git describe --tags --always --dirty 2>/dev/null || echo dev)" -o ~/.local/bin/scribe ./cmd/scribe
+  make build
+
+# build + deploy ./bin/scribe to ~/.local/bin (the binary cron runs)
+install:
+  make install
 
 # === Compound ===
 full-cycle: sync dream lint

--- a/Makefile
+++ b/Makefile
@@ -3,32 +3,44 @@
 # FTS5 is required because ccrider's sessions.db uses a `messages_fts` virtual
 # table and triage runs scored BM25 queries against it. go-sqlite3 ships without
 # FTS5 by default; the `sqlite_fts5` build tag enables it.
+#
+# Build vs deploy are split (issue #18): `make build` compiles to ./bin/scribe
+# (repo-local, gitignored) and never touches the live binary; `make install`
+# deploys to $(PREFIX)/bin — the binary cron executes. On macOS, replacing the
+# deployed binary invalidates the chat.db Full Disk Access grant; re-run
+# `scribe fda` after `make install`.
 
 GO      ?= go
 GOFLAGS ?=
 TAGS    ?= sqlite_fts5
 PKG     := ./cmd/scribe/
+BIN     := bin/scribe
 PREFIX  ?= $(HOME)/.local
-BIN     := $(PREFIX)/bin/scribe
+INSTALL_BIN := $(PREFIX)/bin/scribe
 # If the user has GOBIN set (e.g. via mise), shadow that path too so `which
 # scribe` returns the same binary cron uses. Without this, a mise-managed
-# stale binary in $GOBIN will silently shadow the fresh build.
+# stale binary in $GOBIN will silently shadow the fresh deploy.
 GOBIN_DIR := $(shell $(GO) env GOBIN)
 VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 LDFLAGS := -X main.version=$(VERSION)
 
 .PHONY: build install test tidy check fmt race lint vuln ci clean
 
-# Default target builds — matches existing muscle memory. `make ci` runs the
-# full pre-release gate (test+vet+race+lint+vuln).
-build: ## Build the scribe binary (default)
+# Default target builds — matches existing muscle memory, but the output now
+# lands in ./bin/scribe instead of ~/.local/bin (deploy is `make install`).
+# `make ci` runs the full pre-release gate (test+vet+race+lint+vuln).
+build: ## Build the scribe binary to ./bin/scribe (default; does not deploy)
+	@mkdir -p $(dir $(BIN))
 	CGO_ENABLED=1 $(GO) build -tags "$(TAGS)" -ldflags "$(LDFLAGS)" $(GOFLAGS) -o $(BIN) $(PKG)
 
-install: build ## Build and install to $PREFIX/bin (and $GOBIN if set)
-	@if [ -n "$(GOBIN_DIR)" ] && [ "$(GOBIN_DIR)/scribe" != "$(BIN)" ]; then \
+install: build ## Build, then deploy to $(PREFIX)/bin (and $GOBIN if set) — the binary cron runs
+	install -d "$(PREFIX)/bin"
+	install -m 0755 "$(BIN)" "$(INSTALL_BIN)"
+	@if [ -n "$(GOBIN_DIR)" ] && [ "$(GOBIN_DIR)/scribe" != "$(INSTALL_BIN)" ]; then \
 		echo "mirroring binary to $(GOBIN_DIR)/scribe (GOBIN is set — keeps \`which scribe\` in sync)"; \
 		install -m 0755 "$(BIN)" "$(GOBIN_DIR)/scribe"; \
 	fi
+	@echo "deployed $(INSTALL_BIN) — on macOS, re-run \`scribe fda\` (replacing the binary drops the chat.db Full Disk Access grant)"
 
 test: ## Run tests
 	$(GO) test -tags "$(TAGS)" $(GOFLAGS) -count=1 ./...
@@ -54,5 +66,5 @@ check: test ## Run test + vet (quick dev gate)
 
 ci: check race lint vuln ## Full pre-release gate — test+vet+race+lint+vuln
 
-clean: ## Remove built binary
-	rm -f $(BIN)
+clean: ## Remove repo-local build output (never touches the deployed binary)
+	rm -rf bin

--- a/README.md
+++ b/README.md
@@ -133,8 +133,10 @@ Requires Go ≥ 1.26 and a C toolchain (for `go-sqlite3` with FTS5 support):
 ```sh
 git clone https://github.com/oliver-kriska/scribe.git
 cd scribe
-make install    # builds with -tags sqlite_fts5 and drops binary in ~/.local/bin
+make install    # builds with -tags sqlite_fts5 to ./bin/scribe, then deploys to ~/.local/bin
 ```
+
+`make build` alone compiles to the repo-local `./bin/scribe` and never touches `~/.local/bin` — only `make install` replaces the binary cron executes. On macOS, re-run `scribe fda` after `make install`: replacing the deployed binary invalidates its Full Disk Access grant.
 
 ---
 

--- a/cmd/scribe/absorb_chapter_test.go
+++ b/cmd/scribe/absorb_chapter_test.go
@@ -425,7 +425,7 @@ func TestSlugifyForChunk(t *testing.T) {
 		{"Chapter One", "chapter-one"},
 		{"3.1 Event-Level Binding", "3-1-event-level-binding"},
 		{"!!!", "chunk"}, // empty after slug → fallback
-		{"a very very very very very very very very very long heading", "a-very-very-very-very-very-very-very-ver"},
+		{"a very very very very very very very very very long heading", "a-very-very-very-very-very-very-very-ver"}, //nolint:dupword // the repetition IS the fixture — exercises slug truncation
 	}
 	for _, c := range cases {
 		got := slugifyForChunk(c.in)

--- a/cmd/scribe/absorb_chapter_test.go
+++ b/cmd/scribe/absorb_chapter_test.go
@@ -321,7 +321,10 @@ func TestMergedFacts_LoadMergedFacts_RoundTrip(t *testing.T) {
 			{ID: "c00-f1", Type: "claim", Claim: "x", Anchor: "y"},
 		},
 	}
-	data, _ := json.Marshal(mf)
+	data, err := json.Marshal(mf)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(filepath.Join(factsDir, "doc.json"), data, 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/scribe/absorb_log_test.go
+++ b/cmd/scribe/absorb_log_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -249,7 +250,7 @@ func TestLoadAbsorbLog_SalvagesAndEagerHeals(t *testing.T) {
 		t.Fatal(err)
 	}
 	after, _ := os.ReadFile(path)
-	if string(before) != string(after) {
+	if !bytes.Equal(before, after) {
 		t.Error("re-loading a clean file rewrote it (should be a no-op fast path)")
 	}
 }
@@ -275,7 +276,7 @@ func TestLoadAbsorbLog_TotalGarbageFailsOpenAndLeavesFileIntact(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(after) != string(garbage) {
+	if !bytes.Equal(after, garbage) {
 		t.Errorf("total-garbage file was overwritten (should be left intact for inspection); got %q", string(after))
 	}
 }

--- a/cmd/scribe/assess_orchestrator.go
+++ b/cmd/scribe/assess_orchestrator.go
@@ -138,7 +138,7 @@ func assessSourceTree(projectPath string, maxEntries int) string {
 	var entries []string
 	walkErr := filepath.Walk(projectPath, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			return nil //nolint:nilerr
+			return nil //nolint:nilerr // unreadable entry: skip it, keep sampling the rest of the tree
 		}
 		if info.IsDir() {
 			if excludedDirNames[info.Name()] {

--- a/cmd/scribe/assess_orchestrator.go
+++ b/cmd/scribe/assess_orchestrator.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -169,6 +170,6 @@ func assessGitLog(projectPath string, n int) string {
 	if !hasGit(projectPath) {
 		return "(not a git repo)"
 	}
-	out := runCmd(projectPath, "git", "log", "--oneline", "-n", fmt.Sprintf("%d", n))
+	out := runCmd(projectPath, "git", "log", "--oneline", "-n", strconv.Itoa(n))
 	return out
 }

--- a/cmd/scribe/backlinks.go
+++ b/cmd/scribe/backlinks.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -97,11 +98,12 @@ func (b *BacklinksCmd) Run() error {
 
 	if b.DryRun {
 		existing, err := os.ReadFile(outPath)
-		if err != nil {
+		switch {
+		case err != nil:
 			fmt.Println("would create _backlinks.json")
-		} else if string(existing) != string(data) {
+		case !bytes.Equal(existing, data):
 			fmt.Println("_backlinks.json would change")
-		} else {
+		default:
 			fmt.Println("_backlinks.json is up to date")
 		}
 		return nil

--- a/cmd/scribe/capture.go
+++ b/cmd/scribe/capture.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -94,7 +95,7 @@ func (c *CaptureCmd) Run() error {
 
 	selfChatIDs := resolveSelfChatHandles(cfg.Capture)
 	if len(selfChatIDs) == 0 {
-		return fmt.Errorf("no self-chat handle configured\n\nSet one of:\n  scribe.yaml →\n    capture:\n      self_chat_handles:\n        - \"+1234567890\"\n        - \"you@icloud.com\"\n  or env:\n    SCRIBE_SELF_CHAT_ID=\"+1234567890,you@icloud.com\"\n\nList every iMessage address you use to message yourself — phone numbers and emails each map to a distinct chat in chat.db")
+		return errors.New("no self-chat handle configured\n\nSet one of:\n  scribe.yaml →\n    capture:\n      self_chat_handles:\n        - \"+1234567890\"\n        - \"you@icloud.com\"\n  or env:\n    SCRIBE_SELF_CHAT_ID=\"+1234567890,you@icloud.com\"\n\nList every iMessage address you use to message yourself — phone numbers and emails each map to a distinct chat in chat.db")
 	}
 
 	messages, err := readSelfChatMessages(selfChatIDs, since)
@@ -372,7 +373,7 @@ func resolveSelfChatHandles(c CaptureConfig) []string {
 // callers must pass every address they use to message themselves.
 func readSelfChatMessages(selfChatIDs []string, since string) ([]chatMessage, error) {
 	if len(selfChatIDs) == 0 {
-		return nil, fmt.Errorf("no self-chat handles supplied")
+		return nil, errors.New("no self-chat handles supplied")
 	}
 	dbPath := filepath.Join(os.Getenv("HOME"), "Library", "Messages", "chat.db")
 	if !fileExists(dbPath) {

--- a/cmd/scribe/capture.go
+++ b/cmd/scribe/capture.go
@@ -94,7 +94,7 @@ func (c *CaptureCmd) Run() error {
 
 	selfChatIDs := resolveSelfChatHandles(cfg.Capture)
 	if len(selfChatIDs) == 0 {
-		return fmt.Errorf("no self-chat handle configured\n\nSet one of:\n  scribe.yaml →\n    capture:\n      self_chat_handles:\n        - \"+1234567890\"\n        - \"you@icloud.com\"\n  or env:\n    SCRIBE_SELF_CHAT_ID=\"+1234567890,you@icloud.com\"\n\nList every iMessage address you use to message yourself — phone numbers and emails each map to a distinct chat in chat.db") //nolint:revive // multi-line error serves as user help text
+		return fmt.Errorf("no self-chat handle configured\n\nSet one of:\n  scribe.yaml →\n    capture:\n      self_chat_handles:\n        - \"+1234567890\"\n        - \"you@icloud.com\"\n  or env:\n    SCRIBE_SELF_CHAT_ID=\"+1234567890,you@icloud.com\"\n\nList every iMessage address you use to message yourself — phone numbers and emails each map to a distinct chat in chat.db")
 	}
 
 	messages, err := readSelfChatMessages(selfChatIDs, since)
@@ -398,7 +398,7 @@ func readSelfChatMessages(selfChatIDs []string, since string) ([]chatMessage, er
 		if qerr != nil {
 			msg := qerr.Error()
 			if strings.Contains(msg, "operation not permitted") || strings.Contains(msg, "unable to open") {
-				return nil, fmt.Errorf("query handle: %w\n\nfull disk access required. macOS blocks reads of ~/Library/Messages/chat.db without it.\nGrant it to the scribe binary:\n  System Settings → Privacy & Security → Full Disk Access → add %s\nFor LaunchAgent-driven captures, the binary itself needs the grant (inheriting from Terminal is not enough)", qerr, os.Args[0]) //nolint:revive // multi-line error serves as user help text
+				return nil, fmt.Errorf("query handle: %w\n\nfull disk access required. macOS blocks reads of ~/Library/Messages/chat.db without it.\nGrant it to the scribe binary:\n  System Settings → Privacy & Security → Full Disk Access → add %s\nFor LaunchAgent-driven captures, the binary itself needs the grant (inheriting from Terminal is not enough)", qerr, os.Args[0])
 			}
 			return nil, fmt.Errorf("query handle %s: %w", id, qerr)
 		}

--- a/cmd/scribe/capture.go
+++ b/cmd/scribe/capture.go
@@ -394,8 +394,7 @@ func readSelfChatMessages(selfChatIDs []string, since string) ([]chatMessage, er
 	var handleIDs []int64
 	var missing []string
 	for _, id := range selfChatIDs {
-		//nolint:noctx // CLI top-level, no context propagation yet
-		rows, qerr := db.Query("SELECT ROWID FROM handle WHERE id = ?", id)
+		ids, qerr := handleRowIDs(db, id)
 		if qerr != nil {
 			msg := qerr.Error()
 			if strings.Contains(msg, "operation not permitted") || strings.Contains(msg, "unable to open") {
@@ -403,22 +402,8 @@ func readSelfChatMessages(selfChatIDs []string, since string) ([]chatMessage, er
 			}
 			return nil, fmt.Errorf("query handle %s: %w", id, qerr)
 		}
-		var matched int
-		for rows.Next() {
-			var rowid int64
-			if scanErr := rows.Scan(&rowid); scanErr != nil {
-				rows.Close()
-				return nil, fmt.Errorf("scan handle %s: %w", id, scanErr)
-			}
-			handleIDs = append(handleIDs, rowid)
-			matched++
-		}
-		if rerr := rows.Err(); rerr != nil {
-			rows.Close()
-			return nil, fmt.Errorf("iterate handle %s: %w", id, rerr)
-		}
-		rows.Close()
-		if matched == 0 {
+		handleIDs = append(handleIDs, ids...)
+		if len(ids) == 0 {
 			missing = append(missing, id)
 		}
 	}
@@ -499,6 +484,30 @@ func readSelfChatMessages(selfChatIDs []string, since string) ([]chatMessage, er
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterate rows: %w", err)
+	}
+	return out, nil
+}
+
+// handleRowIDs returns every handle ROWID for one handle id. Split out of
+// readSelfChatMessages so rows.Close can be deferred per query — the caller
+// loops over handles, where a bare defer would pile up until function exit.
+func handleRowIDs(db *sql.DB, id string) ([]int64, error) {
+	//nolint:noctx // CLI top-level, no context propagation yet
+	rows, err := db.Query("SELECT ROWID FROM handle WHERE id = ?", id)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []int64
+	for rows.Next() {
+		var rowid int64
+		if err := rows.Scan(&rowid); err != nil {
+			return nil, fmt.Errorf("scan: %w", err)
+		}
+		out = append(out, rowid)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate: %w", err)
 	}
 	return out, nil
 }

--- a/cmd/scribe/capture_write_test.go
+++ b/cmd/scribe/capture_write_test.go
@@ -1,0 +1,250 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// appleNanos converts a wall-clock time into the chat.db date column unit
+// (nanoseconds since 2001-01-01 UTC).
+func appleNanos(t time.Time) int64 {
+	return (t.UTC().Unix() - appleEpochOffset) * 1_000_000_000
+}
+
+func TestMessageURLs(t *testing.T) {
+	t.Run("text column wins", func(t *testing.T) {
+		m := chatMessage{
+			Text:           "check https://example.com/a and https://example.com/b",
+			AttributedBody: []byte("https://from-blob.example/ignored"),
+		}
+		urls := messageURLs(m)
+		if len(urls) != 2 || urls[0] != "https://example.com/a" || urls[1] != "https://example.com/b" {
+			t.Errorf("urls = %v", urls)
+		}
+	})
+
+	t.Run("attributedBody fallback with WHttpURL sentinel", func(t *testing.T) {
+		blob := append([]byte{0x01, 0x02}, []byte("https://example.com/pathWHttpURL\x01garbage")...)
+		m := chatMessage{Text: "no links here", AttributedBody: blob}
+		urls := messageURLs(m)
+		if len(urls) != 1 || urls[0] != "https://example.com/path" {
+			t.Errorf("urls = %v, want clean URL truncated at sentinel", urls)
+		}
+	})
+
+	t.Run("no urls anywhere", func(t *testing.T) {
+		if urls := messageURLs(chatMessage{Text: "plain note"}); urls != nil {
+			t.Errorf("urls = %v, want nil", urls)
+		}
+	})
+}
+
+func TestSortCapturedMessages(t *testing.T) {
+	ts := appleNanos(time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC))
+	messages := []chatMessage{
+		{Text: "https://example.com/article.", Date: ts},           // trailing punctuation trimmed
+		{Text: "https://example.com/article", Date: ts},            // dup of the above after trim
+		{Text: "https://maps.google.com/place/x", Date: ts},        // skip domain
+		{Text: "https://already.example/seen", Date: ts},           // pre-captured
+		{Text: "Permission request https://x.example/y", Date: ts}, // control message
+		{Text: "an idea worth keeping around", Date: ts},           // note
+		{Text: "Liked an idea worth keeping around", Date: ts},     // reaction noise
+		{Text: "short", Date: ts},                                  // <=10 chars
+	}
+	captured := map[string]bool{"https://already.example/seen": true}
+
+	urls, notes := sortCapturedMessages(messages, captured, []string{"maps.google.com"})
+
+	if len(urls) != 1 {
+		t.Fatalf("urls = %+v, want 1", urls)
+	}
+	u := urls[0]
+	if u.URL != "https://example.com/article" {
+		t.Errorf("URL = %q, want punctuation trimmed", u.URL)
+	}
+	if u.Date != "2026-06-01" {
+		t.Errorf("Date = %q", u.Date)
+	}
+	if !captured["https://example.com/article"] {
+		t.Error("accepted URL not marked captured")
+	}
+
+	if len(notes) != 1 || notes[0].Text != "an idea worth keeping around" {
+		t.Errorf("notes = %+v", notes)
+	}
+}
+
+func TestWriteURLCaptures(t *testing.T) {
+	rawDir := t.TempDir()
+	item := capturedURL{
+		URL:        "https://example.com/some/article",
+		Date:       "2026-06-01",
+		SourceText: "https://example.com/some/article",
+	}
+
+	t.Run("writes a stub article", func(t *testing.T) {
+		c := &CaptureCmd{}
+		saved := c.writeURLCaptures(rawDir, []capturedURL{item})
+		if len(saved) != 1 {
+			t.Fatalf("saved = %v", saved)
+		}
+		wantName := "2026-06-01-imessage-example-com-some-article.md"
+		if saved[0] != wantName {
+			t.Errorf("filename = %q, want %q", saved[0], wantName)
+		}
+		data, err := os.ReadFile(filepath.Join(rawDir, wantName))
+		if err != nil {
+			t.Fatal(err)
+		}
+		content := string(data)
+		for _, want := range []string{
+			`source_url: "https://example.com/some/article"`,
+			"fetched_via: stub",
+			"captured: 2026-06-01",
+			"tags: [imessage]",
+			"Captured from iMessage self-chat on 2026-06-01.",
+		} {
+			if !strings.Contains(content, want) {
+				t.Errorf("missing %q in:\n%s", want, content)
+			}
+		}
+	})
+
+	t.Run("existing file is not overwritten", func(t *testing.T) {
+		c := &CaptureCmd{}
+		saved := c.writeURLCaptures(rawDir, []capturedURL{item})
+		if len(saved) != 0 {
+			t.Errorf("second pass saved %v, want none", saved)
+		}
+	})
+
+	t.Run("dry run writes nothing", func(t *testing.T) {
+		dryDir := t.TempDir()
+		c := &CaptureCmd{DryRun: true}
+		var saved []string
+		out := captureLintStdout(t, func() {
+			saved = c.writeURLCaptures(dryDir, []capturedURL{item})
+		})
+		if len(saved) != 0 {
+			t.Errorf("dry run saved %v", saved)
+		}
+		entries, _ := os.ReadDir(dryDir)
+		if len(entries) != 0 {
+			t.Errorf("dry run created files: %v", entries)
+		}
+		if !strings.Contains(out, "WOULD CAPTURE") {
+			t.Errorf("dry run output:\n%s", out)
+		}
+	})
+}
+
+func TestWriteNoteCaptures(t *testing.T) {
+	rawDir := t.TempDir()
+	long := strings.Repeat("idea ", 30) // >80 chars, title must truncate
+	notes := []capturedNote{
+		{Text: long, Date: "2026-06-02"},
+	}
+
+	c := &CaptureCmd{}
+	saved := c.writeNoteCaptures(rawDir, notes)
+	if len(saved) != 1 {
+		t.Fatalf("saved = %v", saved)
+	}
+	if !strings.HasPrefix(saved[0], "2026-06-02-imessage-note-") {
+		t.Errorf("filename = %q", saved[0])
+	}
+	data, err := os.ReadFile(filepath.Join(rawDir, saved[0]))
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "fetched_via: imessage-note") {
+		t.Errorf("missing via marker:\n%s", content)
+	}
+	if !strings.Contains(content, "tags: [imessage, note]") {
+		t.Errorf("missing tags:\n%s", content)
+	}
+	// Title is clipped to 80 chars; body keeps the full text.
+	titleLine := ""
+	for line := range strings.SplitSeq(content, "\n") {
+		if strings.HasPrefix(line, "title:") {
+			titleLine = line
+			break
+		}
+	}
+	if len(titleLine) > len(`title: ""`)+80 {
+		t.Errorf("title not truncated: %q", titleLine)
+	}
+	if !strings.Contains(content, strings.TrimSpace(long)) {
+		t.Errorf("full note text missing from body:\n%s", content)
+	}
+
+	// Existing note is skipped on a second run.
+	if again := c.writeNoteCaptures(rawDir, notes); len(again) != 0 {
+		t.Errorf("second pass saved %v", again)
+	}
+}
+
+func TestWriteCaptureFile_CreatesParents(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "deep", "nested", "file.md")
+	if err := writeCaptureFile(path, "content\n"); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil || string(data) != "content\n" {
+		t.Errorf("read back: %q, %v", data, err)
+	}
+}
+
+func TestCaptureStateRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "scripts", "imessage-state.json")
+
+	t.Run("missing file yields zero state", func(t *testing.T) {
+		st, err := loadCaptureState(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if st.LastCapture != nil || st.CapturedCount != 0 || len(st.CapturedURLs) != 0 {
+			t.Errorf("zero state = %+v", st)
+		}
+	})
+
+	t.Run("save creates parents and round-trips", func(t *testing.T) {
+		last := "2026-06-01"
+		st := &captureState{
+			LastCapture:   &last,
+			CapturedURLs:  []string{"https://example.com/a"},
+			CapturedCount: 7,
+		}
+		if err := saveCaptureState(path, st); err != nil {
+			t.Fatal(err)
+		}
+		if fileExists(path + ".tmp") {
+			t.Error("tmp file left behind")
+		}
+		got, err := loadCaptureState(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.LastCapture == nil || *got.LastCapture != "2026-06-01" {
+			t.Errorf("LastCapture = %v", got.LastCapture)
+		}
+		if got.CapturedCount != 7 || len(got.CapturedURLs) != 1 {
+			t.Errorf("round-trip lost data: %+v", got)
+		}
+	})
+
+	t.Run("malformed JSON is an error not a reset", func(t *testing.T) {
+		bad := filepath.Join(dir, "bad.json")
+		if err := os.WriteFile(bad, []byte("{nope"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := loadCaptureState(bad); err == nil {
+			t.Error("want parse error — silently resetting state would re-capture everything")
+		}
+	})
+}

--- a/cmd/scribe/chunker_test.go
+++ b/cmd/scribe/chunker_test.go
@@ -489,7 +489,7 @@ func titleList(chunks []Chunk) []string {
 
 func TestChunkByHeadings_CoalescesTinySections(t *testing.T) {
 	var b strings.Builder
-	for i := 0; i < 12; i++ {
+	for i := range 12 {
 		b.WriteString("## Heading ")
 		b.WriteByte(byte('A' + i))
 		b.WriteString("\n\nA short paragraph that is nowhere near a chapter.\n\n")

--- a/cmd/scribe/chunker_test.go
+++ b/cmd/scribe/chunker_test.go
@@ -329,7 +329,7 @@ func TestChunkByTOC_HappyPath(t *testing.T) {
 	if !strings.Contains(got[0].Body, "body one") {
 		t.Errorf("chunk 1 body missing content: %q", got[0].Body)
 	}
-	if got[0].SourcePages == nil || got[0].SourcePages[0] != 0 {
+	if len(got[0].SourcePages) == 0 || got[0].SourcePages[0] != 0 {
 		t.Errorf("chunk 1 source pages = %v", got[0].SourcePages)
 	}
 }

--- a/cmd/scribe/chunker_test.go
+++ b/cmd/scribe/chunker_test.go
@@ -154,7 +154,10 @@ func TestReadTOCSidecar_VersionMismatchReturnsNil(t *testing.T) {
 	rawPath := filepath.Join(tmp, "article.md")
 	_ = os.WriteFile(rawPath, []byte("body"), 0o644)
 	bad := TOCSidecar{Version: 99, Chapters: []ChapterEntry{{Title: "x"}}}
-	data, _ := json.Marshal(bad)
+	data, err := json.Marshal(bad)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(tocSidecarPath(rawPath), data, 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/scribe/claude.go
+++ b/cmd/scribe/claude.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"embed"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -20,7 +21,7 @@ var promptFS embed.FS
 
 // runClaude invokes `claude -p` with the given prompt and returns the output.
 // ErrRateLimit is returned when claude -p hits Anthropic rate limits.
-var ErrRateLimit = fmt.Errorf("rate limit hit")
+var ErrRateLimit = errors.New("rate limit hit")
 
 // runClaude is a package variable (pointing at realRunClaude) purely so
 // driver tests can swap in a scripted stub (see llm_stub_test.go) without

--- a/cmd/scribe/codex_test.go
+++ b/cmd/scribe/codex_test.go
@@ -41,7 +41,9 @@ func writeCodexRollout(t *testing.T, root, year, month, day, id, cwd string) str
 	if err != nil {
 		t.Fatalf("marshal envelope: %v", err)
 	}
-	body := append(first, '\n')
+	body := make([]byte, 0, len(first)+128)
+	body = append(body, first...)
+	body = append(body, '\n')
 	body = append(body, []byte(`{"type":"message","payload":{"role":"user","content":"hi"}}`+"\n")...)
 	if err := os.WriteFile(path, body, 0o644); err != nil {
 		t.Fatalf("write rollout: %v", err)
@@ -323,7 +325,7 @@ func TestDiscoverCodex_PromotesClaudeOnlyToBoth(t *testing.T) {
 	// Pre-seed manifest as if Claude had already surfaced this project.
 	pname := projectName(cwd)
 	manifestPath := filepath.Join(kbRoot, "scripts", "projects.json")
-	seed := fmt.Sprintf(`{"projects":{"%s":{"path":"%s","domain":"general","discovered_from":"claude"}},"domain_aliases":{},"ignored_paths":[]}`, pname, cwd)
+	seed := fmt.Sprintf(`{"projects":{%q:{"path":%q,"domain":"general","discovered_from":"claude"}},"domain_aliases":{},"ignored_paths":[]}`, pname, cwd)
 	if err := os.WriteFile(manifestPath, []byte(seed), 0o644); err != nil {
 		t.Fatalf("seed manifest: %v", err)
 	}

--- a/cmd/scribe/config.go
+++ b/cmd/scribe/config.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"maps"
 	"os"
@@ -845,7 +846,7 @@ func kbDir() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return "", fmt.Errorf("cannot find scribe KB root; run `scribe init` inside your KB checkout, use -C <path>, or set SCRIBE_KB")
+	return "", errors.New("cannot find scribe KB root; run `scribe init` inside your KB checkout, use -C <path>, or set SCRIBE_KB")
 }
 
 // announceDefaultKBOnce dedups the default-KB notice across repeated

--- a/cmd/scribe/config_trust.go
+++ b/cmd/scribe/config_trust.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -435,8 +436,14 @@ func sensitiveDiff(trusted, current sensitiveConfig) []string {
 	}
 	var out []string
 	for _, p := range pairs {
-		oldJSON, _ := json.Marshal(p.old)
-		newJSON, _ := json.Marshal(p.new)
+		oldJSON, oldErr := json.Marshal(p.old)
+		newJSON, newErr := json.Marshal(p.new)
+		if oldErr != nil || newErr != nil {
+			// Config structs are plain scalars/slices, so this can't
+			// happen — but a silent nil here would hide real drift.
+			out = append(out, fmt.Sprintf("%s: (unrenderable: %v)", p.key, errors.Join(oldErr, newErr)))
+			continue
+		}
 		if !bytes.Equal(oldJSON, newJSON) {
 			out = append(out, fmt.Sprintf("%s: %s -> %s", p.key, oldJSON, newJSON))
 		}

--- a/cmd/scribe/config_trust.go
+++ b/cmd/scribe/config_trust.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -436,7 +437,7 @@ func sensitiveDiff(trusted, current sensitiveConfig) []string {
 	for _, p := range pairs {
 		oldJSON, _ := json.Marshal(p.old)
 		newJSON, _ := json.Marshal(p.new)
-		if string(oldJSON) != string(newJSON) {
+		if !bytes.Equal(oldJSON, newJSON) {
 			out = append(out, fmt.Sprintf("%s: %s -> %s", p.key, oldJSON, newJSON))
 		}
 	}

--- a/cmd/scribe/config_update_test.go
+++ b/cmd/scribe/config_update_test.go
@@ -254,7 +254,7 @@ func TestConfigUpdateCmdEndToEnd(t *testing.T) {
 		t.Fatal(err)
 	}
 	again, _ := os.ReadFile(path)
-	if string(again) != string(data) {
+	if !bytes.Equal(again, data) {
 		t.Error("second run changed the file — not idempotent")
 	}
 }

--- a/cmd/scribe/conflicts.go
+++ b/cmd/scribe/conflicts.go
@@ -50,7 +50,7 @@ func findConflictMarkers(root string) []conflictHit {
 		if !strings.HasSuffix(path, ".md") || strings.HasPrefix(info.Name(), ".") {
 			return nil
 		}
-		content, err := os.ReadFile(path) //nolint:gosec // user-supplied KB root, deliberate walk
+		content, err := os.ReadFile(path)
 		if err != nil {
 			return nil //nolint:nilerr // skip unreadable, continue walk
 		}

--- a/cmd/scribe/contextualize.go
+++ b/cmd/scribe/contextualize.go
@@ -292,7 +292,7 @@ func contextualizeOne(root, rawPath, model string) error {
 	}
 	text = sanitizeContextParagraph(text)
 	if text == "" {
-		return fmt.Errorf("empty context paragraph")
+		return errors.New("empty context paragraph")
 	}
 	// Reject degenerate output rather than splice it. Small models on
 	// table/image-dense articles fall back to echoing the first line (the
@@ -344,7 +344,7 @@ func insertRetrievalContext(content, paragraph string) (string, error) {
 
 	end := strings.Index(content[3:], "\n---")
 	if end < 0 {
-		return "", fmt.Errorf("malformed frontmatter (no closing ---)")
+		return "", errors.New("malformed frontmatter (no closing ---)")
 	}
 	// Absolute offset of the byte after the closing "---".
 	absClosing := 3 + end + len("\n---")

--- a/cmd/scribe/contextualize_test.go
+++ b/cmd/scribe/contextualize_test.go
@@ -227,10 +227,13 @@ func TestContextualizeRawArticles_MarkerIsSourceOfTruth(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Both recorded "done" in the (now non-authoritative) filename log.
-	logBytes, _ := json.Marshal(map[string]string{
+	logBytes, err := json.Marshal(map[string]string{
 		"a.md": "2026-06-01T00:00:00Z",
 		"b.md": "2026-06-01T00:00:00Z",
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(filepath.Join(root, "wiki", "_contextualized_log.json"), logBytes, 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/scribe/contradictions_ledger.go
+++ b/cmd/scribe/contradictions_ledger.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -269,7 +270,7 @@ func resolveContradiction(root, id, note string) error {
 		return err
 	}
 	if len(entries) == 0 {
-		return fmt.Errorf("ledger empty (run `scribe contradictions build` first)")
+		return errors.New("ledger empty (run `scribe contradictions build` first)")
 	}
 	now := time.Now().UTC().Format(time.RFC3339)
 	found := false

--- a/cmd/scribe/contradictions_ledger.go
+++ b/cmd/scribe/contradictions_ledger.go
@@ -94,7 +94,7 @@ func buildContradictionLedger(root string) (int, int, error) {
 	err := walkArticles(root, func(path string, content []byte) error {
 		fm, err := parseFrontmatter(content)
 		if err != nil || fm.Title == "" {
-			return nil //nolint:nilerr
+			return nil //nolint:nilerr // unparseable frontmatter: skip the article, keep building the edge map
 		}
 		titleToPath[fm.Title] = path
 		for _, e := range edgesFromFrontmatter(fm) {
@@ -216,7 +216,7 @@ func readContradictionLedger(root string) ([]ContradictionEntry, error) {
 		}
 		var e ContradictionEntry
 		if err := json.Unmarshal([]byte(line), &e); err != nil {
-			continue //nolint:nilerr // skip unparseable rows; build pass overwrites
+			continue
 		}
 		if e.Version == contradictionsLedgerVersion {
 			out = append(out, e)

--- a/cmd/scribe/contradictions_ledger.go
+++ b/cmd/scribe/contradictions_ledger.go
@@ -237,7 +237,7 @@ func shortHash(s string) string {
 	const fnvOffset = 1469598103934665603
 	const fnvPrime = 1099511628211
 	h := uint64(fnvOffset)
-	for i := 0; i < len(s); i++ {
+	for i := range len(s) {
 		h ^= uint64(s[i])
 		h *= fnvPrime
 	}

--- a/cmd/scribe/contradictions_ledger.go
+++ b/cmd/scribe/contradictions_ledger.go
@@ -383,7 +383,10 @@ func (s *ContradictionsShowCmd) Run() error {
 	}
 	for _, e := range entries {
 		if e.ID == s.ID {
-			data, _ := json.MarshalIndent(e, "", "  ")
+			data, err := json.MarshalIndent(e, "", "  ")
+			if err != nil {
+				return err
+			}
 			fmt.Println(string(data))
 			return nil
 		}

--- a/cmd/scribe/contributor_test.go
+++ b/cmd/scribe/contributor_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"os/exec"
@@ -104,7 +105,7 @@ func TestStampContributor(t *testing.T) {
 	}
 
 	// Stamped frontmatter must stay parseable.
-	raw, _ := os.ReadFile(filepath.Join(root, "wiki/new-article.md"))
+	raw, _ := os.ReadFile(filepath.Join(root, "wiki", "new-article.md"))
 	fm, err := parseFrontmatter(raw)
 	if err != nil {
 		t.Fatalf("stamped frontmatter unparseable: %v", err)
@@ -123,10 +124,10 @@ func TestStampContributorIdempotent(t *testing.T) {
 	writeTestArticle(t, root, "wiki/a.md", "---\ntitle: A\ntype: research\n---\nBody.\n")
 
 	stampContributor(root)
-	first, _ := os.ReadFile(filepath.Join(root, "wiki/a.md"))
+	first, _ := os.ReadFile(filepath.Join(root, "wiki", "a.md"))
 	stampContributor(root)
-	second, _ := os.ReadFile(filepath.Join(root, "wiki/a.md"))
-	if string(first) != string(second) {
+	second, _ := os.ReadFile(filepath.Join(root, "wiki", "a.md"))
+	if !bytes.Equal(first, second) {
 		t.Errorf("second stamp changed the file:\n--- first ---\n%s\n--- second ---\n%s", first, second)
 	}
 	if n := strings.Count(string(second), "contributor:"); n != 1 {

--- a/cmd/scribe/convert_docx.go
+++ b/cmd/scribe/convert_docx.go
@@ -272,7 +272,7 @@ func renderTable(rows [][]string) string {
 	}
 	pad(header)
 	sb.WriteString("|")
-	for i := 0; i < cols; i++ {
+	for range cols {
 		sb.WriteString(" --- |")
 	}
 	sb.WriteString("\n")

--- a/cmd/scribe/convert_docx.go
+++ b/cmd/scribe/convert_docx.go
@@ -46,7 +46,7 @@ func convertDOCXTier0(data []byte) (string, error) {
 		}
 	}
 	if len(docXML) == 0 {
-		return "", fmt.Errorf("docx missing word/document.xml (not a Word doc?)")
+		return "", errors.New("docx missing word/document.xml (not a Word doc?)")
 	}
 
 	return renderDOCX(docXML)
@@ -201,7 +201,7 @@ func renderDOCX(docXML []byte) (string, error) {
 	// each emit their own \n boundaries which can stack up.
 	out = collapseBlankLines(out)
 	if out == "" {
-		return "", fmt.Errorf("no extractable text in docx")
+		return "", errors.New("no extractable text in docx")
 	}
 	return out, nil
 }
@@ -224,16 +224,18 @@ func renderRuns(runs []docxRun) string {
 		}
 		bold := r.RPr.Bold != nil
 		italic := r.RPr.Italic != nil
+		marker := ""
 		switch {
 		case bold && italic:
-			sb.WriteString("***" + text + "***")
+			marker = "***"
 		case bold:
-			sb.WriteString("**" + text + "**")
+			marker = "**"
 		case italic:
-			sb.WriteString("*" + text + "*")
-		default:
-			sb.WriteString(text)
+			marker = "*"
 		}
+		sb.WriteString(marker)
+		sb.WriteString(text)
+		sb.WriteString(marker)
 	}
 	return sb.String()
 }

--- a/cmd/scribe/convert_epub.go
+++ b/cmd/scribe/convert_epub.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"io"
 	"path"
@@ -37,7 +38,7 @@ func convertEPUBTier0(data []byte) (string, error) {
 
 	containerFile, ok := files["META-INF/container.xml"]
 	if !ok {
-		return "", fmt.Errorf("epub missing META-INF/container.xml (not a valid EPUB?)")
+		return "", errors.New("epub missing META-INF/container.xml (not a valid EPUB?)")
 	}
 	opfPath, err := readOPFPath(containerFile)
 	if err != nil {
@@ -82,7 +83,7 @@ func convertEPUBTier0(data []byte) (string, error) {
 
 	out := strings.TrimSpace(sb.String())
 	if out == "" {
-		return "", fmt.Errorf("no extractable text in epub (image-only book?)")
+		return "", errors.New("no extractable text in epub (image-only book?)")
 	}
 	return out, nil
 }
@@ -113,7 +114,7 @@ func readOPFPath(f *zip.File) (string, error) {
 		return "", fmt.Errorf("parse container.xml: %w", err)
 	}
 	if len(c.Rootfiles.Rootfile) == 0 || c.Rootfiles.Rootfile[0].FullPath == "" {
-		return "", fmt.Errorf("container.xml has no rootfile")
+		return "", errors.New("container.xml has no rootfile")
 	}
 	return c.Rootfiles.Rootfile[0].FullPath, nil
 }

--- a/cmd/scribe/convert_marker.go
+++ b/cmd/scribe/convert_marker.go
@@ -122,7 +122,7 @@ func convertWithMarker(inputPath, _ string) (string, *MarkerStats, error) {
 	if err != nil {
 		return "", nil, err
 	}
-	data, err := os.ReadFile(mdPath) //nolint:gosec // path is from a tmp dir we just created
+	data, err := os.ReadFile(mdPath)
 	if err != nil {
 		return "", nil, fmt.Errorf("read marker output: %w", err)
 	}
@@ -206,7 +206,7 @@ func runMarkerOnce(absInput, tmpDir string, timeout time.Duration, mpsFallback b
 	// 'auto' lets torch decide; 'cpu' on the retry path uses the env
 	// var rather than the flag because older marker releases didn't
 	// expose --device. TORCH_DEVICE is the universal lever.
-	cmd := exec.CommandContext(ctx, "marker_single", args...) //nolint:gosec // marker_single resolved from PATH; args are scribe-controlled
+	cmd := exec.CommandContext(ctx, "marker_single", args...)
 	cmd.Env = markerEnvWithDevice(os.Environ(), mpsFallback, device)
 
 	var tail bytes.Buffer
@@ -242,7 +242,7 @@ func (b *boundedWriter) Write(p []byte) (int, error) {
 	n := len(p)
 	if n >= b.max {
 		b.w.Reset()
-		b.w.Write(p[n-b.max:]) //nolint:errcheck // bytes.Buffer.Write never errors
+		b.w.Write(p[n-b.max:])
 		return n, nil
 	}
 	if b.w.Len()+n > b.max {
@@ -251,7 +251,7 @@ func (b *boundedWriter) Write(p []byte) (int, error) {
 		dropped := make([]byte, excess)
 		_, _ = b.w.Read(dropped) // discard oldest bytes; bytes.Buffer.Read never errors on a non-empty buffer
 	}
-	b.w.Write(p) //nolint:errcheck // bytes.Buffer.Write never errors
+	b.w.Write(p)
 	return n, nil
 }
 
@@ -296,7 +296,7 @@ func isMPSCrash(stderr string) bool {
 func readMarkerStats(mdPath string) *MarkerStats {
 	stem := strings.TrimSuffix(filepath.Base(mdPath), ".md")
 	metaPath := filepath.Join(filepath.Dir(mdPath), stem+"_meta.json")
-	data, err := os.ReadFile(metaPath) //nolint:gosec // metaPath is in the same tmp dir we just created
+	data, err := os.ReadFile(metaPath)
 	if err != nil {
 		return nil
 	}
@@ -431,12 +431,12 @@ func extractImageRefs(md string) []string {
 // copyFile is a minimal tee from src to dst with 0o644 permissions.
 // Used by image sidecar; we don't need anything fancier.
 func copyFile(src, dst string) error {
-	in, err := os.Open(src) //nolint:gosec // src is inside our marker tmp dir
+	in, err := os.Open(src)
 	if err != nil {
 		return err
 	}
 	defer in.Close()
-	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644) //nolint:gosec // dst is inside our resolved KB
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
 	if err != nil {
 		return err
 	}

--- a/cmd/scribe/convert_phase1b_test.go
+++ b/cmd/scribe/convert_phase1b_test.go
@@ -127,16 +127,15 @@ func minimalEPUB(t *testing.T, chapters map[string]string) []byte {
 <rootfiles><rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/></rootfiles>
 </container>`)
 
-	manifestItems := ""
-	spineItems := ""
+	var manifestItems, spineItems strings.Builder
 	for id := range chapters {
-		manifestItems += `<item id="` + id + `" href="` + id + `.xhtml" media-type="application/xhtml+xml"/>`
-		spineItems += `<itemref idref="` + id + `"/>`
+		manifestItems.WriteString(`<item id="` + id + `" href="` + id + `.xhtml" media-type="application/xhtml+xml"/>`)
+		spineItems.WriteString(`<itemref idref="` + id + `"/>`)
 	}
 	must("OEBPS/content.opf", `<?xml version="1.0"?>
 <package xmlns="http://www.idpf.org/2007/opf">
-<manifest>`+manifestItems+`</manifest>
-<spine>`+spineItems+`</spine>
+<manifest>`+manifestItems.String()+`</manifest>
+<spine>`+spineItems.String()+`</spine>
 </package>`)
 
 	for id, body := range chapters {

--- a/cmd/scribe/convert_phase2a_test.go
+++ b/cmd/scribe/convert_phase2a_test.go
@@ -187,9 +187,7 @@ func TestShouldRouteSmallPDFToTier0_NoKBContextReturnsFalse(t *testing.T) {
 	t.Setenv("SCRIBE_KB_ROOT", "")
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp) // ensure no scribe.yaml is auto-discovered
-	prev, _ := os.Getwd()
-	defer os.Chdir(prev)
-	_ = os.Chdir(tmp)
+	t.Chdir(tmp)
 	if shouldRouteSmallPDFToTier0(".pdf", []byte("anything")) {
 		t.Error("smart routing must be off when no KB is resolvable")
 	}

--- a/cmd/scribe/convert_phase2a_test.go
+++ b/cmd/scribe/convert_phase2a_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -157,7 +158,7 @@ func TestCopyFile_RoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(got) != string(want) {
+	if !bytes.Equal(got, want) {
 		t.Errorf("copy mismatch: got %v want %v", got, want)
 	}
 }

--- a/cmd/scribe/convert_tier0.go
+++ b/cmd/scribe/convert_tier0.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -54,7 +55,7 @@ func convertPDFTier0(data []byte) (string, error) {
 
 	out := strings.TrimSpace(sb.String())
 	if out == "" {
-		return "", fmt.Errorf("no extractable text (likely a scanned PDF — install marker-pdf for OCR)")
+		return "", errors.New("no extractable text (likely a scanned PDF — install marker-pdf for OCR)")
 	}
 	return out, nil
 }

--- a/cmd/scribe/cost_ledger.go
+++ b/cmd/scribe/cost_ledger.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -791,7 +792,7 @@ func padCell(s string, width int, left bool) string {
 // commaInt formats an integer with thousands separators (16196224 ->
 // "16,196,224") so long token and call counts stay scannable.
 func commaInt(n int64) string {
-	s := fmt.Sprintf("%d", n)
+	s := strconv.FormatInt(n, 10)
 	sign := ""
 	if strings.HasPrefix(s, "-") {
 		sign, s = "-", s[1:]

--- a/cmd/scribe/cost_ledger_test.go
+++ b/cmd/scribe/cost_ledger_test.go
@@ -123,13 +123,19 @@ func TestSummarizeCosts_DayWindowFiltersOldFiles(t *testing.T) {
 	}
 	// Old file: 30 days ago.
 	old := time.Now().UTC().AddDate(0, 0, -30).Format("2006-01-02")
-	oldEntry, _ := json.Marshal(CostEntry{Model: "haiku", DurationMS: 1000, OK: true})
+	oldEntry, err := json.Marshal(CostEntry{Model: "haiku", DurationMS: 1000, OK: true})
+	if err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(filepath.Join(costsDir, old+".jsonl"), append(oldEntry, '\n'), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	// Today's file.
 	today := time.Now().UTC().Format("2006-01-02")
-	newEntry, _ := json.Marshal(CostEntry{Model: "sonnet", DurationMS: 2000, OK: true})
+	newEntry, err := json.Marshal(CostEntry{Model: "sonnet", DurationMS: 2000, OK: true})
+	if err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(filepath.Join(costsDir, today+".jsonl"), append(newEntry, '\n'), 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/scribe/cost_ledger_test.go
+++ b/cmd/scribe/cost_ledger_test.go
@@ -42,7 +42,7 @@ func TestAppendCostEntry_WritesJSONLine(t *testing.T) {
 
 func TestAppendCostEntry_AppendsMultiple(t *testing.T) {
 	tmp := t.TempDir()
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		appendCostEntry(tmp, CostEntry{Model: "haiku", OK: true})
 	}
 	day := time.Now().UTC().Format("2006-01-02")
@@ -87,7 +87,7 @@ func TestSummarizeCosts_SortsByEstimatedCost(t *testing.T) {
 	tmp := t.TempDir()
 	// haiku is cheap; opus is expensive. With same prompt size, opus
 	// should sort first.
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		appendCostEntry(tmp, CostEntry{Model: "haiku", PromptChars: 100000, OK: true})
 	}
 	appendCostEntry(tmp, CostEntry{Model: "opus", PromptChars: 100000, OK: true})
@@ -305,7 +305,7 @@ func TestSummarizeCosts_PrefersActualUSDWhenPresent(t *testing.T) {
 
 func TestSummarizeCosts_AllLegacyRowsKeepEstimates(t *testing.T) {
 	tmp := t.TempDir()
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		appendCostEntry(tmp, CostEntry{Model: "haiku", PromptChars: 8000, OK: true, DurationMS: 1000})
 	}
 	rows, err := summarizeCosts(tmp, 0)

--- a/cmd/scribe/cost_ledger_test.go
+++ b/cmd/scribe/cost_ledger_test.go
@@ -398,7 +398,7 @@ func TestParseClaudeResult_HappyPath(t *testing.T) {
 func TestParseClaudeResult_TrailingHookNoise(t *testing.T) {
 	// CMUX / SessionEnd hooks can leak text after the JSON.
 	stdout := `{"type":"result","subtype":"success","is_error":false,"result":"ok","usage":{"input_tokens":5,"output_tokens":3}}` + "\n" +
-		"SessionEnd hook [cmux] failed: Hook canceled\n" //nolint:misspell // fixture echoes US spelling; CMUX itself emits both spellings
+		"SessionEnd hook [cmux] failed: Hook canceled\n"
 	env, ok := parseClaudeResult(stdout)
 	if !ok {
 		t.Fatal("trailing hook noise should not break parse")

--- a/cmd/scribe/cron.go
+++ b/cmd/scribe/cron.go
@@ -468,12 +468,12 @@ func probeLaunchAgent(domain, label, plistPath string) string {
 
 // resolveScribeBinary finds the installed scribe binary.
 //
-// Prefer ~/.local/bin/scribe (the canonical install target from the Justfile)
+// Prefer ~/.local/bin/scribe (the canonical deploy target of `make install`)
 // over a PATH lookup. Relying on exec.LookPath means whichever directory comes
 // first in PATH wins — and a stray old build in ~/bin/scribe would silently
-// shadow the fresh one from `just build`, baking the wrong path into the
+// shadow the fresh one from `make install`, baking the wrong path into the
 // installed LaunchAgent plists. If the canonical binary isn't on disk yet
-// (e.g. first install from a freshly cloned repo before `just build`), fall
+// (e.g. first install from a freshly cloned repo before `make install`), fall
 // back to PATH so install still works.
 func resolveScribeBinary() string {
 	canonical := filepath.Join(os.Getenv("HOME"), ".local", "bin", "scribe")

--- a/cmd/scribe/cron.go
+++ b/cmd/scribe/cron.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -328,13 +329,13 @@ func renderCrontab(job cronJob) []string {
 		hr := "*"
 		wd := "*"
 		if ct.Minute >= 0 {
-			minute = fmt.Sprintf("%d", ct.Minute)
+			minute = strconv.Itoa(ct.Minute)
 		}
 		if ct.Hour >= 0 {
-			hr = fmt.Sprintf("%d", ct.Hour)
+			hr = strconv.Itoa(ct.Hour)
 		}
 		if ct.Weekday >= 0 {
-			wd = fmt.Sprintf("%d", ct.Weekday)
+			wd = strconv.Itoa(ct.Weekday)
 		}
 		lines = append(lines, fmt.Sprintf("%s %s * * %s %s", minute, hr, wd, job.Command))
 	}

--- a/cmd/scribe/debug.go
+++ b/cmd/scribe/debug.go
@@ -82,7 +82,10 @@ func (c *DebugWikilinksCmd) Run() error {
 			"raw_count":       len(rawTargets),
 			"naive_count":     len(naiveTargets),
 		}
-		data, _ := json.MarshalIndent(out, "", "  ")
+		data, err := json.MarshalIndent(out, "", "  ")
+		if err != nil {
+			return err
+		}
 		fmt.Println(string(data))
 		return nil
 	}
@@ -157,7 +160,10 @@ func (c *DebugBacklinksCmd) Run() error {
 			"sources": sources,
 			"fresh":   c.Fresh,
 		}
-		data, _ := json.MarshalIndent(out, "", "  ")
+		data, err := json.MarshalIndent(out, "", "  ")
+		if err != nil {
+			return err
+		}
 		fmt.Println(string(data))
 		return nil
 	}

--- a/cmd/scribe/doctor.go
+++ b/cmd/scribe/doctor.go
@@ -1156,7 +1156,7 @@ func checkRecentErrors(root string, now time.Time, window time.Duration) []check
 	if len(errs) == 0 {
 		return []check{{
 			Section: "errors", Name: "recent runs", Status: statusOK,
-			Detail: fmt.Sprintf("no errors in last %s", shortDuration(window)),
+			Detail: "no errors in last " + shortDuration(window),
 		}}
 	}
 	// Stable order: sort command keys.

--- a/cmd/scribe/doctor.go
+++ b/cmd/scribe/doctor.go
@@ -1356,7 +1356,9 @@ func printChecksJSON(all []check, root string) {
 	}
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")
-	_ = enc.Encode(payload)
+	if err := enc.Encode(payload); err != nil {
+		logMsg("doctor", "encode json output: %v", err)
+	}
 }
 
 // checkVaultScaffolding flags directories from other vault tools that have

--- a/cmd/scribe/doctor.go
+++ b/cmd/scribe/doctor.go
@@ -1051,6 +1051,11 @@ func loadRunRecords(root string) (map[string]time.Time, error) {
 				}
 			}
 		}
+		if err := scanner.Err(); err != nil {
+			// Partial data only skews this one file's freshness reading;
+			// keep auditing the rest, but say so on stderr.
+			logMsg("doctor", "read %s truncated: %v", e.Name(), err)
+		}
 		_ = f.Close()
 	}
 	return result, nil
@@ -1124,6 +1129,9 @@ func loadRunErrors(root string, since time.Time) (map[string]runError, error) {
 			if prev, ok := result[r.Command]; !ok || ts.After(prev.When) {
 				result[r.Command] = runError{When: ts, Msg: r.Error, Args: r.Args}
 			}
+		}
+		if err := scanner.Err(); err != nil {
+			logMsg("doctor", "read %s truncated: %v", e.Name(), err)
 		}
 		_ = f.Close()
 	}

--- a/cmd/scribe/doctor.go
+++ b/cmd/scribe/doctor.go
@@ -562,15 +562,14 @@ func checkConvert() []check {
 
 	// Marker presence + version. Frames every other row's verdict.
 	if markerTierAvailable() {
+		// The second element surfaces the device pin + retry policy so
+		// users can tell at a glance whether the unattended drain has
+		// the MPS-crash safety net in play. Only matters when marker is
+		// installed — no point reporting a knob that's never read.
 		out = append(out, check{
 			Section: "convert", Name: "marker (tier 1)", Status: statusOK,
 			Detail: markerVersionLine(),
-		})
-		// Surface the device pin + retry policy so users can tell at
-		// a glance whether the unattended drain has the MPS-crash
-		// safety net in play. Only matters when marker is installed —
-		// no point reporting a knob that's never read.
-		out = append(out, markerDeviceCheck())
+		}, markerDeviceCheck())
 	} else {
 		out = append(out, check{
 			Section: "convert", Name: "marker (tier 1)", Status: statusWarn,

--- a/cmd/scribe/dream.go
+++ b/cmd/scribe/dream.go
@@ -152,7 +152,7 @@ func (d *DreamCmd) Run() error {
 		logMsg("dream", "index/backlinks rebuilt")
 
 		if !gitAddWiki(root) {
-			return fmt.Errorf("dream commit skipped: a detected secret could not be held back")
+			return errors.New("dream commit skipped: a detected secret could not be held back")
 		}
 		if err := gitCommit(root, commitMsg); err != nil {
 			return fmt.Errorf("dream commit: %w", err)

--- a/cmd/scribe/dream_orchestrator.go
+++ b/cmd/scribe/dream_orchestrator.go
@@ -133,7 +133,7 @@ func dreamSampleInventory(root string, maxEntries int) string {
 	_ = walkArticles(root, func(path string, content []byte) error {
 		fm, err := parseFrontmatter(content)
 		if err != nil || fm == nil {
-			return nil //nolint:nilerr
+			return nil //nolint:nilerr // unparseable frontmatter: skip the article, keep sampling
 		}
 		rel, _ := filepath.Rel(root, path)
 		samples = append(samples, dreamArticleSample{
@@ -174,7 +174,7 @@ func dreamStaleCandidates(root string, days int) string {
 	_ = walkArticles(root, func(path string, content []byte) error {
 		fm, err := parseFrontmatter(content)
 		if err != nil || fm == nil {
-			return nil //nolint:nilerr
+			return nil //nolint:nilerr // unparseable article: skip it, keep walking
 		}
 		updated := stringFromAny(fm.Updated)
 		if updated == "" {
@@ -182,7 +182,7 @@ func dreamStaleCandidates(root string, days int) string {
 		}
 		t, err := time.Parse("2006-01-02", updated)
 		if err != nil {
-			return nil //nolint:nilerr
+			return nil //nolint:nilerr // unparseable article: skip it, keep walking
 		}
 		if t.Before(cutoff) {
 			rel, _ := filepath.Rel(root, path)
@@ -211,7 +211,7 @@ func dreamContradictionCandidates(root string) string {
 	_ = walkArticles(root, func(path string, content []byte) error {
 		fm, err := parseFrontmatter(content)
 		if err != nil || fm == nil {
-			return nil //nolint:nilerr
+			return nil //nolint:nilerr // unparseable article: skip it, keep walking
 		}
 		rel, _ := filepath.Rel(root, path)
 		a := article{Path: filepath.ToSlash(rel), Title: fm.Title, Conf: fm.Confidence}

--- a/cmd/scribe/each.go
+++ b/cmd/scribe/each.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -51,7 +52,7 @@ func (c *EachCmd) effectiveArgs() []string {
 func (c *EachCmd) Run() error {
 	args := c.effectiveArgs()
 	if len(args) == 0 {
-		return fmt.Errorf("usage: scribe each -- <subcommand> [args...]")
+		return errors.New("usage: scribe each -- <subcommand> [args...]")
 	}
 	kbs := registeredKBs()
 	if len(kbs) == 0 {

--- a/cmd/scribe/each_test.go
+++ b/cmd/scribe/each_test.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 	"strings"
 	"testing"
 
@@ -22,7 +22,7 @@ func TestEachCmd_IteratesWithFailureIsolation(t *testing.T) {
 	eachRunner = func(root string, args []string) error {
 		ran = append(ran, root+"|"+strings.Join(args, " "))
 		if root == a {
-			return fmt.Errorf("boom")
+			return errors.New("boom")
 		}
 		return nil
 	}

--- a/cmd/scribe/estimate.go
+++ b/cmd/scribe/estimate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
@@ -20,7 +21,7 @@ type tokenEstimate struct {
 // humanTokens formats a token count like "1.2K" or "34K" for readability.
 func humanTokens(n int) string {
 	if n < 1000 {
-		return fmt.Sprintf("%d", n)
+		return strconv.Itoa(n)
 	}
 	if n < 1_000_000 {
 		return fmt.Sprintf("%.1fK", float64(n)/1000)

--- a/cmd/scribe/estimate_test.go
+++ b/cmd/scribe/estimate_test.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestHumanTokens(t *testing.T) {
+	tests := []struct {
+		n    int
+		want string
+	}{
+		{0, "0"},
+		{999, "999"},
+		{1000, "1.0K"},
+		{1500, "1.5K"},
+		{999_999, "1000.0K"},
+		{1_000_000, "1.0M"},
+		{2_500_000, "2.5M"},
+	}
+	for _, tt := range tests {
+		if got := humanTokens(tt.n); got != tt.want {
+			t.Errorf("humanTokens(%d) = %q, want %q", tt.n, got, tt.want)
+		}
+	}
+}
+
+// estimateTestKB scaffolds raw/articles + wiki for the queue scanners.
+func estimateTestKB(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "scribe.yaml"), []byte("domains: [acme]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, d := range []string{"raw/articles", "wiki"} {
+		if err := os.MkdirAll(filepath.Join(root, d), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+func TestUnprocessedForContextualize(t *testing.T) {
+	root := estimateTestKB(t)
+	writeKBFile(t, root, "raw/articles/fresh.md", "# Fresh\n\nbody\n")
+	writeKBFile(t, root, "raw/articles/logged.md", "# Logged\n\nbody\n")
+	writeKBFile(t, root, "raw/articles/marked.md",
+		"# Marked\n\n"+retrievalContextMarker+"\nContext paragraph.\n")
+	writeKBFile(t, root, "raw/articles/notes.txt", "not markdown")
+	if err := os.MkdirAll(filepath.Join(root, "raw", "articles", "subdir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeKBFile(t, root, "wiki/_contextualized_log.json", `{"logged.md": "2026-06-01"}`)
+
+	got := unprocessedForContextualize(root)
+	if len(got) != 1 || filepath.Base(got[0]) != "fresh.md" {
+		t.Errorf("queue = %v, want only fresh.md", got)
+	}
+
+	if got := unprocessedForContextualize(t.TempDir()); got != nil {
+		t.Errorf("missing raw dir should yield nil, got %v", got)
+	}
+}
+
+func TestUnprocessedForAbsorb(t *testing.T) {
+	root := estimateTestKB(t)
+	writeKBFile(t, root, "raw/articles/fresh.md", "# Fresh\n\nbody\n")
+	writeKBFile(t, root, "raw/articles/done.md", "# Done\n\nbody\n")
+	writeKBFile(t, root, "wiki/_absorb_log.json", `{"done.md": {"at": "2026-06-01T00:00:00Z"}}`)
+
+	got := unprocessedForAbsorb(root)
+	if len(got) != 1 || filepath.Base(got[0]) != "fresh.md" {
+		t.Errorf("queue = %v, want only fresh.md", got)
+	}
+
+	// Legacy v1 log shape (filename → timestamp string) still counts as done.
+	writeKBFile(t, root, "wiki/_absorb_log.json", `{"done.md": "2026-06-01T00:00:00Z", "fresh.md": "2026-06-02T00:00:00Z"}`)
+	if got := unprocessedForAbsorb(root); len(got) != 0 {
+		t.Errorf("v1 log entries ignored: %v", got)
+	}
+}
+
+func TestEstimateSync(t *testing.T) {
+	root := estimateTestKB(t)
+	// One standard source and one dense source in the absorb queue; both
+	// also uncontextualized.
+	writeKBFile(t, root, "raw/articles/standard.md",
+		"---\ntitle: \"Std\"\ndensity: standard\n---\n\n"+strings.Repeat("word ", 300)+"\n")
+	writeKBFile(t, root, "raw/articles/dense.md",
+		"---\ntitle: \"Dense\"\ndensity: dense\n---\n\n"+strings.Repeat("word ", 500)+"\n")
+
+	cfg := loadConfig(root) // defaults: contextualize enabled
+	estimates := estimateSync(root, cfg)
+
+	notes := make([]string, 0, len(estimates))
+	for _, e := range estimates {
+		notes = append(notes, e.Note)
+		if e.InputTokens <= 0 || e.OutputTokens <= 0 {
+			t.Errorf("estimate %q has non-positive tokens: %+v", e.Note, e)
+		}
+	}
+	joined := strings.Join(notes, "; ")
+	if !strings.Contains(joined, "2 source(s) × contextualize") {
+		t.Errorf("contextualize phase missing or wrong: %v", notes)
+	}
+	if !strings.Contains(joined, "1 brief/standard source(s)") {
+		t.Errorf("single-pass phase missing: %v", notes)
+	}
+	if !strings.Contains(joined, "1 dense source(s)") {
+		t.Errorf("dense phase missing: %v", notes)
+	}
+}
+
+func TestEstimateSync_OllamaContextualizeIsLabeledFree(t *testing.T) {
+	root := estimateTestKB(t)
+	yaml := `domains: [acme]
+absorb:
+  contextualize:
+    provider: ollama
+    model: gemma3
+`
+	if err := os.WriteFile(filepath.Join(root, "scribe.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeKBFile(t, root, "raw/articles/one.md", "# One\n\nbody text\n")
+
+	cfg := loadConfig(root)
+	estimates := estimateSync(root, cfg)
+	found := false
+	for _, e := range estimates {
+		if strings.Contains(e.Note, "contextualize") {
+			found = true
+			if !strings.Contains(e.Model, "ollama:gemma3") || !strings.Contains(e.Model, "free") {
+				t.Errorf("ollama contextualize not labeled free: %q", e.Model)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("no contextualize estimate: %+v", estimates)
+	}
+}
+
+func TestEstimateSync_EmptyQueues(t *testing.T) {
+	root := estimateTestKB(t)
+	cfg := loadConfig(root)
+	if got := estimateSync(root, cfg); len(got) != 0 {
+		t.Errorf("empty KB should produce no estimates, got %+v", got)
+	}
+}
+
+func TestPrintEstimate(t *testing.T) {
+	t.Run("empty is a no-op message", func(t *testing.T) {
+		out := captureLintStdout(t, func() { printEstimate(nil) })
+		if !strings.Contains(out, "nothing queued") {
+			t.Errorf("output:\n%s", out)
+		}
+	})
+
+	t.Run("totals are summed", func(t *testing.T) {
+		out := captureLintStdout(t, func() {
+			printEstimate([]tokenEstimate{
+				{InputTokens: 1000, OutputTokens: 100, Model: "haiku", Note: "a"},
+				{InputTokens: 2000, OutputTokens: 400, Model: "sonnet", Note: "b"},
+			})
+		})
+		if !strings.Contains(out, "total") {
+			t.Errorf("missing total row:\n%s", out)
+		}
+		if !strings.Contains(out, "3.0K") || !strings.Contains(out, "500") {
+			t.Errorf("totals not summed (want 3.0K in / 500 out):\n%s", out)
+		}
+	})
+}

--- a/cmd/scribe/fda.go
+++ b/cmd/scribe/fda.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -337,5 +338,5 @@ func runFDAFlow(s fdaState) error {
 			return nil
 		}
 	}
-	return fmt.Errorf("full disk access still missing after 2 minutes — re-run `scribe fda` when you've completed the steps above")
+	return errors.New("full disk access still missing after 2 minutes — re-run `scribe fda` when you've completed the steps above")
 }

--- a/cmd/scribe/fetch.go
+++ b/cmd/scribe/fetch.go
@@ -123,7 +123,7 @@ func fetchFxTwitter(ctx context.Context, rawURL string) (fetchResult, error) {
 	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, "GET", apiURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
 	if err != nil {
 		return fetchResult{}, err
 	}
@@ -134,7 +134,7 @@ func fetchFxTwitter(ctx context.Context, rawURL string) (fetchResult, error) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		return fetchResult{}, fmt.Errorf("fxtwitter status %d", resp.StatusCode)
 	}
 
@@ -272,7 +272,7 @@ func fetchJina(ctx context.Context, rawURL string) (fetchResult, error) {
 	jinaURL := "https://r.jina.ai/" + rawURL
 	var raw []byte
 	if err := WithRetry(ctx, defaultRetryConfig(), func() error {
-		req, err := http.NewRequestWithContext(ctx, "GET", jinaURL, nil)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, jinaURL, nil)
 		if err != nil {
 			return err
 		}
@@ -283,7 +283,7 @@ func fetchJina(ctx context.Context, rawURL string) (fetchResult, error) {
 			return fmt.Errorf("jina request: %w", err)
 		}
 		defer resp.Body.Close()
-		if resp.StatusCode != 200 {
+		if resp.StatusCode != http.StatusOK {
 			return fmt.Errorf("jina status %d", resp.StatusCode)
 		}
 		raw, err = io.ReadAll(resp.Body)

--- a/cmd/scribe/fetch.go
+++ b/cmd/scribe/fetch.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -187,7 +188,7 @@ func fxTweetToResult(data fxTweetResp) (fetchResult, error) {
 
 func fetchTrafilatura(ctx context.Context, rawURL string) (fetchResult, error) {
 	if _, err := exec.LookPath("trafilatura"); err != nil {
-		return fetchResult{}, fmt.Errorf("trafilatura not installed")
+		return fetchResult{}, errors.New("trafilatura not installed")
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
@@ -226,7 +227,7 @@ func fetchTrafilatura(ctx context.Context, rawURL string) (fetchResult, error) {
 		body = strings.TrimSpace(meta.Raw)
 	}
 	if body == "" {
-		return fetchResult{}, fmt.Errorf("trafilatura: empty body")
+		return fetchResult{}, errors.New("trafilatura: empty body")
 	}
 
 	title := strings.TrimSpace(meta.Title)
@@ -295,7 +296,7 @@ func fetchJina(ctx context.Context, rawURL string) (fetchResult, error) {
 	}
 	body := strings.TrimSpace(string(raw))
 	if body == "" {
-		return fetchResult{}, fmt.Errorf("jina: empty body")
+		return fetchResult{}, errors.New("jina: empty body")
 	}
 
 	// Jina's markdown header includes "Title: ..." and "URL Source: ..." lines

--- a/cmd/scribe/fetch_arxiv.go
+++ b/cmd/scribe/fetch_arxiv.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -114,7 +115,7 @@ func fetchArxivMetadata(ctx context.Context, id string) (arxivMeta, error) {
 		case <-time.After(retryAfter):
 		}
 	}
-	return arxivMeta{}, fmt.Errorf("arxiv api: rate-limited after retry")
+	return arxivMeta{}, errors.New("arxiv api: rate-limited after retry")
 }
 
 // arxivMetadataAttempt returns the parsed metadata, a non-zero retryAfter
@@ -140,7 +141,7 @@ func arxivMetadataAttempt(ctx context.Context, id string) (arxivMeta, time.Durat
 				wait = secs
 			}
 		}
-		return arxivMeta{}, wait, fmt.Errorf("arxiv api status 429")
+		return arxivMeta{}, wait, errors.New("arxiv api status 429")
 	}
 	if resp.StatusCode != 200 {
 		return arxivMeta{}, 0, fmt.Errorf("arxiv api status %d", resp.StatusCode)
@@ -323,7 +324,9 @@ func assembleArxivResult(originalURL, id string, meta arxivMeta, body, via strin
 	}
 
 	var preamble strings.Builder
-	preamble.WriteString("# " + title + "\n\n")
+	preamble.WriteString("# ")
+	preamble.WriteString(title)
+	preamble.WriteString("\n\n")
 	if len(meta.Authors) > 0 {
 		fmt.Fprintf(&preamble, "**Authors:** %s\n\n", strings.Join(meta.Authors, ", "))
 	}

--- a/cmd/scribe/fetch_arxiv.go
+++ b/cmd/scribe/fetch_arxiv.go
@@ -124,7 +124,7 @@ func arxivMetadataAttempt(ctx context.Context, id string) (arxivMeta, time.Durat
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, "GET", arxivAPIQueryURL+id, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, arxivAPIQueryURL+id, nil)
 	if err != nil {
 		return arxivMeta{}, 0, err
 	}
@@ -143,7 +143,7 @@ func arxivMetadataAttempt(ctx context.Context, id string) (arxivMeta, time.Durat
 		}
 		return arxivMeta{}, wait, errors.New("arxiv api status 429")
 	}
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		return arxivMeta{}, 0, fmt.Errorf("arxiv api status %d", resp.StatusCode)
 	}
 
@@ -263,7 +263,7 @@ func fetchArxivPDF(ctx context.Context, id string) (string, error) {
 
 	dlCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
 	defer cancel()
-	req, err := http.NewRequestWithContext(dlCtx, "GET", pdfURL, nil)
+	req, err := http.NewRequestWithContext(dlCtx, http.MethodGet, pdfURL, nil)
 	if err != nil {
 		return "", err
 	}
@@ -273,7 +273,7 @@ func fetchArxivPDF(ctx context.Context, id string) (string, error) {
 		return "", fmt.Errorf("download pdf: %w", err)
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("pdf download status %d", resp.StatusCode)
 	}
 

--- a/cmd/scribe/fetch_defuddle.go
+++ b/cmd/scribe/fetch_defuddle.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -26,7 +27,7 @@ import (
 
 func fetchDefuddle(ctx context.Context, rawURL string) (fetchResult, error) {
 	if _, err := exec.LookPath("defuddle"); err != nil {
-		return fetchResult{}, fmt.Errorf("defuddle not installed")
+		return fetchResult{}, errors.New("defuddle not installed")
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
@@ -68,7 +69,7 @@ func fetchDefuddle(ctx context.Context, rawURL string) (fetchResult, error) {
 		body = strings.TrimSpace(meta.Text)
 	}
 	if body == "" {
-		return fetchResult{}, fmt.Errorf("defuddle: empty body")
+		return fetchResult{}, errors.New("defuddle: empty body")
 	}
 
 	title := strings.TrimSpace(meta.Title)

--- a/cmd/scribe/frontmatter.go
+++ b/cmd/scribe/frontmatter.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -98,11 +99,11 @@ type Frontmatter struct {
 func parseFrontmatter(content []byte) (*Frontmatter, error) {
 	s := string(content)
 	if !strings.HasPrefix(s, "---") {
-		return nil, fmt.Errorf("no frontmatter delimiter")
+		return nil, errors.New("no frontmatter delimiter")
 	}
 	end := strings.Index(s[3:], "\n---")
 	if end < 0 {
-		return nil, fmt.Errorf("no closing frontmatter delimiter")
+		return nil, errors.New("no closing frontmatter delimiter")
 	}
 	yamlBytes := []byte(s[3 : end+3])
 	var fm Frontmatter
@@ -122,11 +123,11 @@ func parseFrontmatter(content []byte) (*Frontmatter, error) {
 func parseFrontmatterRaw(content []byte) (map[string]any, error) {
 	s := string(content)
 	if !strings.HasPrefix(s, "---") {
-		return nil, fmt.Errorf("no frontmatter delimiter")
+		return nil, errors.New("no frontmatter delimiter")
 	}
 	end := strings.Index(s[3:], "\n---")
 	if end < 0 {
-		return nil, fmt.Errorf("no closing frontmatter delimiter")
+		return nil, errors.New("no closing frontmatter delimiter")
 	}
 	yamlBytes := []byte(s[3 : end+3])
 	var raw map[string]any

--- a/cmd/scribe/frontmatter.go
+++ b/cmd/scribe/frontmatter.go
@@ -53,8 +53,8 @@ type Frontmatter struct {
 	// Authority marks how load-bearing an article's claims are when two
 	// sources contradict. Used by `scribe lint --resolve` to pick a winner.
 	//   canonical — intentional decisions/policies; wins over everything
-	//   contextual — curated solutions/patterns; wins over opinion
 	//   opinion — raw captures, tweets, excerpts; loses by default
+	//   contextual — curated solutions/patterns; wins over opinion
 	// Absent = "contextual" for wiki pages, "opinion" for raw articles.
 	Authority string `yaml:"authority,omitempty"`
 	// IndexTier (Phase 5B) controls qmd ranking weight. Computed by

--- a/cmd/scribe/frontmatter.go
+++ b/cmd/scribe/frontmatter.go
@@ -258,7 +258,7 @@ func walkMarkdown(root string, skipUnderscored bool, fn func(path string, conten
 			if skipUnderscored && strings.HasPrefix(info.Name(), "_") {
 				return nil
 			}
-			content, err := os.ReadFile(path) //nolint:gosec // user-supplied KB root, deliberate walk
+			content, err := os.ReadFile(path)
 			if err != nil {
 				return nil //nolint:nilerr // skip unreadable, continue walk
 			}

--- a/cmd/scribe/gitops.go
+++ b/cmd/scribe/gitops.go
@@ -198,7 +198,7 @@ func autoResolveDerivedConflicts(repoPath string) (bool, error) {
 	}
 	if rebaseInProgress(repoPath) {
 		_, _ = runCmdErr(repoPath, "git", "rebase", "--abort")
-		return false, fmt.Errorf("rebase did not converge while auto-resolving derived files (aborted)")
+		return false, errors.New("rebase did not converge while auto-resolving derived files (aborted)")
 	}
 	return true, nil
 }

--- a/cmd/scribe/hook.go
+++ b/cmd/scribe/hook.go
@@ -358,6 +358,11 @@ func pendingContainsID(path, sessionID string) bool {
 			return true
 		}
 	}
+	if err := sc.Err(); err != nil {
+		// Truncated read can't confirm presence — log it and report
+		// absent; the drain-side dedupe folds a duplicate enqueue away.
+		logMsg("hook", "scan pending queue: %v", err)
+	}
 	return false
 }
 
@@ -386,6 +391,10 @@ func peekPendingSessions() []string {
 			seen[id] = true
 			ids = append(ids, id)
 		}
+	}
+	if err := sc.Err(); err != nil {
+		logMsg("sync", "peek pending queue: %v", err)
+		return nil
 	}
 	return ids
 }
@@ -428,7 +437,14 @@ func readAndClearPendingSessions() ([]string, error) {
 			ids = append(ids, id)
 		}
 	}
+	scanErr := sc.Err()
 	f.Close()
+	if scanErr != nil {
+		// Do NOT remove the claim file: a truncated read followed by
+		// the unlink would silently destroy queued sessions. A leftover
+		// .reading file is recovered by the next drain.
+		return nil, fmt.Errorf("read pending file: %w", scanErr)
+	}
 
 	if err := os.Remove(claim); err != nil && !os.IsNotExist(err) {
 		return ids, fmt.Errorf("clear pending file: %w", err)

--- a/cmd/scribe/hot.go
+++ b/cmd/scribe/hot.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -254,7 +255,7 @@ func writeHotMDQuiet(root string) {
 func installHotHooks(root string) error {
 	home := os.Getenv("HOME")
 	if home == "" {
-		return fmt.Errorf("HOME not set")
+		return errors.New("HOME not set")
 	}
 	settingsPath := filepath.Join(home, ".claude", "settings.json")
 	hotPath := filepath.Join(root, "wiki", "_hot.md")

--- a/cmd/scribe/identities_apply.go
+++ b/cmd/scribe/identities_apply.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -38,7 +39,7 @@ func runApplyIdentities(proposalsPath string, applyLow, dryRun bool) error {
 	}
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return fmt.Errorf("no identity proposals — run `scribe lint --identities` first")
+		return errors.New("no identity proposals — run `scribe lint --identities` first")
 	}
 	blocks := parseIdentityBlocks(string(data))
 	if len(blocks) == 0 {
@@ -177,11 +178,11 @@ func appendAliasesToPeopleFile(path string, forms []string, dryRun bool) (int, e
 	}
 	content := string(data)
 	if !strings.HasPrefix(content, "---") {
-		return 0, fmt.Errorf("no frontmatter")
+		return 0, errors.New("no frontmatter")
 	}
 	end := strings.Index(content[3:], "\n---")
 	if end < 0 {
-		return 0, fmt.Errorf("no closing frontmatter delimiter")
+		return 0, errors.New("no closing frontmatter delimiter")
 	}
 	fmBlock := content[3 : end+3]
 	rest := content[end+3:]

--- a/cmd/scribe/identities_apply_test.go
+++ b/cmd/scribe/identities_apply_test.go
@@ -1,0 +1,319 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const sampleProposals = `# Identity proposals — scanned 2026-06-01T00:00:00Z
+
+### Jane Doe
+
+- Existing page: people/jane-doe.md
+- Surface forms:
+  - jane@corp.example
+  - @janedoe
+- Confidence: high
+- Suggested action: add-aliases
+
+---
+
+### Maybe Person
+
+- Existing page: people/maybe.md
+- Surface forms:
+  - maybe@corp.example
+- Confidence: low
+- Suggested action: add-aliases
+
+---
+
+### New Face
+
+- Surface forms:
+  - new@corp.example
+- Confidence: high
+- Suggested action: create-new
+`
+
+func TestParseIdentityBlocks(t *testing.T) {
+	blocks := parseIdentityBlocks(sampleProposals)
+	// "New Face" has no Existing page line → dropped at flush.
+	if len(blocks) != 2 {
+		t.Fatalf("want 2 blocks, got %d: %+v", len(blocks), blocks)
+	}
+
+	jane := blocks[0]
+	if jane.Page != "people/jane-doe.md" {
+		t.Errorf("page = %q", jane.Page)
+	}
+	if jane.Action != "add-aliases" || !strings.EqualFold(jane.Confidence, "high") {
+		t.Errorf("action/confidence = %q/%q", jane.Action, jane.Confidence)
+	}
+	if len(jane.SurfaceForms) != 2 || jane.SurfaceForms[0] != "jane@corp.example" || jane.SurfaceForms[1] != "@janedoe" {
+		t.Errorf("surface forms = %v", jane.SurfaceForms)
+	}
+
+	if blocks[1].Page != "people/maybe.md" || !strings.EqualFold(blocks[1].Confidence, "low") {
+		t.Errorf("second block parsed wrong: %+v", blocks[1])
+	}
+}
+
+func TestParseIdentityBlocks_Resilience(t *testing.T) {
+	t.Run("empty input", func(t *testing.T) {
+		if got := parseIdentityBlocks(""); len(got) != 0 {
+			t.Errorf("want no blocks, got %v", got)
+		}
+	})
+
+	t.Run("page path with leading ./ normalized", func(t *testing.T) {
+		body := "### X Y\n- Existing page: ./people/x.md\n- Suggested action: add-aliases\n"
+		blocks := parseIdentityBlocks(body)
+		if len(blocks) != 1 || blocks[0].Page != "people/x.md" {
+			t.Errorf("got %+v", blocks)
+		}
+	})
+
+	t.Run("non-indented line ends surface forms list", func(t *testing.T) {
+		body := "### X Y\n- Existing page: people/x.md\n- Surface forms:\n  - one\nplain text line\n  - not-captured\n"
+		blocks := parseIdentityBlocks(body)
+		if len(blocks) != 1 {
+			t.Fatalf("got %+v", blocks)
+		}
+		if len(blocks[0].SurfaceForms) != 1 || blocks[0].SurfaceForms[0] != "one" {
+			t.Errorf("surface forms = %v, want just [one]", blocks[0].SurfaceForms)
+		}
+	})
+}
+
+func TestExistingAliases(t *testing.T) {
+	tests := []struct {
+		name string
+		fm   string
+		want []string
+	}{
+		{
+			name: "inline array",
+			fm:   "\ntitle: \"X\"\naliases: [a, \"B C\", 'd']\n",
+			want: []string{"a", "b c", "d"},
+		},
+		{
+			name: "block list",
+			fm:   "\ntitle: \"X\"\naliases:\n  - a\n  - \"B C\"\nother: 1\n",
+			want: []string{"a", "b c"},
+		},
+		{
+			name: "no aliases key",
+			fm:   "\ntitle: \"X\"\n",
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := existingAliases(tt.fm)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+			for _, w := range tt.want {
+				if !got[w] {
+					t.Errorf("missing %q in %v", w, got)
+				}
+			}
+		})
+	}
+}
+
+func TestInsertOrExtendAliases(t *testing.T) {
+	t.Run("creates key when absent", func(t *testing.T) {
+		got := insertOrExtendAliases("\ntitle: \"X\"", []string{"new one"})
+		if !strings.Contains(got, "aliases:\n  - \"new one\"") &&
+			!strings.Contains(got, "aliases:\n  - new one") {
+			t.Errorf("aliases block not appended:\n%s", got)
+		}
+	})
+
+	t.Run("extends existing block list", func(t *testing.T) {
+		fm := "\ntitle: \"X\"\naliases:\n  - old\nstatus: active"
+		got := insertOrExtendAliases(fm, []string{"fresh"})
+		oldIdx := strings.Index(got, "- old")
+		freshIdx := strings.Index(got, "- fresh")
+		statusIdx := strings.Index(got, "status: active")
+		if oldIdx < 0 || freshIdx < 0 {
+			t.Fatalf("entries missing:\n%s", got)
+		}
+		if oldIdx >= freshIdx || freshIdx >= statusIdx {
+			t.Errorf("new alias not inserted inside the list:\n%s", got)
+		}
+	})
+
+	t.Run("converts inline form to block form", func(t *testing.T) {
+		fm := "\ntitle: \"X\"\naliases: [a, b]"
+		got := insertOrExtendAliases(fm, []string{"c"})
+		for _, want := range []string{"aliases:", "  - a", "  - b", "  - c"} {
+			if !strings.Contains(got, want) {
+				t.Errorf("missing %q in:\n%s", want, got)
+			}
+		}
+		if strings.Contains(got, "[a, b]") {
+			t.Errorf("inline form should be gone:\n%s", got)
+		}
+	})
+}
+
+func TestAppendAliasesToPeopleFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "jane.md")
+	content := "---\ntitle: \"Jane Doe\"\naliases: [jd]\n---\n\nBody.\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	added, err := appendAliasesToPeopleFile(path, []string{"jane@corp.example", "JD", ""}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// "JD" is a case-insensitive dup of jd; "" is dropped.
+	if added != 1 {
+		t.Errorf("added = %d, want 1", added)
+	}
+	data, _ := os.ReadFile(path)
+	if !strings.Contains(string(data), "jane@corp.example") {
+		t.Errorf("new alias not written:\n%s", data)
+	}
+	if !strings.HasSuffix(strings.TrimSpace(string(data)), "Body.") {
+		t.Errorf("body lost:\n%s", data)
+	}
+
+	// Idempotent: second pass adds nothing.
+	added, err = appendAliasesToPeopleFile(path, []string{"jane@corp.example"}, false)
+	if err != nil || added != 0 {
+		t.Errorf("second pass added=%d err=%v, want 0/nil", added, err)
+	}
+}
+
+func TestAppendAliasesToPeopleFile_DryRunAndErrors(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("dry run reports but does not write", func(t *testing.T) {
+		path := filepath.Join(dir, "dry.md")
+		content := "---\ntitle: \"X\"\n---\n\nBody.\n"
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		added, err := appendAliasesToPeopleFile(path, []string{"new"}, true)
+		if err != nil || added != 1 {
+			t.Fatalf("added=%d err=%v", added, err)
+		}
+		data, _ := os.ReadFile(path)
+		if string(data) != content {
+			t.Errorf("dry run modified the file:\n%s", data)
+		}
+	})
+
+	t.Run("no frontmatter", func(t *testing.T) {
+		path := filepath.Join(dir, "plain.md")
+		if err := os.WriteFile(path, []byte("just text"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := appendAliasesToPeopleFile(path, []string{"x"}, false); err == nil {
+			t.Error("want error for missing frontmatter")
+		}
+	})
+
+	t.Run("unclosed frontmatter", func(t *testing.T) {
+		path := filepath.Join(dir, "unclosed.md")
+		if err := os.WriteFile(path, []byte("---\ntitle: x\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := appendAliasesToPeopleFile(path, []string{"x"}, false); err == nil {
+			t.Error("want error for unclosed frontmatter")
+		}
+	})
+}
+
+func TestRunApplyIdentities(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "scribe.yaml"), []byte("domains: [acme]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SCRIBE_KB", root)
+	writeKBFile(t, root, "people/jane-doe.md",
+		"---\ntitle: \"Jane Doe\"\n---\n\nBody.\n")
+	// people/maybe.md exists too, but its block is low-confidence.
+	writeKBFile(t, root, "people/maybe.md",
+		"---\ntitle: \"Maybe Person\"\n---\n\nBody.\n")
+	writeKBFile(t, root, "wiki/_identity-proposals.md", sampleProposals)
+
+	var err error
+	out := captureLintStdout(t, func() { err = runApplyIdentities("", false, false) })
+	if err != nil {
+		t.Fatalf("runApplyIdentities: %v", err)
+	}
+	if !strings.Contains(out, "touched 1 file(s)") {
+		t.Errorf("expected 1 touched file:\n%s", out)
+	}
+
+	jane, _ := os.ReadFile(filepath.Join(root, "people", "jane-doe.md"))
+	for _, want := range []string{"jane@corp.example", "@janedoe"} {
+		if !strings.Contains(string(jane), want) {
+			t.Errorf("jane missing alias %q:\n%s", want, jane)
+		}
+	}
+	maybe, _ := os.ReadFile(filepath.Join(root, "people", "maybe.md"))
+	if strings.Contains(string(maybe), "maybe@corp.example") {
+		t.Errorf("low-confidence block applied without --apply-low:\n%s", maybe)
+	}
+
+	// --apply-low picks up the low-confidence block on a second pass.
+	out = captureLintStdout(t, func() { err = runApplyIdentities("", true, false) })
+	if err != nil {
+		t.Fatalf("apply-low pass: %v", err)
+	}
+	maybe, _ = os.ReadFile(filepath.Join(root, "people", "maybe.md"))
+	if !strings.Contains(string(maybe), "maybe@corp.example") {
+		t.Errorf("--apply-low did not apply:\n%s", maybe)
+	}
+	// Jane's block is now a no-op — only maybe.md counts as touched.
+	if !strings.Contains(out, "touched 1 file(s)") {
+		t.Errorf("re-run should be idempotent for already-applied blocks:\n%s", out)
+	}
+}
+
+func TestRunApplyIdentities_MissingInputs(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "scribe.yaml"), []byte("domains: [acme]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SCRIBE_KB", root)
+
+	t.Run("no proposals file", func(t *testing.T) {
+		err := runApplyIdentities("", false, false)
+		if err == nil || !strings.Contains(err.Error(), "no identity proposals") {
+			t.Errorf("want guidance error, got %v", err)
+		}
+	})
+
+	t.Run("page not found is skipped, not fatal", func(t *testing.T) {
+		writeKBFile(t, root, "wiki/_identity-proposals.md",
+			"### Ghost Person\n- Existing page: people/ghost.md\n- Surface forms:\n  - g@x.io\n- Confidence: high\n- Suggested action: add-aliases\n")
+		var err error
+		out := captureLintStdout(t, func() { err = runApplyIdentities("", false, false) })
+		if err != nil {
+			t.Fatalf("missing page should skip, not fail: %v", err)
+		}
+		if !strings.Contains(out, "touched 0 file(s), skipped 1") {
+			t.Errorf("expected skip accounting:\n%s", out)
+		}
+	})
+}
+
+func TestDryRunSuffix(t *testing.T) {
+	if got := dryRunSuffix(false); got != "" {
+		t.Errorf("got %q", got)
+	}
+	if got := dryRunSuffix(true); !strings.Contains(got, "dry-run") {
+		t.Errorf("got %q", got)
+	}
+}

--- a/cmd/scribe/identities_test.go
+++ b/cmd/scribe/identities_test.go
@@ -1,0 +1,211 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLooksLikePersonTarget(t *testing.T) {
+	tests := []struct {
+		target string
+		want   bool
+	}{
+		{"Lisa Chen", true},
+		{"Jean-Pierre Dupont", true},
+		{"O'Brien Smith", true},
+		{"Anna Maria Della Rosa", true}, // 4 tokens — upper bound
+		{"Lisa", false},                 // single token
+		{"lisa chen", false},            // lowercase lead
+		{"Lisa von Chen", false},        // lowercase preposition
+		{"Phoenix LiveView", false},     // CamelCase token
+		{"LLM Agents", false},           // ALL-CAPS acronym
+		{"One Two Three Four Five", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.target, func(t *testing.T) {
+			if got := looksLikePersonTarget(tt.target); got != tt.want {
+				t.Errorf("looksLikePersonTarget(%q) = %v, want %v", tt.target, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestKnownIdentities(t *testing.T) {
+	people := []existingPerson{
+		{Title: "Lisa Chen", Aliases: []string{"lchen", "Lisa C."}},
+		{Title: "", Aliases: []string{"ghost"}},
+	}
+	set := knownIdentities(people)
+	for _, want := range []string{"lisa chen", "lchen", "lisa c.", "ghost"} {
+		if !set[want] {
+			t.Errorf("missing %q in known set: %v", want, set)
+		}
+	}
+	if set[""] {
+		t.Error("empty title must not enter the set")
+	}
+}
+
+func TestCollectExistingPeople(t *testing.T) {
+	root := t.TempDir()
+	writeKBFile(t, root, "people/lisa-chen.md",
+		"---\ntitle: \"Lisa Chen\"\naliases: [lchen]\n---\n\nBody.\n")
+	writeKBFile(t, root, "people/_template.md",
+		"---\ntitle: \"Skip Me\"\n---\n")
+	writeKBFile(t, root, "people/notes.txt", "not markdown")
+	writeKBFile(t, root, "people/broken.md", "---\ntitle: [unclosed\n")
+
+	people := collectExistingPeople(root)
+	if len(people) != 1 {
+		t.Fatalf("want 1 person, got %d: %+v", len(people), people)
+	}
+	p := people[0]
+	if p.Title != "Lisa Chen" || p.PagePath != "people/lisa-chen.md" {
+		t.Errorf("unexpected entry: %+v", p)
+	}
+	if len(p.Aliases) != 1 || p.Aliases[0] != "lchen" {
+		t.Errorf("aliases not collected: %v", p.Aliases)
+	}
+
+	if got := collectExistingPeople(filepath.Join(root, "missing")); got != nil {
+		t.Errorf("missing people dir should yield nil, got %v", got)
+	}
+}
+
+func TestHarvestMentions(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "scribe.yaml"), []byte("domains: [acme]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Non-person wiki page whose title must be prefiltered from wikilink hits.
+	writeKBFile(t, root, "tools/plugin.md",
+		"---\ntitle: \"Claude Plugin\"\n---\n\nA tool page.\n")
+	// Wiki article with every mention shape.
+	writeKBFile(t, root, "wiki/notes.md", `---
+title: "Notes"
+---
+
+Mail from jane@corp.example and noise@example.com (stopword domain).
+Handle @janedoe appears here; module attribute @moduledoc must not.
+Linked person [[Mark Webber]] and [[Mark Webber]] again and [[Mark Webber]] once more.
+Known [[Lisa Chen]] is already cataloged. Tool page [[Claude Plugin]] is not a person.
+Rare name [[Once Only]] appears a single time.
+
+`+"```\ncode-fence@corp.example must be ignored\n@fencehandle too\n```\n")
+	// Raw articles are scanned too.
+	writeKBFile(t, root, "raw/articles/cap.md", "Raw capture mentions raw@corp.example.\n")
+
+	existing := []existingPerson{{Title: "Lisa Chen", Aliases: nil}}
+	mentions := harvestMentions(root, existing)
+
+	wantPresent := map[string]int{
+		"jane@corp.example": 1,
+		"@janedoe":          1,
+		"Mark Webber":       3,
+		"raw@corp.example":  1,
+	}
+	for k, n := range wantPresent {
+		if mentions[k] != n {
+			t.Errorf("mentions[%q] = %d, want %d (all: %v)", k, mentions[k], n, mentions)
+		}
+	}
+	for _, absent := range []string{
+		"noise@example.com",       // stopword email domain
+		"@moduledoc",              // stopword handle
+		"Lisa Chen",               // known person
+		"Claude Plugin",           // non-person wiki title
+		"Once Only",               // below the 3-occurrence bare-name floor
+		"code-fence@corp.example", // inside code fence
+		"@fencehandle",            // inside code fence
+	} {
+		if _, ok := mentions[absent]; ok {
+			t.Errorf("%q should have been filtered out", absent)
+		}
+	}
+}
+
+func TestRenderPeopleBlock(t *testing.T) {
+	if got := renderPeopleBlock(nil); got != "(none)" {
+		t.Errorf("empty people = %q, want (none)", got)
+	}
+	got := renderPeopleBlock([]existingPerson{
+		{Title: "Zed Zee", PagePath: "people/zed.md"},
+		{Title: "Amy Aye", PagePath: "people/amy.md", Aliases: []string{"aa", "amy"}},
+	})
+	lines := strings.Split(got, "\n")
+	if len(lines) != 2 {
+		t.Fatalf("want 2 lines, got %q", got)
+	}
+	if !strings.HasPrefix(lines[0], "- Amy Aye") {
+		t.Errorf("lines not sorted: %q", got)
+	}
+	if !strings.Contains(lines[0], "aliases: aa, amy") {
+		t.Errorf("aliases not rendered: %q", lines[0])
+	}
+}
+
+func TestRenderMentionsBlock(t *testing.T) {
+	t.Run("sorted by frequency then name", func(t *testing.T) {
+		got := renderMentionsBlock(map[string]int{
+			"bob@x.io": 2, "@alice": 5, "Zed Zee": 5,
+		})
+		want := "- @alice (×5)\n- Zed Zee (×5)\n- bob@x.io (×2)"
+		if got != want {
+			t.Errorf("got:\n%s\nwant:\n%s", got, want)
+		}
+	})
+
+	t.Run("truncates at the prompt cap", func(t *testing.T) {
+		counts := make(map[string]int, maxMentionsForIdentityPrompt+10)
+		for i := 0; i < maxMentionsForIdentityPrompt+10; i++ {
+			counts[fmt.Sprintf("Person%04d Mention", i)] = 1
+		}
+		got := renderMentionsBlock(counts)
+		if n := len(strings.Split(got, "\n")); n != maxMentionsForIdentityPrompt {
+			t.Errorf("rendered %d lines, want %d", n, maxMentionsForIdentityPrompt)
+		}
+	})
+}
+
+func TestRunIdentitiesCheck_NoMentions(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "scribe.yaml"), []byte("domains: [acme]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SCRIBE_KB", root)
+
+	var err error
+	out := captureLintStdout(t, func() { err = runIdentitiesCheck("", false) })
+	if err != nil {
+		t.Fatalf("runIdentitiesCheck: %v", err)
+	}
+	if !strings.Contains(out, "no unmatched person-mentions") {
+		t.Errorf("expected empty-KB message, got:\n%s", out)
+	}
+}
+
+func TestRunIdentitiesCheck_DryRunPrintsWithoutWriting(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "scribe.yaml"), []byte("domains: [acme]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SCRIBE_KB", root)
+	writeKBFile(t, root, "wiki/notes.md",
+		"---\ntitle: \"Notes\"\n---\n\nPing jane@corp.example today.\n")
+
+	var err error
+	out := captureLintStdout(t, func() { err = runIdentitiesCheck("", true) })
+	if err != nil {
+		t.Fatalf("dry run: %v", err)
+	}
+	if !strings.Contains(out, "jane@corp.example") {
+		t.Errorf("dry run should list mentions:\n%s", out)
+	}
+	if fileExists(filepath.Join(root, "wiki", "_identity-proposals.md")) {
+		t.Error("dry run must not write the proposals file")
+	}
+}

--- a/cmd/scribe/identities_test.go
+++ b/cmd/scribe/identities_test.go
@@ -161,7 +161,7 @@ func TestRenderMentionsBlock(t *testing.T) {
 
 	t.Run("truncates at the prompt cap", func(t *testing.T) {
 		counts := make(map[string]int, maxMentionsForIdentityPrompt+10)
-		for i := 0; i < maxMentionsForIdentityPrompt+10; i++ {
+		for i := range maxMentionsForIdentityPrompt + 10 {
 			counts[fmt.Sprintf("Person%04d Mention", i)] = 1
 		}
 		got := renderMentionsBlock(counts)

--- a/cmd/scribe/inbox.go
+++ b/cmd/scribe/inbox.go
@@ -162,7 +162,7 @@ func drainFileInbox(root string) (int, error) {
 // on success so callers can record it in the idempotency state file.
 // Errors propagate so quarantine can run.
 func ingestInboxFile(root, full, processedDir string) (string, error) {
-	data, err := os.ReadFile(full) //nolint:gosec // user-supplied source path; reading is the point
+	data, err := os.ReadFile(full)
 	if err != nil {
 		return "", fmt.Errorf("read: %w", err)
 	}
@@ -351,7 +351,7 @@ func (s *inboxState) persist(inboxDir string) error {
 // PDFs. Returns "" + nil-error semantics by reading; callers tolerate
 // any read error by treating the file as un-deduplicated.
 func sha256File(full string) (string, error) {
-	f, err := os.Open(full) //nolint:gosec // user-supplied source path; reading is the point
+	f, err := os.Open(full)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/scribe/index.go
+++ b/cmd/scribe/index.go
@@ -102,11 +102,12 @@ article_count: %%d
 
 	if i.DryRun {
 		existing, err := os.ReadFile(outPath)
-		if err != nil {
+		switch {
+		case err != nil:
 			fmt.Printf("would create _index.md with %d articles\n", totalArticles)
-		} else if string(existing) != result {
+		case string(existing) != result:
 			fmt.Printf("_index.md would change (%d articles)\n", totalArticles)
-		} else {
+		default:
 			fmt.Println("_index.md is up to date")
 		}
 		return nil

--- a/cmd/scribe/index_test.go
+++ b/cmd/scribe/index_test.go
@@ -1,0 +1,344 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestTruncateOutsideWikilink(t *testing.T) {
+	tests := []struct {
+		name  string
+		s     string
+		limit int
+		want  string
+	}{
+		{"short string unchanged", "hello world", 80, "hello world"},
+		{"plain cut adds ellipsis", strings.Repeat("a", 100), 10, strings.Repeat("a", 7) + "..."},
+		{
+			name:  "cut mid-wikilink backs up to before the opener",
+			s:     "see the [[Very Long Article Title Goes Here]] for details and more words after",
+			limit: 20,
+			want:  "see the...",
+		},
+		{
+			name:  "closed wikilink inside head survives",
+			s:     "[[Short]] then a lot of extra text that goes well past the cut limit here",
+			limit: 30,
+			want:  "[[Short]] then a lot of ext...",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := truncateOutsideWikilink(tt.s, tt.limit); got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractBody(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{"with frontmatter", "---\ntitle: x\n---\n\nThe body.\n", "The body."},
+		{"no frontmatter", "Just text.", "Just text."},
+		{"unclosed frontmatter", "---\ntitle: x\n", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := extractBody([]byte(tt.content)); got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFirstSentence(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"empty", "", ""},
+		{"skips headings", "# Heading\n\nReal content here.\n", "Real content here."},
+		{"first sentence only", "One sentence. Second sentence.", "One sentence."},
+		{"short line as-is", "No terminal period here", "No terminal period here"},
+		{"only headings", "# A\n## B\n", ""},
+		{
+			name: "long line truncated outside wikilink",
+			body: strings.Repeat("x", 100) + " [[Some Linked Article Title That Is Long]] tail",
+			want: strings.Repeat("x", 100) + "...",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := firstSentence(tt.body); got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// graphTestKB builds a tiny linked KB:
+//
+//	wiki/a.md      "A Article" → links to [[B Article]] and [[Ghost Page]]
+//	wiki/b.md      "B Article" → links to itself (must not count)
+//	tools/c.md     "C Tool"    → no links in or out (orphan)
+//	wiki/_index.md hub         → links to [[A Article]]
+func graphTestKB(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "scribe.yaml"), []byte("domains: [acme]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SCRIBE_KB", root)
+	writeKBFile(t, root, "wiki/a.md",
+		"---\ntitle: \"A Article\"\ntype: solution\ndomain: general\n---\n\nFirst sentence about A. More.\n\nSee [[B Article]] and [[Ghost Page]].\n")
+	writeKBFile(t, root, "wiki/b.md",
+		"---\ntitle: \"B Article\"\ntype: solution\ndomain: general\n---\n\nB body refers to [[B Article]] itself.\n")
+	writeKBFile(t, root, "tools/c.md",
+		"---\ntitle: \"C Tool\"\ntype: tool\ndomain: general\n---\n\nA tool nobody links to.\n")
+	writeKBFile(t, root, "wiki/_index.md", "- [[A Article]] -- s\n")
+	return root
+}
+
+func TestIndexCmdRun(t *testing.T) {
+	root := graphTestKB(t)
+
+	var err error
+	captureLintStdout(t, func() { err = (&IndexCmd{}).Run() })
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(root, "wiki", "_index.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "article_count: 3") {
+		t.Errorf("article_count wrong:\n%s", content)
+	}
+	for _, want := range []string{
+		"## tools/",
+		"## wiki/",
+		"- [[A Article]] -- First sentence about A. (solution, general)",
+		"- [[C Tool]] -- A tool nobody links to. (tool, general)",
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("missing %q in:\n%s", want, content)
+		}
+	}
+	// Groups are sorted: tools/ section before wiki/.
+	if strings.Index(content, "## tools/") > strings.Index(content, "## wiki/") {
+		t.Errorf("directory groups not sorted:\n%s", content)
+	}
+	if strings.Contains(content, "%d") {
+		t.Errorf("count placeholder not substituted:\n%s", content)
+	}
+}
+
+func TestIndexCmdDryRun(t *testing.T) {
+	root := graphTestKB(t)
+	// Remove the seeded index so dry-run hits the would-create path.
+	if err := os.Remove(filepath.Join(root, "wiki", "_index.md")); err != nil {
+		t.Fatal(err)
+	}
+
+	var err error
+	out := captureLintStdout(t, func() { err = (&IndexCmd{DryRun: true}).Run() })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "would create _index.md with 3 articles") {
+		t.Errorf("unexpected dry-run output:\n%s", out)
+	}
+	if fileExists(filepath.Join(root, "wiki", "_index.md")) {
+		t.Error("dry run wrote the index")
+	}
+
+	// Write the real index, then dry-run again: up to date.
+	captureLintStdout(t, func() { err = (&IndexCmd{}).Run() })
+	if err != nil {
+		t.Fatal(err)
+	}
+	out = captureLintStdout(t, func() { err = (&IndexCmd{DryRun: true}).Run() })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "up to date") {
+		t.Errorf("expected up-to-date message:\n%s", out)
+	}
+}
+
+func TestBacklinksCmdRun(t *testing.T) {
+	root := graphTestKB(t)
+
+	var err error
+	captureLintStdout(t, func() { err = (&BacklinksCmd{}).Run() })
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(root, "wiki", "_backlinks.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var backlinks map[string][]string
+	if err := json.Unmarshal(data, &backlinks); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := backlinks["B Article"]; len(got) != 1 || got[0] != "A Article" {
+		t.Errorf("B Article backlinks = %v, want [A Article]", got)
+	}
+	// Self-link from b.md must not appear.
+	for _, src := range backlinks["B Article"] {
+		if src == "B Article" {
+			t.Error("self-link counted as backlink")
+		}
+	}
+	// Hub _index.md links are attributed by relative path.
+	if got := backlinks["A Article"]; len(got) != 1 || got[0] != "wiki/_index.md" {
+		t.Errorf("A Article backlinks = %v, want [wiki/_index.md]", got)
+	}
+	// Ghost Page is linked even though it doesn't exist — backlinks
+	// records inbound edges regardless of target existence.
+	if got := backlinks["Ghost Page"]; len(got) != 1 || got[0] != "A Article" {
+		t.Errorf("Ghost Page backlinks = %v", got)
+	}
+}
+
+func TestBacklinksCmdJSONAndDryRun(t *testing.T) {
+	root := graphTestKB(t)
+
+	var err error
+	out := captureLintStdout(t, func() { err = (&BacklinksCmd{JSON: true}).Run() })
+	if err != nil {
+		t.Fatal(err)
+	}
+	var backlinks map[string][]string
+	if err := json.Unmarshal([]byte(out), &backlinks); err != nil {
+		t.Fatalf("stdout not JSON: %v\n%s", err, out)
+	}
+	if fileExists(filepath.Join(root, "wiki", "_backlinks.json")) {
+		t.Error("--json must not write the file")
+	}
+
+	out = captureLintStdout(t, func() { err = (&BacklinksCmd{DryRun: true}).Run() })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "would create _backlinks.json") {
+		t.Errorf("dry-run output:\n%s", out)
+	}
+	if fileExists(filepath.Join(root, "wiki", "_backlinks.json")) {
+		t.Error("dry run wrote the file")
+	}
+}
+
+func TestOrphansCmdRun(t *testing.T) {
+	root := graphTestKB(t)
+	_ = root
+
+	var err error
+	out := captureLintStdout(t, func() { err = (&OrphansCmd{JSON: true}).Run() })
+	if err != nil {
+		t.Fatal(err)
+	}
+	var report orphanReport
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatalf("bad JSON: %v\n%s", err, out)
+	}
+
+	// C Tool has no inbound links; A Article is linked from the hub
+	// index; B Article is linked from A.
+	if len(report.Orphans) != 1 || report.Orphans[0] != "C Tool" {
+		t.Errorf("orphans = %v, want [C Tool]", report.Orphans)
+	}
+	if len(report.Missing) != 1 || report.Missing[0] != "Ghost Page" {
+		t.Errorf("missing = %v, want [Ghost Page]", report.Missing)
+	}
+}
+
+func TestOrphansCmdFilters(t *testing.T) {
+	graphTestKB(t)
+
+	t.Run("orphans only", func(t *testing.T) {
+		var err error
+		out := captureLintStdout(t, func() {
+			err = (&OrphansCmd{JSON: true, OrphansOnly: true}).Run()
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		var report orphanReport
+		if err := json.Unmarshal([]byte(out), &report); err != nil {
+			t.Fatal(err)
+		}
+		if len(report.Orphans) != 1 || report.Missing != nil {
+			t.Errorf("orphans-only report = %+v", report)
+		}
+	})
+
+	t.Run("missing only", func(t *testing.T) {
+		var err error
+		out := captureLintStdout(t, func() {
+			err = (&OrphansCmd{JSON: true, MissingOnly: true}).Run()
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		var report orphanReport
+		if err := json.Unmarshal([]byte(out), &report); err != nil {
+			t.Fatal(err)
+		}
+		if len(report.Missing) != 1 || report.Orphans != nil {
+			t.Errorf("missing-only report = %+v", report)
+		}
+	})
+
+	t.Run("text output lists both sections", func(t *testing.T) {
+		var err error
+		out := captureLintStdout(t, func() { err = (&OrphansCmd{}).Run() })
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(out, "Orphan articles (1)") || !strings.Contains(out, "C Tool") {
+			t.Errorf("orphan section wrong:\n%s", out)
+		}
+		if !strings.Contains(out, "Missing pages (1)") || !strings.Contains(out, "[[Ghost Page]]") {
+			t.Errorf("missing section wrong:\n%s", out)
+		}
+	})
+}
+
+func TestOrphansCmd_AliasCountsAsTitle(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "scribe.yaml"), []byte("domains: [acme]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SCRIBE_KB", root)
+	writeKBFile(t, root, "wiki/a.md",
+		"---\ntitle: \"A Article\"\n---\n\nLinks to [[Bee]].\n")
+	writeKBFile(t, root, "wiki/b.md",
+		"---\ntitle: \"B Article\"\naliases: [Bee]\n---\n\nLinks to [[A Article]].\n")
+
+	var err error
+	out := captureLintStdout(t, func() { err = (&OrphansCmd{JSON: true}).Run() })
+	if err != nil {
+		t.Fatal(err)
+	}
+	var report orphanReport
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatal(err)
+	}
+	if len(report.Missing) != 0 {
+		t.Errorf("alias link reported missing: %v", report.Missing)
+	}
+}

--- a/cmd/scribe/ingest.go
+++ b/cmd/scribe/ingest.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -44,7 +45,7 @@ func (c *IngestURLCmd) Run() error {
 		return fmt.Errorf("invalid URL: scheme %q not supported (need http/https)", u.Scheme)
 	}
 	if u.Host == "" {
-		return fmt.Errorf("invalid URL: missing host")
+		return errors.New("invalid URL: missing host")
 	}
 
 	root, err := kbDir()
@@ -415,7 +416,7 @@ func drainOne(root, queuePath string, dryRun bool) error {
 	}
 	entry := parseQueueEntry(string(data))
 	if entry["url"] == "" {
-		return fmt.Errorf("no url in queue entry")
+		return errors.New("no url in queue entry")
 	}
 
 	rawURL := entry["url"]

--- a/cmd/scribe/ingest.go
+++ b/cmd/scribe/ingest.go
@@ -550,7 +550,7 @@ func (c *IngestFileCmd) Run() error {
 		return err
 	}
 
-	data, err := os.ReadFile(absPath) //nolint:gosec // user-supplied source path; reading is the point
+	data, err := os.ReadFile(absPath)
 	if err != nil {
 		return fmt.Errorf("read file: %w", err)
 	}

--- a/cmd/scribe/init.go
+++ b/cmd/scribe/init.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bufio"
 	"embed"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -543,13 +542,12 @@ func createKBSkeleton(root string) error {
 // seedProjectsJSON produces an empty, well-formed manifest so the scan/sync
 // pipeline can run immediately without a special "file missing" branch.
 func seedProjectsJSON() string {
-	empty := map[string]any{
-		"projects":       map[string]any{},
-		"ignored_paths":  []string{},
-		"domain_aliases": map[string]string{},
-	}
-	b, _ := json.MarshalIndent(empty, "", "  ")
-	return string(b) + "\n"
+	return `{
+  "domain_aliases": {},
+  "ignored_paths": [],
+  "projects": {}
+}
+`
 }
 
 func initGit(root string) error {

--- a/cmd/scribe/init.go
+++ b/cmd/scribe/init.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"embed"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -557,7 +558,7 @@ func initGit(root string) error {
 		return nil
 	}
 	if _, err := exec.LookPath("git"); err != nil {
-		return fmt.Errorf("git not in PATH")
+		return errors.New("git not in PATH")
 	}
 	out, err := exec.Command("git", "-C", root, "init", "-b", "main").CombinedOutput() //nolint:noctx // one-shot init
 	if err != nil {

--- a/cmd/scribe/init_plan.go
+++ b/cmd/scribe/init_plan.go
@@ -27,7 +27,7 @@ func (c *InitCmd) buildInitPlan(abs string, vars templateVars, ucKBDir string, a
 	var plan []initAction
 
 	scaffold := initAction{
-		Title: fmt.Sprintf("write KB scaffold at %s", abs),
+		Title: "write KB scaffold at " + abs,
 		Explain: "Renders the embedded templates — scribe.yaml, CLAUDE.md, .gitignore, " +
 			"wiki/_index.md, wiki/_hot.md, log.md — creates the content directory tree " +
 			"(wiki/, projects/, raw/, scripts/, output/, …) and seeds empty state files " +
@@ -143,7 +143,7 @@ func (c *InitCmd) buildInitPlan(abs string, vars templateVars, ucKBDir string, a
 
 	if strings.EqualFold(vars.LLMProvider, "ollama") {
 		plan = append(plan, initAction{
-			Title: fmt.Sprintf("probe Ollama and pre-pull %s", vars.LLMModel),
+			Title: "probe Ollama and pre-pull " + vars.LLMModel,
 			Explain: "Checks that an Ollama server is reachable and pulls the recommended " +
 				"model now, so the first sync run doesn't stall on /api/pull. Non-fatal — " +
 				"if Ollama isn't running yet, init prints a hint instead.",

--- a/cmd/scribe/init_test.go
+++ b/cmd/scribe/init_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -245,7 +246,7 @@ func TestInstallCodexMD_Lifecycle(t *testing.T) {
 		t.Fatalf("in-sync: %v", err)
 	}
 	after, _ := os.ReadFile(path)
-	if string(before) != string(after) {
+	if !bytes.Equal(before, after) {
 		t.Errorf("in-sync run rewrote the file:\nbefore=%q\nafter=%q", before, after)
 	}
 

--- a/cmd/scribe/install_tools.go
+++ b/cmd/scribe/install_tools.go
@@ -242,7 +242,7 @@ func extractUVFromTarball(tarball []byte, dst string) error {
 		}
 		return os.Rename(tmp, dst)
 	}
-	return fmt.Errorf("uv binary not found in tarball")
+	return errors.New("uv binary not found in tarball")
 }
 
 // installMarkerViaUV runs `uv tool install marker-pdf`. uv prints
@@ -353,7 +353,7 @@ func readInstallState() *installState {
 // SCRIBE_AUTO_INSTALL_TOOLS=1").
 func lazyBootstrapMarker() error {
 	if os.Getenv("SCRIBE_AUTO_INSTALL_TOOLS") != "1" {
-		return fmt.Errorf("marker not installed; set SCRIBE_AUTO_INSTALL_TOOLS=1 or run `scribe install-tools` to bootstrap")
+		return errors.New("marker not installed; set SCRIBE_AUTO_INSTALL_TOOLS=1 or run `scribe install-tools` to bootstrap")
 	}
 	cmd := &InstallToolsCmd{}
 	return cmd.Run()

--- a/cmd/scribe/install_tools.go
+++ b/cmd/scribe/install_tools.go
@@ -182,7 +182,7 @@ func downloadUV() (string, error) {
 // fine — the uv tarball is ~30 MB.
 func httpGetVerified(url, expectedSHA string) ([]byte, error) {
 	client := &http.Client{Timeout: 5 * time.Minute}
-	resp, err := client.Get(url) //nolint:noctx,gosec // URL pinned by version constant; download is intentional
+	resp, err := client.Get(url) //nolint:noctx // URL pinned by version constant; download is intentional
 	if err != nil {
 		return nil, fmt.Errorf("http get %s: %w", url, err)
 	}
@@ -229,7 +229,7 @@ func extractUVFromTarball(tarball []byte, dst string) error {
 			continue
 		}
 		tmp := dst + ".tmp"
-		f, err := os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755) //nolint:gosec // path computed from scribeHome, not user input
+		f, err := os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
 		if err != nil {
 			return fmt.Errorf("open tmp: %w", err)
 		}

--- a/cmd/scribe/lint.go
+++ b/cmd/scribe/lint.go
@@ -11,6 +11,8 @@ import (
 type LintCmd struct {
 	Files   []string `arg:"" optional:"" help:"Files to lint. If empty, lints all wiki articles."`
 	Changed bool     `help:"Lint only uncommitted git changes." short:"c"`
+	Verbose bool     `help:"Print every warning per-file instead of the grouped-by-class summary." short:"v" xor:"output"`
+	Quiet   bool     `help:"Errors and final summary only — suppress phase headers and warnings. Used by sync mid-extract." short:"q" xor:"output"`
 
 	Contradictions bool    `help:"Run LLM-based contradiction check instead of structural lints. Writes wiki/_contradictions.md."`
 	Duplicates     bool    `help:"Structural (no-LLM) content-duplicate scan: exact-body hashes + token overlap. Writes wiki/_duplicates.md. Report-only — never deletes."`
@@ -63,40 +65,47 @@ func (l *LintCmd) Run() error {
 		return nil
 	}
 
-	errors, warnings := 0, 0
-	count := func(e, w int) { errors += e; warnings += w }
+	rep := newLintReport(os.Stdout, l.Verbose, l.Quiet)
+	phase := func(name string) {
+		if !l.Quiet {
+			fmt.Println(name)
+		}
+	}
 
-	fmt.Println("Phase 1: Frontmatter validation")
-	count(lintFrontmatter(root, files), 0)
-	fmt.Println("Phase 2: Size checks")
-	count(0, lintSizes(root, files))
+	phase("Phase 1: Frontmatter validation")
+	lintFrontmatter(rep, root, files)
+	phase("Phase 2: Size checks")
+	lintSizes(rep, root, files)
 
 	// Phases 3-6 are cross-KB structural checks — they only make sense
 	// on a full scan, not a --changed subset.
 	if !l.Changed {
-		fmt.Println("Phase 3: Orphan detection")
-		count(0, lintOrphans(root))
-		fmt.Println("Phase 4: Index consistency")
-		count(0, lintIndexConsistency(root))
-		fmt.Println("Phase 5: Self-ingestion artifacts")
-		count(lintSelfIngestion(root))
-		fmt.Println("Phase 6: Conflict markers")
-		count(lintConflictMarkers(root), 0)
+		phase("Phase 3: Orphan detection")
+		lintOrphans(rep, root)
+		phase("Phase 4: Index consistency")
+		lintIndexConsistency(rep, root)
+		phase("Phase 5: Self-ingestion artifacts")
+		lintSelfIngestion(rep, root)
+		phase("Phase 6: Conflict markers")
+		lintConflictMarkers(rep, root)
 	}
 
 	runStats = map[string]any{
 		"files_checked": len(files),
-		"errors":        errors,
-		"warnings":      warnings,
+		"errors":        rep.errors,
+		"warnings":      rep.warnings,
 	}
 
-	// Summary
-	fmt.Println()
-	if errors > 0 {
-		return fmt.Errorf("FAILED: %d errors, %d warnings", errors, warnings)
+	// Grouped warning summary (default mode only), then verdict.
+	rep.flush()
+	if !l.Quiet {
+		fmt.Println()
 	}
-	if warnings > 0 {
-		fmt.Printf("PASSED with %d warnings\n", warnings)
+	if rep.errors > 0 {
+		return fmt.Errorf("FAILED: %d errors, %d warnings", rep.errors, rep.warnings)
+	}
+	if rep.warnings > 0 {
+		fmt.Printf("PASSED with %d warnings\n", rep.warnings)
 	} else {
 		fmt.Println("PASSED: all checks clean")
 	}
@@ -121,25 +130,25 @@ func (l *LintCmd) targetFiles(root string) ([]string, error) {
 	}
 }
 
-// lintFrontmatter (Phase 1) validates each file's frontmatter. Returns
-// the number of files with at least one error (a file with three
-// problems counts once, matching the historical summary).
-func lintFrontmatter(root string, files []string) (errors int) {
+// lintFrontmatter (Phase 1) validates each file's frontmatter. Counts
+// files with at least one error (a file with three problems counts
+// once, matching the historical summary) while still printing every
+// finding per-file.
+func lintFrontmatter(rep *lintReport, root string, files []string) {
 	for _, path := range files {
 		errs := validateFile(root, path)
 		if len(errs) > 0 {
-			errors++
+			rep.errors++
 			for _, e := range errs {
-				fmt.Printf("  ERROR %s: %s\n", relPath(root, path), e)
+				rep.errorLinef("%s: %s", relPath(root, path), e)
 			}
 		}
 	}
-	return errors
 }
 
 // lintSizes (Phase 2) warns on thin/bloated articles, overgrown rolling
 // files, and missing index_tier frontmatter.
-func lintSizes(root string, files []string) (warnings int) {
+func lintSizes(rep *lintReport, root string, files []string) {
 	for _, path := range files {
 		content, err := os.ReadFile(path)
 		if err != nil {
@@ -158,38 +167,35 @@ func lintSizes(root string, files []string) (warnings int) {
 			base := filepath.Base(rel)
 			isArchive := strings.Contains(base, "-archive-")
 			if !isArchive && lines > 200 {
-				fmt.Printf("  WARN %s: rolling file is %d lines (should archive at 150)\n", rel, lines)
-				warnings++
+				rep.warnf(lintClassRollingOvergrown, "%s: rolling file is %d lines (should archive at 150)", rel, lines)
 			}
 			continue
 		}
 
 		if lines < 15 {
-			fmt.Printf("  WARN %s: thin article (%d lines, minimum 15)\n", rel, lines)
-			warnings++
+			rep.warnf(lintClassThinArticle, "%s: thin article (%d lines, minimum 15)", rel, lines)
 		}
 		if lines > 150 {
-			fmt.Printf("  WARN %s: bloated article (%d lines, should split at 150)\n", rel, lines)
-			warnings++
+			rep.warnf(lintClassBloatedArticle, "%s: bloated article (%d lines, should split at 150)", rel, lines)
 		}
 
 		// Phase 5B: index_tier presence. Warn (not error) when the
 		// computed tier hasn't been written into frontmatter yet, so
 		// the field can roll out without a flag-day migration. Lint
 		// remains green; a follow-up `scribe tier write --missing-only`
-		// resolves the warning. Skip for rolling files (they don't
-		// participate in retrieval ranking the same way).
+		// (hinted via lintHints) resolves the warning. Skip for rolling
+		// files (they don't participate in retrieval ranking the same way).
 		if fm != nil && !fm.Rolling && strings.TrimSpace(fm.IndexTier) == "" {
-			fmt.Printf("  WARN %s: index_tier missing (run `scribe tier write --missing-only`)\n", rel)
-			warnings++
+			rep.warnf(lintClassIndexTierMissing, "%s: index_tier missing", rel)
 		}
 	}
-	return warnings
 }
 
 // lintOrphans (Phase 3) counts articles with no inbound wikilinks and
-// wikilink targets that don't exist.
-func lintOrphans(root string) (warnings int) {
+// wikilink targets that don't exist. Both findings are KB-wide
+// aggregates — already one line per class — so they print inline via
+// warnAggregatef instead of joining the grouped per-file summary.
+func lintOrphans(rep *lintReport, root string) {
 	allTitles := make(map[string]bool)
 	allTargets := make(map[string]bool)
 	inboundCount := make(map[string]int)
@@ -233,8 +239,7 @@ func lintOrphans(root string) (warnings int) {
 		}
 	}
 	if orphanCount > 0 {
-		fmt.Printf("  %d orphan articles (no inbound wikilinks)\n", orphanCount)
-		warnings++
+		rep.warnAggregatef("%d orphan articles (no inbound wikilinks)", orphanCount)
 	}
 
 	missingCount := 0
@@ -244,19 +249,17 @@ func lintOrphans(root string) (warnings int) {
 		}
 	}
 	if missingCount > 0 {
-		fmt.Printf("  %d missing pages (linked but don't exist)\n", missingCount)
-		warnings++
+		rep.warnAggregatef("%d missing pages (linked but don't exist)", missingCount)
 	}
-	return warnings
 }
 
 // lintIndexConsistency (Phase 4) compares wiki/_index.md entry count to
 // the article count on disk; small drift is normal between reindexes.
-func lintIndexConsistency(root string) (warnings int) {
+func lintIndexConsistency(rep *lintReport, root string) {
 	indexPath := filepath.Join(root, "wiki", "_index.md")
 	content, err := os.ReadFile(indexPath)
 	if err != nil {
-		return 0
+		return
 	}
 	// Count lines that *start* with "- [[", not every "- [[" occurrence.
 	// Some one-line summaries contain a second "[[X]]" after a dash
@@ -276,12 +279,10 @@ func lintIndexConsistency(root string) (warnings int) {
 	})
 	diff := diskCount - indexCount
 	if diff > 3 || diff < -3 {
-		fmt.Printf("  WARN index has %d entries but disk has %d articles (diff: %d)\n", indexCount, diskCount, diff)
-		warnings++
+		rep.warnAggregatef("WARN index has %d entries but disk has %d articles (diff: %d)", indexCount, diskCount, diff)
 	} else {
-		fmt.Printf("  index: %d entries, disk: %d articles\n", indexCount, diskCount)
+		rep.infof("index: %d entries, disk: %d articles", indexCount, diskCount)
 	}
-	return warnings
 }
 
 // lintSelfIngestion (Phase 5) flags the artifacts of the
@@ -289,14 +290,12 @@ func lintIndexConsistency(root string) (warnings int) {
 // ".md.md" extensions are always malformed (ERROR); slugified
 // "<x>_md.md" files that shadow an existing "<x>.md" are likely
 // duplicates (WARN). Both are remediated by `scribe lint --fix`.
-func lintSelfIngestion(root string) (errors, warnings int) {
+func lintSelfIngestion(rep *lintReport, root string) {
 	for _, d := range findSelfIngestionDuplicates(root) {
 		if d.Shape == "doubled-ext" {
-			errors++
-			fmt.Printf("  ERROR %s: doubled .md extension — malformed page (run `scribe lint --fix`)\n", d.Rel)
+			rep.errorf("%s: doubled .md extension — malformed page (run `scribe lint --fix`)", d.Rel)
 		} else {
-			warnings++
-			fmt.Printf("  WARN %s: looks like a filename-as-title duplicate of %s (run `scribe lint --fix`)\n", d.Rel, d.CanonicalRel)
+			rep.warnf(lintClassFilenameAsTitle, "%s: looks like a filename-as-title duplicate of %s", d.Rel, d.CanonicalRel)
 		}
 	}
 	// Directories named after the KB itself — the KB filed pages under
@@ -304,22 +303,18 @@ func lintSelfIngestion(root string) (errors, warnings int) {
 	// Contents may hold unique fragments, so this is a review pointer,
 	// not an auto-fix.
 	for _, dir := range findSelfNamedDirs(root) {
-		warnings++
-		fmt.Printf("  WARN %s/: directory named after the KB itself — likely self-ingested pages; review and merge into canonical articles\n", dir)
+		rep.warnf(lintClassSelfNamedDir, "%s/: directory named after the KB itself — likely self-ingested pages; review and merge into canonical articles", dir)
 	}
-	return errors, warnings
 }
 
 // lintConflictMarkers (Phase 6) hard-errors on unresolved merge
 // markers. Team KBs auto-pull, so a botched merge can leave
 // "<<<<<<< HEAD" blocks inside articles where they poison search and
 // LLM context until a human resolves them.
-func lintConflictMarkers(root string) (errors int) {
+func lintConflictMarkers(rep *lintReport, root string) {
 	for _, h := range findConflictMarkers(root) {
-		errors++
-		fmt.Printf("  ERROR %s:%d: unresolved git conflict marker — resolve the merge and recommit\n", h.Rel, h.Line)
+		rep.errorf("%s:%d: unresolved git conflict marker — resolve the merge and recommit", h.Rel, h.Line)
 	}
-	return errors
 }
 
 // runFix collects the file set (--changed, explicit args, or all wiki

--- a/cmd/scribe/lint_dupes_test.go
+++ b/cmd/scribe/lint_dupes_test.go
@@ -162,11 +162,11 @@ func setupByteIdenticalKB(t *testing.T) string {
 	root := t.TempDir()
 	wiki := filepath.Join(root, "wiki")
 	mustMkdir(t, filepath.Join(wiki, "scriptorium"))
-	identical := "---\ntitle: Cache\n---\n\n# Cache\n\nbody body body\n"
+	identical := "---\ntitle: Cache\n---\n\n# Cache\n\nshared cache body\n"
 	mustWrite(t, filepath.Join(wiki, "cache.md"), identical)
 	mustWrite(t, filepath.Join(wiki, "scriptorium", "cache.md"), identical)
 	// Same normalized body, different frontmatter → must NOT be byte-identical.
-	mustWrite(t, filepath.Join(wiki, "cache-copy.md"), "---\ntitle: Other\n---\n\n# Cache\n\nbody body body\n")
+	mustWrite(t, filepath.Join(wiki, "cache-copy.md"), "---\ntitle: Other\n---\n\n# Cache\n\nshared cache body\n")
 	mustWrite(t, filepath.Join(wiki, "unrelated.md"), "---\ntitle: U\n---\n\n# U\n\nentirely different\n")
 	return root
 }

--- a/cmd/scribe/lint_fix.go
+++ b/cmd/scribe/lint_fix.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"regexp"
@@ -63,7 +64,7 @@ func autoFixArticle(root, rel string, content []byte) ([]string, []byte, error) 
 	closeFenceRE := regexp.MustCompile(`\n---[ \t]*(?:\r?\n|$)`)
 	loc := closeFenceRE.FindStringIndex(s[4:])
 	if loc == nil {
-		return nil, nil, fmt.Errorf("malformed frontmatter (no closing ---)")
+		return nil, nil, errors.New("malformed frontmatter (no closing ---)")
 	}
 	fmStart := 4
 	fmEnd := 4 + loc[0]      // start of the "\n" preceding the fence

--- a/cmd/scribe/lint_report.go
+++ b/cmd/scribe/lint_report.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"sort"
+)
+
+// Warning classes for grouped lint output. Constants keep the warnf call
+// sites and the lintHints table from drifting apart.
+const (
+	lintClassIndexTierMissing = "index_tier missing"
+	lintClassThinArticle      = "thin article"
+	lintClassBloatedArticle   = "bloated article"
+	lintClassRollingOvergrown = "rolling file overgrown"
+	lintClassFilenameAsTitle  = "filename-as-title duplicate"
+	lintClassSelfNamedDir     = "directory named after the KB"
+)
+
+// lintHints maps a warning class to the command that remediates it.
+// Single source of truth for remediation hints: the grouped summary
+// appends "(run: <cmd>)" and verbose per-file lines append
+// "(run `<cmd>`)" from this table — call sites never embed hints in
+// their messages. Add an entry here when a new class gains a fix
+// command; classes without one simply render bare.
+var lintHints = map[string]string{
+	lintClassIndexTierMissing: "scribe tier write --missing-only",
+	lintClassFilenameAsTitle:  "scribe lint --fix",
+}
+
+// lintReport accumulates findings during a structural lint run and
+// controls how they render. Three modes:
+//
+//   - default: per-file warnings are counted by class and printed as a
+//     grouped summary by flush() — a production KB can emit hundreds of
+//     identical "index_tier missing" lines, which is noise per-file but
+//     signal as "412× index_tier missing".
+//   - verbose: every warning prints per-file as it's found (the
+//     pre-grouping behavior); flush() is a no-op.
+//   - quiet: warnings and info lines are suppressed entirely — only
+//     per-file ERROR lines and the caller's final summary line reach
+//     stdout. Used when lint runs inside `scribe sync` so the cron log
+//     isn't flooded mid-extract.
+//
+// ERROR lines always print per-file in every mode: each one is
+// individually actionable, so grouping them would hide the work.
+type lintReport struct {
+	w        io.Writer
+	verbose  bool
+	quiet    bool
+	errors   int
+	warnings int
+
+	classCounts map[string]int
+}
+
+func newLintReport(w io.Writer, verbose, quiet bool) *lintReport {
+	return &lintReport{w: w, verbose: verbose, quiet: quiet, classCounts: make(map[string]int)}
+}
+
+// errorf prints a per-file ERROR line and counts one error. Errors are
+// never grouped or suppressed.
+func (r *lintReport) errorf(format string, args ...any) {
+	r.errors++
+	r.errorLinef(format, args...)
+}
+
+// errorLinef prints a per-file ERROR line without counting — for callers
+// that count errors at a coarser grain (per file, not per finding).
+func (r *lintReport) errorLinef(format string, args ...any) {
+	fmt.Fprintf(r.w, "  ERROR "+format+"\n", args...)
+}
+
+// warnf records a per-file warning of the given class. Verbose mode
+// prints it immediately, with the class's remediation hint appended when
+// lintHints knows one; default mode counts it for the grouped flush;
+// quiet mode only counts.
+func (r *lintReport) warnf(class, format string, args ...any) {
+	r.warnings++
+	if r.quiet {
+		return
+	}
+	if r.verbose {
+		msg := fmt.Sprintf(format, args...)
+		if hint := lintHints[class]; hint != "" {
+			msg += fmt.Sprintf(" (run `%s`)", hint)
+		}
+		fmt.Fprintf(r.w, "  WARN %s\n", msg)
+		return
+	}
+	r.classCounts[class]++
+}
+
+// warnAggregatef records a warning that is already one line per class
+// (orphan totals, index drift). It prints inline in default and verbose
+// modes — there is nothing to group — and is suppressed in quiet mode.
+func (r *lintReport) warnAggregatef(format string, args ...any) {
+	r.warnings++
+	if r.quiet {
+		return
+	}
+	fmt.Fprintf(r.w, "  "+format+"\n", args...)
+}
+
+// infof prints a neutral informational line (suppressed in quiet mode).
+func (r *lintReport) infof(format string, args ...any) {
+	if r.quiet {
+		return
+	}
+	fmt.Fprintf(r.w, "  "+format+"\n", args...)
+}
+
+// flush renders the grouped warning summary in default mode: one line
+// per class, sorted by count descending (ties alphabetical), counts
+// right-aligned and hints column-aligned:
+//
+//	412× index_tier missing          (run: scribe tier write --missing-only)
+//	 23× thin article
+//
+// No-op in verbose mode (warnings already printed per-file), quiet mode,
+// or when no per-file warnings were recorded.
+func (r *lintReport) flush() {
+	if r.verbose || r.quiet || len(r.classCounts) == 0 {
+		return
+	}
+
+	classes := make([]string, 0, len(r.classCounts))
+	for c := range r.classCounts {
+		classes = append(classes, c)
+	}
+	sort.Slice(classes, func(i, j int) bool {
+		ci, cj := r.classCounts[classes[i]], r.classCounts[classes[j]]
+		if ci != cj {
+			return ci > cj
+		}
+		return classes[i] < classes[j]
+	})
+
+	countW := len(fmt.Sprintf("%d", r.classCounts[classes[0]]))
+	nameW := 0
+	for _, c := range classes {
+		if len(c) > nameW {
+			nameW = len(c)
+		}
+	}
+
+	fmt.Fprintln(r.w)
+	for _, c := range classes {
+		if hint := lintHints[c]; hint != "" {
+			fmt.Fprintf(r.w, "%*d× %-*s (run: %s)\n", countW, r.classCounts[c], nameW, c, hint)
+		} else {
+			fmt.Fprintf(r.w, "%*d× %s\n", countW, r.classCounts[c], c)
+		}
+	}
+}

--- a/cmd/scribe/lint_report.go
+++ b/cmd/scribe/lint_report.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"strconv"
 )
 
 // Warning classes for grouped lint output. Constants keep the warnf call
@@ -136,7 +137,7 @@ func (r *lintReport) flush() {
 		return classes[i] < classes[j]
 	})
 
-	countW := len(fmt.Sprintf("%d", r.classCounts[classes[0]]))
+	countW := len(strconv.Itoa(r.classCounts[classes[0]]))
 	nameW := 0
 	for _, c := range classes {
 		if len(c) > nameW {

--- a/cmd/scribe/lint_report_test.go
+++ b/cmd/scribe/lint_report_test.go
@@ -1,0 +1,201 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestLintReportGroupedFlush: default mode groups per-file warnings by
+// class — count descending, counts right-aligned, remediation hints from
+// lintHints column-aligned. This is the issue-15 output shape:
+//
+//	412× index_tier missing       (run: scribe tier write --missing-only)
+//	 23× thin article
+func TestLintReportGroupedFlush(t *testing.T) {
+	var buf bytes.Buffer
+	rep := newLintReport(&buf, false, false)
+
+	for range 12 {
+		rep.warnf(lintClassIndexTierMissing, "wiki/a.md: index_tier missing")
+	}
+	for range 3 {
+		rep.warnf(lintClassThinArticle, "wiki/b.md: thin article (4 lines, minimum 15)")
+	}
+	rep.warnf(lintClassFilenameAsTitle, "wiki/c_md.md: looks like a filename-as-title duplicate of wiki/c.md")
+
+	if buf.Len() != 0 {
+		t.Fatalf("default mode must not print warnings per-file, got:\n%s", buf.String())
+	}
+	if rep.warnings != 16 {
+		t.Fatalf("warnings = %d, want 16", rep.warnings)
+	}
+
+	rep.flush()
+	want := "\n" +
+		"12× index_tier missing          (run: scribe tier write --missing-only)\n" +
+		" 3× thin article\n" +
+		" 1× filename-as-title duplicate (run: scribe lint --fix)\n"
+	if got := buf.String(); got != want {
+		t.Errorf("grouped flush mismatch:\ngot:\n%q\nwant:\n%q", got, want)
+	}
+}
+
+// TestLintReportFlushTieBreak: classes with equal counts sort
+// alphabetically so the summary is deterministic run-to-run.
+func TestLintReportFlushTieBreak(t *testing.T) {
+	var buf bytes.Buffer
+	rep := newLintReport(&buf, false, false)
+	rep.warnf(lintClassThinArticle, "x")
+	rep.warnf(lintClassBloatedArticle, "y")
+
+	rep.flush()
+	want := "\n" +
+		"1× bloated article\n" +
+		"1× thin article\n"
+	if got := buf.String(); got != want {
+		t.Errorf("tie-break flush mismatch:\ngot:\n%q\nwant:\n%q", got, want)
+	}
+}
+
+// TestLintReportModes: per-mode visibility of each line kind. Errors are
+// always per-file; per-file warnings print only in verbose; aggregate
+// warnings and info lines print except in quiet; counts accrue in every
+// mode.
+func TestLintReportModes(t *testing.T) {
+	tests := []struct {
+		name    string
+		verbose bool
+		quiet   bool
+
+		wantWarnLine      bool // per-file WARN visible immediately
+		wantAggregateLine bool
+		wantInfoLine      bool
+		wantFlushOutput   bool
+	}{
+		{name: "default", wantAggregateLine: true, wantInfoLine: true, wantFlushOutput: true},
+		{name: "verbose", verbose: true, wantWarnLine: true, wantAggregateLine: true, wantInfoLine: true},
+		{name: "quiet", quiet: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			rep := newLintReport(&buf, tt.verbose, tt.quiet)
+
+			rep.errorf("wiki/e.md: broken frontmatter")
+			rep.warnf(lintClassThinArticle, "wiki/t.md: thin article (3 lines, minimum 15)")
+			rep.warnAggregatef("%d orphan articles (no inbound wikilinks)", 7)
+			rep.infof("index: 10 entries, disk: 10 articles")
+			preFlush := buf.String()
+			rep.flush()
+			postFlush := buf.String()[len(preFlush):]
+
+			if !strings.Contains(preFlush, "ERROR wiki/e.md: broken frontmatter") {
+				t.Errorf("ERROR line must print in %s mode, got:\n%s", tt.name, preFlush)
+			}
+			if got := strings.Contains(preFlush, "WARN wiki/t.md"); got != tt.wantWarnLine {
+				t.Errorf("per-file WARN visible = %v, want %v in %s mode", got, tt.wantWarnLine, tt.name)
+			}
+			if got := strings.Contains(preFlush, "7 orphan articles"); got != tt.wantAggregateLine {
+				t.Errorf("aggregate warning visible = %v, want %v in %s mode", got, tt.wantAggregateLine, tt.name)
+			}
+			if got := strings.Contains(preFlush, "index: 10 entries"); got != tt.wantInfoLine {
+				t.Errorf("info line visible = %v, want %v in %s mode", got, tt.wantInfoLine, tt.name)
+			}
+			if got := strings.Contains(postFlush, "1× thin article"); got != tt.wantFlushOutput {
+				t.Errorf("flush output present = %v, want %v in %s mode", got, tt.wantFlushOutput, tt.name)
+			}
+
+			if rep.errors != 1 {
+				t.Errorf("errors = %d, want 1 in %s mode", rep.errors, tt.name)
+			}
+			if rep.warnings != 2 {
+				t.Errorf("warnings = %d, want 2 in %s mode (per-file + aggregate)", rep.warnings, tt.name)
+			}
+		})
+	}
+}
+
+// TestLintReportVerboseHint: verbose per-file lines carry the remediation
+// hint from lintHints — call sites no longer embed it — and classes
+// without a hint render bare.
+func TestLintReportVerboseHint(t *testing.T) {
+	var buf bytes.Buffer
+	rep := newLintReport(&buf, true, false)
+
+	rep.warnf(lintClassIndexTierMissing, "wiki/a.md: index_tier missing")
+	rep.warnf(lintClassThinArticle, "wiki/b.md: thin article (4 lines, minimum 15)")
+
+	out := buf.String()
+	wantHinted := "  WARN wiki/a.md: index_tier missing (run `scribe tier write --missing-only`)\n"
+	if !strings.Contains(out, wantHinted) {
+		t.Errorf("verbose line missing data-driven hint:\ngot:\n%s\nwant substring:\n%s", out, wantHinted)
+	}
+	if strings.Contains(out, "thin article (4 lines, minimum 15) (run") {
+		t.Errorf("hintless class must not grow a hint:\n%s", out)
+	}
+}
+
+// TestLintSizesGroupsByClass drives the real Phase 2 walker over fixture
+// articles and asserts each size/tier warning lands in its class.
+func TestLintSizesGroupsByClass(t *testing.T) {
+	root := t.TempDir()
+	wiki := filepath.Join(root, "wiki")
+	if err := os.MkdirAll(wiki, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	write := func(name, content string) string {
+		t.Helper()
+		path := filepath.Join(wiki, name)
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+
+	body := func(lines int) string {
+		return strings.Repeat("line\n", lines)
+	}
+
+	files := []string{
+		// thin + index_tier missing (2 warnings, 2 classes)
+		write("thin.md", "---\ntitle: Thin\n---\n"+body(2)),
+		// clean: tiered, between 15 and 150 lines
+		write("ok.md", "---\ntitle: OK\nindex_tier: core\n---\n"+body(40)),
+		// bloated only (tier present)
+		write("bloated.md", "---\ntitle: Big\nindex_tier: core\n---\n"+body(160)),
+		// rolling overgrown (rolling files skip thin/bloated/tier checks)
+		write("rolling.md", "---\ntitle: Roll\nrolling: true\n---\n"+body(210)),
+		// rolling archive: exempt from the size warning entirely
+		write("roll-archive-2025.md", "---\ntitle: Arch\nrolling: true\n---\n"+body(210)),
+	}
+
+	var buf bytes.Buffer
+	rep := newLintReport(&buf, false, false)
+	lintSizes(rep, root, files)
+
+	wantCounts := map[string]int{
+		lintClassThinArticle:      1,
+		lintClassIndexTierMissing: 1,
+		lintClassBloatedArticle:   1,
+		lintClassRollingOvergrown: 1,
+	}
+	for class, want := range wantCounts {
+		if got := rep.classCounts[class]; got != want {
+			t.Errorf("class %q count = %d, want %d", class, got, want)
+		}
+	}
+	if rep.warnings != 4 {
+		t.Errorf("warnings = %d, want 4", rep.warnings)
+	}
+	if rep.errors != 0 {
+		t.Errorf("errors = %d, want 0", rep.errors)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("default mode printed per-file output:\n%s", buf.String())
+	}
+}

--- a/cmd/scribe/lint_test.go
+++ b/cmd/scribe/lint_test.go
@@ -117,7 +117,9 @@ func TestLintFrontmatter(t *testing.T) {
 
 	var errors int
 	out := captureLintStdout(t, func() {
-		errors = lintFrontmatter(root, []string{good, bad})
+		rep := newLintReport(os.Stdout, false, false)
+		lintFrontmatter(rep, root, []string{good, bad})
+		errors = rep.errors
 	})
 	// A file with several missing fields still counts once.
 	if errors != 1 {
@@ -190,7 +192,12 @@ func TestLintSizes(t *testing.T) {
 			writeKBFile(t, root, tt.rel, tt.content)
 			var got int
 			out := captureLintStdout(t, func() {
-				got = lintSizes(root, []string{filepath.Join(root, tt.rel)})
+				// Verbose mode prints each warning's message inline so the
+				// per-class wantMsg substrings appear in the captured output;
+				// default mode would defer them to the grouped flush().
+				rep := newLintReport(os.Stdout, true, false)
+				lintSizes(rep, root, []string{filepath.Join(root, tt.rel)})
+				got = rep.warnings
 			})
 			if got != tt.warnings {
 				t.Errorf("warnings = %d, want %d\noutput:\n%s", got, tt.warnings, out)
@@ -211,7 +218,9 @@ func TestLintOrphans(t *testing.T) {
 
 	var warnings int
 	out := captureLintStdout(t, func() {
-		warnings = lintOrphans(root)
+		rep := newLintReport(os.Stdout, false, false)
+		lintOrphans(rep, root)
+		warnings = rep.warnings
 	})
 	// One warning for orphans (A + C have no inbound links), one for the
 	// missing page.
@@ -234,7 +243,8 @@ func TestLintOrphans_AliasResolvesLink(t *testing.T) {
 	writeKBFile(t, root, "wiki/b.md", lintValidArticle("B Article", 20, "aliases: [Bee]"))
 
 	out := captureLintStdout(t, func() {
-		lintOrphans(root)
+		rep := newLintReport(os.Stdout, false, false)
+		lintOrphans(rep, root)
 	})
 	if strings.Contains(out, "missing pages") {
 		t.Errorf("alias-linked page reported missing:\n%s", out)
@@ -246,9 +256,19 @@ func TestLintIndexConsistency(t *testing.T) {
 	writeKBFile(t, root, "wiki/a.md", lintValidArticle("A Article", 20))
 	writeKBFile(t, root, "wiki/b.md", lintValidArticle("B Article", 20))
 
-	t.Run("no index file is silent", func(t *testing.T) {
+	indexWarnings := func(t *testing.T) (int, string) {
+		t.Helper()
 		var w int
-		captureLintStdout(t, func() { w = lintIndexConsistency(root) })
+		out := captureLintStdout(t, func() {
+			rep := newLintReport(os.Stdout, false, false)
+			lintIndexConsistency(rep, root)
+			w = rep.warnings
+		})
+		return w, out
+	}
+
+	t.Run("no index file is silent", func(t *testing.T) {
+		w, _ := indexWarnings(t)
 		if w != 0 {
 			t.Errorf("warnings = %d, want 0 when index missing", w)
 		}
@@ -256,8 +276,7 @@ func TestLintIndexConsistency(t *testing.T) {
 
 	t.Run("small drift tolerated", func(t *testing.T) {
 		writeKBFile(t, root, "wiki/_index.md", "- [[A Article]] -- s\n")
-		var w int
-		out := captureLintStdout(t, func() { w = lintIndexConsistency(root) })
+		w, out := indexWarnings(t)
 		if w != 0 {
 			t.Errorf("warnings = %d, want 0 for diff of 1\noutput:\n%s", w, out)
 		}
@@ -270,8 +289,7 @@ func TestLintIndexConsistency(t *testing.T) {
 			fmt.Fprintf(&sb, "- [[Article %d]] -- s\n", i)
 		}
 		writeKBFile(t, root, "wiki/_index.md", sb.String())
-		var w int
-		out := captureLintStdout(t, func() { w = lintIndexConsistency(root) })
+		w, out := indexWarnings(t)
 		if w != 1 {
 			t.Errorf("warnings = %d, want 1\noutput:\n%s", w, out)
 		}
@@ -283,7 +301,7 @@ func TestLintIndexConsistency(t *testing.T) {
 	t.Run("second wikilink on a line not double counted", func(t *testing.T) {
 		writeKBFile(t, root, "wiki/_index.md",
 			"- [[A Article]] -- relates to [[B Article]] closely\n- [[B Article]] -- s\n")
-		out := captureLintStdout(t, func() { lintIndexConsistency(root) })
+		_, out := indexWarnings(t)
 		if !strings.Contains(out, "index: 2 entries, disk: 2 articles") {
 			t.Errorf("inline second wikilink miscounted:\n%s", out)
 		}
@@ -296,7 +314,11 @@ func TestLintConflictMarkers(t *testing.T) {
 	writeKBFile(t, root, "wiki/broken.md", "# B\n<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> origin/main\n")
 
 	var errors int
-	out := captureLintStdout(t, func() { errors = lintConflictMarkers(root) })
+	out := captureLintStdout(t, func() {
+		rep := newLintReport(os.Stdout, false, false)
+		lintConflictMarkers(rep, root)
+		errors = rep.errors
+	})
 	if errors != 1 {
 		t.Errorf("errors = %d, want 1\noutput:\n%s", errors, out)
 	}

--- a/cmd/scribe/lint_test.go
+++ b/cmd/scribe/lint_test.go
@@ -1,0 +1,405 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// lintTestKB scaffolds a KB root that kbDir() resolves via SCRIBE_KB and
+// that lint's structural phases can walk: scribe.yaml marker + wiki dirs.
+func lintTestKB(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "scribe.yaml"), []byte("domains: [acme]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, d := range []string{"wiki", "solutions", "scripts"} {
+		if err := os.MkdirAll(filepath.Join(root, d), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("SCRIBE_KB", root)
+	return root
+}
+
+// lintValidArticle renders a frontmatter-complete article that passes
+// validateFile with no size warnings (>=15 lines, <=150, index_tier set).
+func lintValidArticle(title string, bodyLines int, extra ...string) string {
+	var sb strings.Builder
+	sb.WriteString("---\n")
+	fmt.Fprintf(&sb, "title: %q\n", title)
+	sb.WriteString("type: solution\n")
+	sb.WriteString("created: 2026-04-10\n")
+	sb.WriteString("updated: 2026-04-10\n")
+	sb.WriteString("domain: general\n")
+	sb.WriteString("confidence: high\n")
+	sb.WriteString("tags: [tag1]\n")
+	sb.WriteString("related: []\n")
+	sb.WriteString(`sources: ["source1"]` + "\n")
+	sb.WriteString(`problem: "p"` + "\n")
+	sb.WriteString("index_tier: standard\n")
+	for _, e := range extra {
+		sb.WriteString(e + "\n")
+	}
+	sb.WriteString("---\n\n")
+	for i := 0; i < bodyLines; i++ {
+		fmt.Fprintf(&sb, "Body line %d of %s.\n", i, title)
+	}
+	return sb.String()
+}
+
+// captureLintStdout runs fn with os.Stdout redirected into a pipe and
+// returns everything it printed.
+func captureLintStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	orig := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+	fn()
+	_ = w.Close()
+	os.Stdout = orig
+	data, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+func TestLintTargetFiles(t *testing.T) {
+	root := lintTestKB(t)
+	writeKBFile(t, root, "wiki/a.md", lintValidArticle("A Article", 20))
+	writeKBFile(t, root, "solutions/b.md", lintValidArticle("B Article", 20))
+	writeKBFile(t, root, "wiki/_index.md", "- [[A Article]]\n")
+
+	t.Run("explicit args win", func(t *testing.T) {
+		l := &LintCmd{Files: []string{"/some/explicit.md"}}
+		files, err := l.targetFiles(root)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(files) != 1 || files[0] != "/some/explicit.md" {
+			t.Errorf("explicit files not passed through: %v", files)
+		}
+	})
+
+	t.Run("default walks articles, skipping meta", func(t *testing.T) {
+		l := &LintCmd{}
+		files, err := l.targetFiles(root)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(files) != 2 {
+			t.Fatalf("want 2 articles, got %d: %v", len(files), files)
+		}
+		for _, f := range files {
+			if strings.Contains(f, "_index") {
+				t.Errorf("underscore meta file leaked into scope: %s", f)
+			}
+		}
+	})
+}
+
+func TestLintFrontmatter(t *testing.T) {
+	root := lintTestKB(t)
+	good := filepath.Join(root, "wiki", "good.md")
+	bad := filepath.Join(root, "wiki", "bad.md")
+	writeKBFile(t, root, "wiki/good.md", lintValidArticle("Good", 20))
+	writeKBFile(t, root, "wiki/bad.md", "---\ntitle: \"Bad\"\ntype: solution\n---\n\nBody.\n")
+
+	var errors int
+	out := captureLintStdout(t, func() {
+		errors = lintFrontmatter(root, []string{good, bad})
+	})
+	// A file with several missing fields still counts once.
+	if errors != 1 {
+		t.Errorf("want 1 file with errors, got %d", errors)
+	}
+	if !strings.Contains(out, "wiki/bad.md") {
+		t.Errorf("error output missing offending file:\n%s", out)
+	}
+	if strings.Contains(out, "good.md") {
+		t.Errorf("clean file flagged:\n%s", out)
+	}
+}
+
+func TestLintSizes(t *testing.T) {
+	root := lintTestKB(t)
+
+	cases := []struct {
+		name     string
+		rel      string
+		content  string
+		warnings int
+		wantMsg  string
+	}{
+		{
+			name: "thin article",
+			rel:  "wiki/thin.md",
+			// Size phase counts total lines including frontmatter, so a
+			// minimal frontmatter keeps the file under the 15-line floor.
+			content:  "---\ntitle: \"Thin\"\nindex_tier: stub\n---\n\nOne line.\n",
+			warnings: 1,
+			wantMsg:  "thin article",
+		},
+		{
+			name:     "bloated article",
+			rel:      "wiki/bloat.md",
+			content:  lintValidArticle("Bloat", 160),
+			warnings: 1,
+			wantMsg:  "bloated article",
+		},
+		{
+			name:     "good article clean",
+			rel:      "wiki/good.md",
+			content:  lintValidArticle("Good", 30),
+			warnings: 0,
+		},
+		{
+			name:     "missing index_tier warns",
+			rel:      "wiki/notier.md",
+			content:  strings.Replace(lintValidArticle("NoTier", 30), "index_tier: standard\n", "", 1),
+			warnings: 1,
+			wantMsg:  "index_tier missing",
+		},
+		{
+			name:     "overgrown rolling file warns",
+			rel:      "wiki/learnings.md",
+			content:  "---\ntitle: \"Learnings\"\nrolling: true\n---\n\n" + strings.Repeat("entry\n", 210),
+			warnings: 1,
+			wantMsg:  "rolling file",
+		},
+		{
+			name:     "rolling archive exempt from size warning",
+			rel:      "wiki/learnings-archive-2025.md",
+			content:  "---\ntitle: \"Learnings Archive\"\nrolling: true\n---\n\n" + strings.Repeat("entry\n", 210),
+			warnings: 0,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			writeKBFile(t, root, tt.rel, tt.content)
+			var got int
+			out := captureLintStdout(t, func() {
+				got = lintSizes(root, []string{filepath.Join(root, tt.rel)})
+			})
+			if got != tt.warnings {
+				t.Errorf("warnings = %d, want %d\noutput:\n%s", got, tt.warnings, out)
+			}
+			if tt.wantMsg != "" && !strings.Contains(out, tt.wantMsg) {
+				t.Errorf("output missing %q:\n%s", tt.wantMsg, out)
+			}
+		})
+	}
+}
+
+func TestLintOrphans(t *testing.T) {
+	root := lintTestKB(t)
+	// A links to B and to a missing page D. C has no inbound links.
+	writeKBFile(t, root, "wiki/a.md", lintValidArticle("A Article", 14)+"\nSee [[B Article]] and [[Missing Page]].\n")
+	writeKBFile(t, root, "wiki/b.md", lintValidArticle("B Article", 20))
+	writeKBFile(t, root, "wiki/c.md", lintValidArticle("C Article", 20))
+
+	var warnings int
+	out := captureLintStdout(t, func() {
+		warnings = lintOrphans(root)
+	})
+	// One warning for orphans (A + C have no inbound links), one for the
+	// missing page.
+	if warnings != 2 {
+		t.Errorf("warnings = %d, want 2\noutput:\n%s", warnings, out)
+	}
+	if !strings.Contains(out, "2 orphan articles") {
+		t.Errorf("expected 2 orphan articles, output:\n%s", out)
+	}
+	if !strings.Contains(out, "1 missing pages") {
+		t.Errorf("expected 1 missing page, output:\n%s", out)
+	}
+}
+
+func TestLintOrphans_AliasResolvesLink(t *testing.T) {
+	root := lintTestKB(t)
+	// B is referenced only by its alias — must not count as a missing page,
+	// and the alias-targeted link gives the alias entry an inbound link.
+	writeKBFile(t, root, "wiki/a.md", lintValidArticle("A Article", 14)+"\nSee [[Bee]].\n")
+	writeKBFile(t, root, "wiki/b.md", lintValidArticle("B Article", 20, "aliases: [Bee]"))
+
+	out := captureLintStdout(t, func() {
+		lintOrphans(root)
+	})
+	if strings.Contains(out, "missing pages") {
+		t.Errorf("alias-linked page reported missing:\n%s", out)
+	}
+}
+
+func TestLintIndexConsistency(t *testing.T) {
+	root := lintTestKB(t)
+	writeKBFile(t, root, "wiki/a.md", lintValidArticle("A Article", 20))
+	writeKBFile(t, root, "wiki/b.md", lintValidArticle("B Article", 20))
+
+	t.Run("no index file is silent", func(t *testing.T) {
+		var w int
+		captureLintStdout(t, func() { w = lintIndexConsistency(root) })
+		if w != 0 {
+			t.Errorf("warnings = %d, want 0 when index missing", w)
+		}
+	})
+
+	t.Run("small drift tolerated", func(t *testing.T) {
+		writeKBFile(t, root, "wiki/_index.md", "- [[A Article]] -- s\n")
+		var w int
+		out := captureLintStdout(t, func() { w = lintIndexConsistency(root) })
+		if w != 0 {
+			t.Errorf("warnings = %d, want 0 for diff of 1\noutput:\n%s", w, out)
+		}
+	})
+
+	t.Run("large drift warns", func(t *testing.T) {
+		// 6 index entries vs 2 disk articles → diff -4.
+		var sb strings.Builder
+		for i := 0; i < 6; i++ {
+			fmt.Fprintf(&sb, "- [[Article %d]] -- s\n", i)
+		}
+		writeKBFile(t, root, "wiki/_index.md", sb.String())
+		var w int
+		out := captureLintStdout(t, func() { w = lintIndexConsistency(root) })
+		if w != 1 {
+			t.Errorf("warnings = %d, want 1\noutput:\n%s", w, out)
+		}
+		if !strings.Contains(out, "diff: -4") {
+			t.Errorf("expected diff -4 in output:\n%s", out)
+		}
+	})
+
+	t.Run("second wikilink on a line not double counted", func(t *testing.T) {
+		writeKBFile(t, root, "wiki/_index.md",
+			"- [[A Article]] -- relates to [[B Article]] closely\n- [[B Article]] -- s\n")
+		out := captureLintStdout(t, func() { lintIndexConsistency(root) })
+		if !strings.Contains(out, "index: 2 entries, disk: 2 articles") {
+			t.Errorf("inline second wikilink miscounted:\n%s", out)
+		}
+	})
+}
+
+func TestLintConflictMarkers(t *testing.T) {
+	root := lintTestKB(t)
+	writeKBFile(t, root, "wiki/clean.md", lintValidArticle("Clean", 20))
+	writeKBFile(t, root, "wiki/broken.md", "# B\n<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> origin/main\n")
+
+	var errors int
+	out := captureLintStdout(t, func() { errors = lintConflictMarkers(root) })
+	if errors != 1 {
+		t.Errorf("errors = %d, want 1\noutput:\n%s", errors, out)
+	}
+	if !strings.Contains(out, "wiki/broken.md:2") {
+		t.Errorf("expected file:line in output:\n%s", out)
+	}
+}
+
+func TestLintRun_StructuralPassAndFail(t *testing.T) {
+	t.Run("clean KB passes", func(t *testing.T) {
+		root := lintTestKB(t)
+		writeKBFile(t, root, "wiki/a.md", lintValidArticle("A Article", 14)+"\nSee [[B Article]].\n")
+		writeKBFile(t, root, "wiki/b.md", lintValidArticle("B Article", 14)+"\nSee [[A Article]].\n")
+		writeKBFile(t, root, "wiki/_index.md", "- [[A Article]] -- s\n- [[B Article]] -- s\n")
+
+		l := &LintCmd{}
+		var err error
+		out := captureLintStdout(t, func() { err = l.Run() })
+		if err != nil {
+			t.Fatalf("Run on clean KB: %v\noutput:\n%s", err, out)
+		}
+		if !strings.Contains(out, "PASSED") {
+			t.Errorf("expected PASSED summary:\n%s", out)
+		}
+	})
+
+	t.Run("frontmatter error fails the run", func(t *testing.T) {
+		root := lintTestKB(t)
+		writeKBFile(t, root, "wiki/bad.md", "---\ntitle: \"Bad\"\n---\n\nBody.\n")
+
+		l := &LintCmd{}
+		var err error
+		captureLintStdout(t, func() { err = l.Run() })
+		if err == nil {
+			t.Fatal("Run should fail on frontmatter errors")
+		}
+		if !strings.Contains(err.Error(), "FAILED") {
+			t.Errorf("error should carry FAILED summary, got: %v", err)
+		}
+	})
+
+	t.Run("changed with no changes is a no-op", func(t *testing.T) {
+		root := lintTestKB(t)
+		gitQuick(t, root, "init")
+		l := &LintCmd{Changed: true}
+		var err error
+		out := captureLintStdout(t, func() { err = l.Run() })
+		if err != nil {
+			t.Fatalf("Run --changed on empty repo: %v", err)
+		}
+		if !strings.Contains(out, "no changed wiki files") {
+			t.Errorf("expected no-op message:\n%s", out)
+		}
+	})
+}
+
+// gitQuick runs a git command in dir, failing the test on error.
+func gitQuick(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...) //nolint:noctx // test fixture, no cancellation needed
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=t@t",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=t@t",
+		"HOME="+dir, // ignore user gitconfig (hooks, signing)
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+func TestChangedWikiFiles(t *testing.T) {
+	root := lintTestKB(t)
+	writeKBFile(t, root, "wiki/tracked.md", lintValidArticle("Tracked", 20))
+	gitQuick(t, root, "init")
+	gitQuick(t, root, "add", ".")
+	gitQuick(t, root, "commit", "-m", "seed")
+
+	// Modify the tracked file, add an untracked one, and an underscore
+	// meta file that must be filtered out.
+	writeKBFile(t, root, "wiki/tracked.md", lintValidArticle("Tracked", 22))
+	writeKBFile(t, root, "wiki/untracked.md", lintValidArticle("Untracked", 20))
+	writeKBFile(t, root, "wiki/_index.md", "- [[Tracked]]\n")
+	writeKBFile(t, root, "wiki/notes.txt", "not markdown")
+
+	files, err := changedWikiFiles(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := make(map[string]bool, len(files))
+	for _, f := range files {
+		got[relPath(root, f)] = true
+	}
+	if !got["wiki/tracked.md"] {
+		t.Errorf("modified tracked file missing: %v", files)
+	}
+	if !got["wiki/untracked.md"] {
+		t.Errorf("untracked file missing: %v", files)
+	}
+	if got["wiki/_index.md"] {
+		t.Errorf("underscore meta file should be filtered: %v", files)
+	}
+	if len(files) != 2 {
+		t.Errorf("want exactly 2 files, got %d: %v", len(files), files)
+	}
+}

--- a/cmd/scribe/lint_test.go
+++ b/cmd/scribe/lint_test.go
@@ -47,7 +47,7 @@ func lintValidArticle(title string, bodyLines int, extra ...string) string {
 		sb.WriteString(e + "\n")
 	}
 	sb.WriteString("---\n\n")
-	for i := 0; i < bodyLines; i++ {
+	for i := range bodyLines {
 		fmt.Fprintf(&sb, "Body line %d of %s.\n", i, title)
 	}
 	return sb.String()
@@ -285,7 +285,7 @@ func TestLintIndexConsistency(t *testing.T) {
 	t.Run("large drift warns", func(t *testing.T) {
 		// 6 index entries vs 2 disk articles → diff -4.
 		var sb strings.Builder
-		for i := 0; i < 6; i++ {
+		for i := range 6 {
 			fmt.Fprintf(&sb, "- [[Article %d]] -- s\n", i)
 		}
 		writeKBFile(t, root, "wiki/_index.md", sb.String())

--- a/cmd/scribe/llm.go
+++ b/cmd/scribe/llm.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -285,7 +286,7 @@ func (o *ollamaProvider) ensureReady(ctx context.Context) error {
 // present a friendly install hint.
 func (o *ollamaProvider) listedModels(ctx context.Context) ([]string, error) {
 	url := strings.TrimRight(o.baseURL, "/") + "/api/tags"
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -348,12 +349,15 @@ func splitModelTag(s string) (string, string) {
 // server emits {"status":"success"}.
 func (o *ollamaProvider) pull(ctx context.Context) error {
 	url := strings.TrimRight(o.baseURL, "/") + "/api/pull"
-	body, _ := json.Marshal(map[string]any{"model": o.model, "stream": true})
+	body, err := json.Marshal(map[string]any{"model": o.model, "stream": true})
+	if err != nil {
+		return fmt.Errorf("encode pull request: %w", err)
+	}
 	// Generous timeout — pulling a 3B model on a slow connection can take
 	// several minutes.
 	pullCtx, cancel := context.WithTimeout(ctx, 30*time.Minute)
 	defer cancel()
-	req, err := http.NewRequestWithContext(pullCtx, "POST", url, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(pullCtx, http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
 		return err
 	}
@@ -400,7 +404,7 @@ func (o *ollamaProvider) pull(ctx context.Context) error {
 	if err := scanner.Err(); err != nil {
 		return fmt.Errorf("read pull stream: %w", err)
 	}
-	return fmt.Errorf("ollama pull ended without success marker")
+	return errors.New("ollama pull ended without success marker")
 }
 
 // ollamaReadyCache remembers which (baseURL|model) pairs have already been
@@ -479,7 +483,7 @@ func (o *ollamaProvider) generate(ctx context.Context, prompt string, jsonMode b
 		appendCostEntry(o.root, entry)
 	}()
 
-	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
 		entry.OK = false
 		entry.ErrKind = "other"

--- a/cmd/scribe/llm_openai_compat.go
+++ b/cmd/scribe/llm_openai_compat.go
@@ -374,7 +374,7 @@ func (p *openaiCompatProvider) postChat(ctx context.Context, reqBody oaiChatRequ
 		return "", oaiChatResponse{}, 0, "", fmt.Errorf("marshal request: %w", err)
 	}
 	url := p.baseURL + "/chat/completions"
-	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
 		return "", oaiChatResponse{}, 0, "", fmt.Errorf("build request: %w", err)
 	}

--- a/cmd/scribe/llm_test.go
+++ b/cmd/scribe/llm_test.go
@@ -34,7 +34,7 @@ func TestOllamaProviderGenerate(t *testing.T) {
 	var gotRequest ollamaRequest
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/generate" {
-			http.Error(w, "wrong path", 404)
+			http.Error(w, "wrong path", http.StatusNotFound)
 			return
 		}
 		body, _ := io.ReadAll(r.Body)
@@ -67,7 +67,7 @@ func TestOllamaProviderGenerate(t *testing.T) {
 
 func TestOllamaProviderErrorBody(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusInternalServerError)
 		_, _ = w.Write([]byte(`{"error":"model not found"}`))
 	}))
 	defer srv.Close()
@@ -105,7 +105,7 @@ func TestOllamaEnsureReadyPullsMissingModel(t *testing.T) {
 			genHits++
 			_ = json.NewEncoder(w).Encode(ollamaResponse{Response: "ok", Done: true})
 		default:
-			http.Error(w, "unknown path", 404)
+			http.Error(w, "unknown path", http.StatusNotFound)
 		}
 	}))
 	defer srv.Close()

--- a/cmd/scribe/main.go
+++ b/cmd/scribe/main.go
@@ -27,50 +27,75 @@ type CLI struct {
 	Root        string           `help:"Override KB root directory." type:"path" short:"C"`
 	VersionFlag kong.VersionFlag `name:"version" short:"V" help:"Show version and exit."`
 
-	Sync           SyncCmd           `cmd:"" help:"Discover, extract, mine sessions, absorb, reindex, commit."`
-	Lint           LintCmd           `cmd:"" help:"Run structural KB health checks."`
-	Validate       ValidateCmd       `cmd:"" help:"Validate YAML frontmatter in markdown files."`
-	Backlinks      BacklinksCmd      `cmd:"" help:"Rebuild _backlinks.json from wikilinks."`
-	Index          IndexCmd          `cmd:"" help:"Rebuild _index.md from disk."`
-	Orphans        OrphansCmd        `cmd:"" help:"Detect orphan articles and missing wikilinks."`
-	Triage         TriageCmd         `cmd:"" help:"Score sessions by knowledge density (FTS5)."`
-	Projects       ProjectsCmd       `cmd:"" help:"List, approve, ignore, or review discovered projects."`
-	Config         ConfigCmd         `cmd:"" help:"Review/approve shared-KB config trust (sensitive scribe.yaml keys)."`
-	Scan           ScanCmd           `cmd:"" help:"Pre-scan a project for extraction."`
-	Deep           DeepCmd           `cmd:"" help:"Deep-extract a project batch-by-directory."`
-	Capture        CaptureCmd        `cmd:"" help:"Capture iMessage self-chat URLs/notes into raw/articles/."`
-	Commit         CommitCmd         `cmd:"" help:"Auto-commit and push pending KB changes."`
-	Dream          DreamCmd          `cmd:"" help:"Run structured memory consolidation (4-phase dream cycle)."`
-	Link           LinkCmd           `cmd:"" help:"Link orphan articles to contextual hosts via See Also sections."`
-	Cron           CronCmd           `cmd:"" help:"Manage macOS LaunchAgents for scheduled KB jobs."`
-	Each           EachCmd           `cmd:"" help:"Run a scribe subcommand in every registered KB (KB-agnostic scheduler)."`
-	Kb             KbCmd             `cmd:"" help:"Manage the machine's KB registry (kbs: in user config)."`
-	Sessions       SessionsCmd       `cmd:"" help:"Debug and repair _sessions_log.json and the session pre-filter."`
-	Debug          DebugCmd          `cmd:"" help:"Low-level diagnostics (wikilinks, backlinks, frontmatter)."`
-	Ingest         IngestCmd         `cmd:"" help:"Ingest a URL into raw/articles/ (queue or synchronous)."`
-	Absorb         AbsorbCmd         `cmd:"" help:"Absorb a local file (md/txt/html) into the KB end-to-end: ingest → contextualize → absorb."`
-	Contextualize  ContextualizeCmd  `cmd:"" help:"Insert LLM-generated retrieval-context paragraph into raw articles for better qmd search."`
-	Status         StatusCmd         `cmd:"" help:"One-shot KB scoreboard: raw by density, absorb/contextualize progress, last sync, Ollama health."`
-	Init           InitCmd           `cmd:"" help:"Check dependencies, verify config, and prep a KB checkout."`
-	Hook           HookCmd           `cmd:"" help:"Claude Code lifecycle hooks (install via ~/.claude/settings.json)."`
-	Hot            HotCmd            `cmd:"" help:"Regenerate wiki/_hot.md context cache (deterministic, no LLM)."`
-	Write          WriteCmd          `cmd:"" help:"Create an article or append to rolling memory (CLI write surface for skills)."`
-	Watch          WatchCmd          `cmd:"" help:"Watch ccrider DB for new sessions (long-running, launchd-friendly)."`
-	Assess         AssessCmd         `cmd:"" help:"One-shot parallel deep assessment of a project (5 tracks + consolidation)."`
-	Doctor         DoctorCmd         `cmd:"" help:"Health check (deps, config, cron, state, run freshness). Read-only."`
-	Digest         DigestCmd         `cmd:"" help:"Regenerate wiki/_digest.md — deterministic team dashboard (activity, findings, owners)."`
-	Promote        PromoteCmd        `cmd:"" help:"Copy an article into another scribe KB with provenance (personal → team promotion)."`
-	InstallTools   InstallToolsCmd   `cmd:"" name:"install-tools" help:"Bootstrap optional tools (uv + marker-pdf) for full PDF/DOCX/PPTX/XLSX/EPUB ingestion."`
-	Fda            FDACmd            `cmd:"" name:"fda" help:"Probe macOS Full Disk Access for chat.db and guide the user through granting it."`
-	Cost           CostCmd           `cmd:"" help:"Summarize claude -p calls (count, wallclock, USD estimate) from the cost ledger."`
-	Sections       SectionsCmd       `cmd:"" help:"Build/list/get section sidecars for wiki articles (Phase 5A)."`
-	Tier           TierCmd           `cmd:"" help:"Compute, set, or backfill index_tier for ranking (Phase 5B)."`
-	Skill          SkillCmd          `cmd:"" help:"Install or list the embedded scribe-kb agent skill bundle (Phase 7A)."`
-	Relations      RelationsCmd      `cmd:"" help:"Get/set/check typed relations between articles (Phase 6A)."`
-	Contradictions ContradictionsCmd `cmd:"" help:"Build/list/show/resolve the contradiction ledger (Phase 6B)."`
-	Stale          StaleCmd          `cmd:"" help:"Build/list/show the staleness ledger (Phase 6C)."`
-	View           ViewCmd           `cmd:"" help:"Run declarative views over wiki frontmatter (Phase 7B)."`
-	Version        VersionCmd        `cmd:"" help:"Show version."`
+	// Core — the pipeline and its health.
+	Sync   SyncCmd   `cmd:"" group:"core" help:"Discover, extract, mine sessions, absorb, reindex, commit."`
+	Status StatusCmd `cmd:"" group:"core" help:"One-shot KB scoreboard: raw by density, absorb/contextualize progress, last sync, Ollama health."`
+	Doctor DoctorCmd `cmd:"" group:"core" help:"Health check (deps, config, cron, state, run freshness). Read-only."`
+	Commit CommitCmd `cmd:"" group:"core" help:"Auto-commit and push pending KB changes."`
+	Watch  WatchCmd  `cmd:"" group:"core" help:"Watch ccrider DB for new sessions (long-running, launchd-friendly)."`
+
+	// Content — getting knowledge into the KB.
+	Write         WriteCmd         `cmd:"" group:"content" help:"Create an article or append to rolling memory (CLI write surface for skills)."`
+	Ingest        IngestCmd        `cmd:"" group:"content" help:"Ingest a URL into raw/articles/ (queue or synchronous)."`
+	Absorb        AbsorbCmd        `cmd:"" group:"content" help:"Absorb a local file (md/txt/html) into the KB end-to-end: ingest → contextualize → absorb."`
+	Capture       CaptureCmd       `cmd:"" group:"content" help:"Capture iMessage self-chat URLs/notes into raw/articles/."`
+	Contextualize ContextualizeCmd `cmd:"" group:"content" help:"Insert LLM-generated retrieval-context paragraph into raw articles for better qmd search."`
+	Projects      ProjectsCmd      `cmd:"" group:"content" help:"List, approve, ignore, or review discovered projects."`
+	Scan          ScanCmd          `cmd:"" group:"content" help:"Pre-scan a project for extraction."`
+	Deep          DeepCmd          `cmd:"" group:"content" help:"Deep-extract a project batch-by-directory."`
+	Assess        AssessCmd        `cmd:"" group:"content" help:"One-shot parallel deep assessment of a project (5 tracks + consolidation)."`
+
+	// Quality — KB hygiene, structure, ranking, consolidation.
+	Lint           LintCmd           `cmd:"" group:"quality" help:"Run structural KB health checks."`
+	Validate       ValidateCmd       `cmd:"" group:"quality" help:"Validate YAML frontmatter in markdown files."`
+	Link           LinkCmd           `cmd:"" group:"quality" help:"Link orphan articles to contextual hosts via See Also sections."`
+	Orphans        OrphansCmd        `cmd:"" group:"quality" help:"Detect orphan articles and missing wikilinks."`
+	Backlinks      BacklinksCmd      `cmd:"" group:"quality" help:"Rebuild _backlinks.json from wikilinks."`
+	Index          IndexCmd          `cmd:"" group:"quality" help:"Rebuild _index.md from disk."`
+	Hot            HotCmd            `cmd:"" group:"quality" help:"Regenerate wiki/_hot.md context cache (deterministic, no LLM)."`
+	Tier           TierCmd           `cmd:"" group:"quality" help:"Compute, set, or backfill index_tier for ranking (Phase 5B)."`
+	Sections       SectionsCmd       `cmd:"" group:"quality" help:"Build/list/get section sidecars for wiki articles (Phase 5A)."`
+	Relations      RelationsCmd      `cmd:"" group:"quality" help:"Get/set/check typed relations between articles (Phase 6A)."`
+	Stale          StaleCmd          `cmd:"" group:"quality" help:"Build/list/show the staleness ledger (Phase 6C)."`
+	Contradictions ContradictionsCmd `cmd:"" group:"quality" help:"Build/list/show/resolve the contradiction ledger (Phase 6B)."`
+	Dream          DreamCmd          `cmd:"" group:"quality" help:"Run structured memory consolidation (4-phase dream cycle)."`
+
+	// Team — shared-KB workflows.
+	Promote PromoteCmd `cmd:"" group:"team" help:"Copy an article into another scribe KB with provenance (personal → team promotion)."`
+	Config  ConfigCmd  `cmd:"" group:"team" help:"Review/approve shared-KB config trust (sensitive scribe.yaml keys)."`
+	Digest  DigestCmd  `cmd:"" group:"team" help:"Regenerate wiki/_digest.md — deterministic team dashboard (activity, findings, owners)."`
+
+	// System — installation and host integration.
+	Init         InitCmd         `cmd:"" group:"system" help:"Check dependencies, verify config, and prep a KB checkout."`
+	Cron         CronCmd         `cmd:"" group:"system" help:"Manage macOS LaunchAgents for scheduled KB jobs."`
+	Each         EachCmd         `cmd:"" group:"system" help:"Run a scribe subcommand in every registered KB (KB-agnostic scheduler)."`
+	Kb           KbCmd           `cmd:"" group:"system" help:"Manage the machine's KB registry (kbs: in user config)."`
+	Hook         HookCmd         `cmd:"" group:"system" help:"Claude Code lifecycle hooks (install via ~/.claude/settings.json)."`
+	Fda          FDACmd          `cmd:"" name:"fda" group:"system" help:"Probe macOS Full Disk Access for chat.db and guide the user through granting it."`
+	Skill        SkillCmd        `cmd:"" group:"system" help:"Install or list the embedded scribe-kb agent skill bundle (Phase 7A)."`
+	InstallTools InstallToolsCmd `cmd:"" name:"install-tools" group:"system" help:"Bootstrap optional tools (uv + marker-pdf) for full PDF/DOCX/PPTX/XLSX/EPUB ingestion."`
+	Version      VersionCmd      `cmd:"" group:"system" help:"Show version."`
+
+	// Debug — diagnostics and introspection.
+	Debug    DebugCmd    `cmd:"" group:"debug" help:"Low-level diagnostics (wikilinks, backlinks, frontmatter)."`
+	Sessions SessionsCmd `cmd:"" group:"debug" help:"Debug and repair _sessions_log.json and the session pre-filter."`
+	Triage   TriageCmd   `cmd:"" group:"debug" help:"Score sessions by knowledge density (FTS5)."`
+	Cost     CostCmd     `cmd:"" group:"debug" help:"Summarize claude -p calls (count, wallclock, USD estimate) from the cost ledger."`
+	View     ViewCmd     `cmd:"" group:"debug" help:"Run declarative views over wiki frontmatter (Phase 7B)."`
+}
+
+// commandGroups maps the `group` struct tags on CLI fields to the section
+// titles rendered in --help. Every command field on CLI must carry one of
+// these keys — TestRootCommandsAreGrouped enforces that, so a new command
+// can't land ungrouped. Subcommands inherit their parent's group, so only
+// root fields need tagging.
+var commandGroups = kong.Groups{
+	"core":    "Core commands:",
+	"content": "Content commands:",
+	"quality": "Quality commands:",
+	"team":    "Team commands:",
+	"system":  "System commands:",
+	"debug":   "Debug commands:",
 }
 
 type VersionCmd struct{}
@@ -80,15 +105,22 @@ func (v *VersionCmd) Run() error {
 	return nil
 }
 
-func main() {
-	setupLogger()
-	cli := CLI{}
-	ctx := kong.Parse(&cli,
+// kongOptions returns the Kong configuration shared by main() and the
+// help-rendering tests, so what the tests assert is what users see.
+func kongOptions() []kong.Option {
+	return []kong.Option{
 		kong.Name("scribe"),
 		kong.Description("scribe — personal knowledge-base pipeline"),
 		kong.UsageOnError(),
 		kong.Vars{"version": "scribe " + version},
-	)
+		commandGroups,
+	}
+}
+
+func main() {
+	setupLogger()
+	cli := CLI{}
+	ctx := kong.Parse(&cli, kongOptions()...)
 
 	globalRoot = cli.Root
 

--- a/cmd/scribe/main_test.go
+++ b/cmd/scribe/main_test.go
@@ -46,6 +46,19 @@ func TestMain(m *testing.M) {
 	for _, v := range []string{"GIT_AUTHOR_NAME", "GIT_AUTHOR_EMAIL", "GIT_COMMITTER_NAME", "GIT_COMMITTER_EMAIL"} {
 		os.Unsetenv(v)
 	}
+	// Git exports repo-locating vars to its hooks (GIT_DIR is absolute
+	// when pushing from a linked worktree), and lefthook's pre-push
+	// test-race inherits them — pointing every fixture's git subprocess
+	// at THIS repo instead of the fixture's temp repo (observed:
+	// a fixture `git commit` reporting "On branch <this branch>", and
+	// codex discovery folding a temp project into the real repo).
+	// Scrub them so the suite is hermetic under hook/CI environments too.
+	for _, v := range []string{
+		"GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_COMMON_DIR",
+		"GIT_OBJECT_DIRECTORY", "GIT_PREFIX", "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+	} {
+		os.Unsetenv(v)
+	}
 	// A developer's shell exports (SCRIBE_KB, SCRIBE_SELF_CHAT_ID, ...)
 	// must not steer test behavior either.
 	for _, kv := range os.Environ() {

--- a/cmd/scribe/main_test.go
+++ b/cmd/scribe/main_test.go
@@ -77,7 +77,7 @@ func TestMain(m *testing.M) {
 // "Commands:" section at the top of --help.
 func TestRootCommandsAreGrouped(t *testing.T) {
 	tp := reflect.TypeOf(CLI{})
-	for i := 0; i < tp.NumField(); i++ {
+	for i := range tp.NumField() {
 		f := tp.Field(i)
 		if _, isCmd := f.Tag.Lookup("cmd"); !isCmd {
 			continue

--- a/cmd/scribe/main_test.go
+++ b/cmd/scribe/main_test.go
@@ -1,10 +1,14 @@
 package main
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/alecthomas/kong"
 )
 
 // TestMain points HOME and XDG_CONFIG_HOME at a scratch directory so no
@@ -52,4 +56,71 @@ func TestMain(m *testing.M) {
 	code := m.Run()
 	os.RemoveAll(scratch)
 	os.Exit(code)
+}
+
+// TestRootCommandsAreGrouped locks the --help grouping: every command field
+// on the root CLI struct must carry a `group` tag whose key is registered in
+// commandGroups. Without this, a new command silently lands in an untitled
+// "Commands:" section at the top of --help.
+func TestRootCommandsAreGrouped(t *testing.T) {
+	tp := reflect.TypeOf(CLI{})
+	for i := 0; i < tp.NumField(); i++ {
+		f := tp.Field(i)
+		if _, isCmd := f.Tag.Lookup("cmd"); !isCmd {
+			continue
+		}
+		key, ok := f.Tag.Lookup("group")
+		if !ok || key == "" {
+			t.Errorf("CLI.%s has no group tag — add group:%q (or another key from commandGroups) so --help stays sectioned", f.Name, "core")
+			continue
+		}
+		if _, known := commandGroups[key]; !known {
+			t.Errorf("CLI.%s uses unknown group %q — register it in commandGroups or use an existing key", f.Name, key)
+		}
+	}
+}
+
+// TestHelpRendersGroupSections renders the real --help output through the
+// same kong options main() uses and asserts the group section titles show
+// up — i.e. the grouping is actually visible, not just present as tags.
+func TestHelpRendersGroupSections(t *testing.T) {
+	var out bytes.Buffer
+	exited := false
+	opts := append(kongOptions(),
+		kong.Writers(&out, &out),
+		kong.Exit(func(int) {
+			exited = true
+			panic(true) // fake exit; recovered below (upstream kong test pattern)
+		}),
+	)
+	parser, err := kong.New(&CLI{}, opts...)
+	if err != nil {
+		t.Fatalf("kong.New: %v", err)
+	}
+
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Fatal("expected --help to exit")
+			}
+		}()
+		_, _ = parser.Parse([]string{"--help"})
+	}()
+	if !exited {
+		t.Fatal("kong.Exit was not invoked for --help")
+	}
+
+	help := out.String()
+	// Every group registered in commandGroups must render as a titled
+	// section — each currently has at least one command tagged with it.
+	for _, title := range commandGroups {
+		if !strings.Contains(help, title) {
+			t.Errorf("--help output missing group section %q", title)
+		}
+	}
+	// Kong puts ungrouped commands under a bare "Commands:" header before
+	// any grouped section — its presence means something escaped grouping.
+	if strings.Contains(help, "\nCommands:\n") {
+		t.Error("--help contains an ungrouped \"Commands:\" section — every root command must carry a group tag")
+	}
 }

--- a/cmd/scribe/manifest.go
+++ b/cmd/scribe/manifest.go
@@ -387,11 +387,12 @@ func decodeClaudePath(dirname string) string {
 			withSlash := path + "/" + seg
 			withDash := path + "-" + seg
 
-			if dirExists(withSlash) {
+			switch {
+			case dirExists(withSlash):
 				path = withSlash
-			} else if dirExists(withDash) {
+			case dirExists(withDash):
 				path = withDash
-			} else {
+			default:
 				// Lookahead: check if dash leads somewhere
 				foundWithDash := false
 				lookahead := withDash

--- a/cmd/scribe/orphans.go
+++ b/cmd/scribe/orphans.go
@@ -106,7 +106,10 @@ func (o *OrphansCmd) Run() error {
 		if showMissing {
 			report.Missing = missing
 		}
-		data, _ := json.MarshalIndent(report, "", "  ")
+		data, err := json.MarshalIndent(report, "", "  ")
+		if err != nil {
+			return err
+		}
 		fmt.Println(string(data))
 		return nil
 	}

--- a/cmd/scribe/projects.go
+++ b/cmd/scribe/projects.go
@@ -85,7 +85,7 @@ type ProjectsApproveCmd struct {
 func withSyncLock(root string, fn func() error) error {
 	err := withLock(loadConfig(root).LockDir, "sync", fn)
 	if errors.Is(err, errLockBusy) {
-		return fmt.Errorf("a sync is running (lock busy) — retry in a moment")
+		return errors.New("a sync is running (lock busy) — retry in a moment")
 	}
 	return err
 }
@@ -109,7 +109,7 @@ func (c *ProjectsApproveCmd) run(root string) error {
 		names = manifest.pendingProjects()
 	}
 	if len(names) == 0 {
-		return fmt.Errorf("nothing to approve — pass project name(s) or --all (see `scribe projects list --pending`)")
+		return errors.New("nothing to approve — pass project name(s) or --all (see `scribe projects list --pending`)")
 	}
 
 	for _, name := range names {

--- a/cmd/scribe/promote.go
+++ b/cmd/scribe/promote.go
@@ -129,18 +129,20 @@ func (c *PromoteCmd) Run() error {
 		// dirty in the target (a sync mid-flight, hand edits) into the
 		// promote commit.
 		destRel := relPath(target, destAbs)
-		if _, err := runCmdErr(target, "git", "add", "--", destRel); err != nil {
-			fmt.Printf("warning: target stage failed: %v — commit manually\n", err)
-		} else if !holdSecretFiles(target, loadConfig(target)) {
+		_, stageErr := runCmdErr(target, "git", "add", "--", destRel)
+		switch {
+		case stageErr != nil:
+			fmt.Printf("warning: target stage failed: %v — commit manually\n", stageErr)
+		case !holdSecretFiles(target, loadConfig(target)):
 			fmt.Println("warning: a detected secret in the target KB could not be held back — commit skipped; resolve there and commit manually")
-		} else if runCmd(target, "git", "status", "--porcelain", "--", destRel) == "" {
+		case runCmd(target, "git", "status", "--porcelain", "--", destRel) == "":
 			fmt.Println("target already had identical content committed — nothing to commit")
-		} else if runCmd(target, "git", "diff", "--cached", "--name-only", "--", destRel) == "" {
+		case runCmd(target, "git", "diff", "--cached", "--name-only", "--", destRel) == "":
 			// The gate held the promoted file itself. A pathspec commit
 			// would commit the WORKTREE state and bypass the hold, so
 			// stop here; the gate already logged the finding.
 			fmt.Println("note: the promoted file was held back from commit by the secret gate — resolve it in the target KB")
-		} else {
+		default:
 			msg := fmt.Sprintf("promote: %s from %s", fm.Title, kbName(root))
 			if _, err := runCmdErr(target, "git", "commit", "--no-gpg-sign", "-m", msg, "--", destRel); err != nil {
 				fmt.Printf("warning: target commit failed: %v — commit manually\n", err)

--- a/cmd/scribe/promote.go
+++ b/cmd/scribe/promote.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -37,7 +38,7 @@ func (c *PromoteCmd) Run() error {
 		return fmt.Errorf("%s is not a scribe KB (no scribe.yaml) — promote needs an initialized target", target)
 	}
 	if filepath.Clean(target) == filepath.Clean(root) {
-		return fmt.Errorf("target KB is the current KB — nothing to promote")
+		return errors.New("target KB is the current KB — nothing to promote")
 	}
 
 	rel := filepath.Clean(c.Article)

--- a/cmd/scribe/readonly_contract_test.go
+++ b/cmd/scribe/readonly_contract_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -82,7 +83,7 @@ func TestLoadConfigIsPure(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(before) != string(after) {
+	if !bytes.Equal(before, after) {
 		t.Errorf("loadConfig mutated scribe.yaml\nbefore:\n%s\nafter:\n%s", before, after)
 	}
 }
@@ -109,7 +110,7 @@ func TestMaybeBackfillAbsorbBlock(t *testing.T) {
 		t.Setenv("SCRIBE_NO_CONFIG_BACKFILL", "1")
 		maybeBackfillAbsorbBlock(dir)
 		after, _ := os.ReadFile(cfgPath)
-		if string(before) != string(after) {
+		if !bytes.Equal(before, after) {
 			t.Error("SCRIBE_NO_CONFIG_BACKFILL=1 must leave scribe.yaml byte-identical")
 		}
 	})

--- a/cmd/scribe/relations.go
+++ b/cmd/scribe/relations.go
@@ -420,7 +420,7 @@ func (c *RelationsCheckCmd) Run() error {
 	err = walkArticles(root, func(path string, content []byte) error {
 		fm, err := parseFrontmatter(content)
 		if err != nil || fm.Title == "" {
-			return nil //nolint:nilerr
+			return nil //nolint:nilerr // unparseable article: skip it, keep walking
 		}
 		titleToPath[fm.Title] = path
 		for _, e := range edgesFromFrontmatter(fm) {

--- a/cmd/scribe/relations.go
+++ b/cmd/scribe/relations.go
@@ -569,13 +569,14 @@ func addTypedEdgeToFrontmatter(path string, kind RelationKind, target string) er
 	_, val, _ := splitFrontmatterLine(headerLine)
 	val = strings.TrimSpace(val)
 
-	if strings.HasPrefix(val, "[") && strings.HasSuffix(val, "]") {
+	switch {
+	case strings.HasPrefix(val, "[") && strings.HasSuffix(val, "]"):
 		// Inline list; rewrite cleanly.
 		inner := strings.TrimSuffix(strings.TrimPrefix(val, "["), "]")
 		existing := splitInlineList(inner)
 		existing = append(existing, `"`+wikilink+`"`)
 		lines[keyIdx] = keyStr + " [" + strings.Join(existing, ", ") + "]"
-	} else if val == "" {
+	case val == "":
 		// Empty header followed by indented bullet lines, or empty header.
 		// Rewrite the header to inline form for compactness.
 		lines[keyIdx] = keyStr + ` ["` + wikilink + `"]`
@@ -602,7 +603,7 @@ func addTypedEdgeToFrontmatter(path string, kind RelationKind, target string) er
 			lines[keyIdx] = keyStr + " [" + strings.Join(existingBullets, ", ") + "]"
 		}
 		lines = append(lines[:keyIdx+1], lines[j:]...)
-	} else {
+	default:
 		// Non-list scalar (rare); promote to inline list with old + new.
 		lines[keyIdx] = keyStr + ` ["` + val + `", "` + wikilink + `"]`
 	}

--- a/cmd/scribe/relations.go
+++ b/cmd/scribe/relations.go
@@ -684,7 +684,7 @@ func splitInlineList(inner string) []string {
 	var out []string
 	cur := strings.Builder{}
 	inQuote := false
-	for i := 0; i < len(inner); i++ {
+	for i := range len(inner) {
 		c := inner[i]
 		switch {
 		case c == '"' && (i == 0 || inner[i-1] != '\\'):

--- a/cmd/scribe/relations.go
+++ b/cmd/scribe/relations.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"slices"
@@ -277,7 +278,7 @@ func (s *RelationsSetCmd) Run() error {
 	target = strings.TrimPrefix(target, "[[")
 	target = strings.TrimSuffix(target, "]]")
 	if target == "" {
-		return fmt.Errorf("target must be non-empty")
+		return errors.New("target must be non-empty")
 	}
 
 	content, err := os.ReadFile(path)
@@ -511,11 +512,11 @@ func addTypedEdgeToFrontmatter(path string, kind RelationKind, target string) er
 	}
 	s := string(data)
 	if !strings.HasPrefix(s, "---") {
-		return fmt.Errorf("no frontmatter delimiter")
+		return errors.New("no frontmatter delimiter")
 	}
 	end := strings.Index(s[3:], "\n---")
 	if end < 0 {
-		return fmt.Errorf("no closing frontmatter delimiter")
+		return errors.New("no closing frontmatter delimiter")
 	}
 	fmBlock := s[3 : end+3]
 	rest := s[end+7:]
@@ -622,11 +623,11 @@ func removeTypedEdgeFromFrontmatter(path string, kind RelationKind, target strin
 	}
 	s := string(data)
 	if !strings.HasPrefix(s, "---") {
-		return fmt.Errorf("no frontmatter delimiter")
+		return errors.New("no frontmatter delimiter")
 	}
 	end := strings.Index(s[3:], "\n---")
 	if end < 0 {
-		return fmt.Errorf("no closing frontmatter delimiter")
+		return errors.New("no closing frontmatter delimiter")
 	}
 	fmBlock := s[3 : end+3]
 	rest := s[end+7:]

--- a/cmd/scribe/relations_migrate.go
+++ b/cmd/scribe/relations_migrate.go
@@ -574,7 +574,7 @@ func findArticleByTitle(root, title string) (string, bool) {
 	_ = walkArticles(root, func(path string, content []byte) error {
 		fm, err := parseFrontmatter(content)
 		if err != nil {
-			return nil //nolint:nilerr
+			return nil //nolint:nilerr // unparseable article: skip it, keep walking
 		}
 		if fm.Title == title {
 			found = path

--- a/cmd/scribe/relations_migrate.go
+++ b/cmd/scribe/relations_migrate.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -578,7 +579,7 @@ func findArticleByTitle(root, title string) (string, bool) {
 		}
 		if fm.Title == title {
 			found = path
-			return fmt.Errorf("__found__") // sentinel break
+			return errors.New("__found__") // sentinel break
 		}
 		return nil
 	})

--- a/cmd/scribe/relations_migrate_test.go
+++ b/cmd/scribe/relations_migrate_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -176,7 +177,7 @@ func TestRelationsMigrate_DryRunMakesNoChanges(t *testing.T) {
 		t.Fatal(err)
 	}
 	after, _ := os.ReadFile(filepath.Join(dir, "decisions", "a.md"))
-	if string(before) != string(after) {
+	if !bytes.Equal(before, after) {
 		t.Errorf("dry-run must not modify file")
 	}
 	matches, _ := filepath.Glob(filepath.Join(dir, "wiki", "_relations_migration_*.jsonl"))

--- a/cmd/scribe/resilience_test.go
+++ b/cmd/scribe/resilience_test.go
@@ -152,7 +152,7 @@ func TestAddJitter(t *testing.T) {
 		t.Errorf("addJitter(-1s) = %v", got)
 	}
 	base := 100 * time.Millisecond
-	for i := 0; i < 50; i++ {
+	for range 50 {
 		got := addJitter(base)
 		if got < base || got >= base+base/2 {
 			t.Fatalf("addJitter(%v) = %v, want [d, d+d/2)", base, got)

--- a/cmd/scribe/resilience_test.go
+++ b/cmd/scribe/resilience_test.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeNetError implements net.Error with a configurable Timeout answer.
+type fakeNetError struct{ timeout bool }
+
+func (e *fakeNetError) Error() string   { return "fake net error" }
+func (e *fakeNetError) Timeout() bool   { return e.timeout }
+func (e *fakeNetError) Temporary() bool { return e.timeout }
+
+// fastRetry keeps test wall time negligible.
+func fastRetry(attempts int) RetryConfig {
+	return RetryConfig{
+		MaxAttempts:   attempts,
+		InitialDelay:  time.Millisecond,
+		MaxDelay:      5 * time.Millisecond,
+		BackoffFactor: 2.0,
+	}
+}
+
+func TestDefaultRetryConfig(t *testing.T) {
+	cfg := defaultRetryConfig()
+	if cfg.MaxAttempts != 3 {
+		t.Errorf("MaxAttempts = %d", cfg.MaxAttempts)
+	}
+	if cfg.InitialDelay != 200*time.Millisecond || cfg.MaxDelay != 10*time.Second {
+		t.Errorf("delays = %v / %v", cfg.InitialDelay, cfg.MaxDelay)
+	}
+	if cfg.BackoffFactor != 2.0 || !cfg.Jitter {
+		t.Errorf("factor/jitter = %v / %v", cfg.BackoffFactor, cfg.Jitter)
+	}
+}
+
+func TestWithRetry(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("first-try success calls fn once", func(t *testing.T) {
+		calls := 0
+		err := WithRetry(ctx, fastRetry(3), func() error {
+			calls++
+			return nil
+		})
+		if err != nil || calls != 1 {
+			t.Errorf("err=%v calls=%d", err, calls)
+		}
+	})
+
+	t.Run("non-retryable error returns immediately and unwrapped", func(t *testing.T) {
+		boom := errors.New("boom")
+		calls := 0
+		err := WithRetry(ctx, fastRetry(3), func() error {
+			calls++
+			return boom
+		})
+		if !errors.Is(err, boom) || calls != 1 {
+			t.Errorf("err=%v calls=%d, want unwrapped boom after 1 call", err, calls)
+		}
+	})
+
+	t.Run("retryable error retries to exhaustion and wraps", func(t *testing.T) {
+		calls := 0
+		timeoutErr := &fakeNetError{timeout: true}
+		err := WithRetry(ctx, fastRetry(3), func() error {
+			calls++
+			return timeoutErr
+		})
+		if calls != 3 {
+			t.Errorf("calls = %d, want 3", calls)
+		}
+		if err == nil || !errors.Is(err, timeoutErr) {
+			t.Errorf("exhaustion error should wrap the last error: %v", err)
+		}
+		if got := err.Error(); !strings.Contains(got, "after 3 attempts") {
+			t.Errorf("error = %q, want attempt count", got)
+		}
+	})
+
+	t.Run("recovers when a later attempt succeeds", func(t *testing.T) {
+		calls := 0
+		err := WithRetry(ctx, fastRetry(3), func() error {
+			calls++
+			if calls < 3 {
+				return &fakeNetError{timeout: true}
+			}
+			return nil
+		})
+		if err != nil || calls != 3 {
+			t.Errorf("err=%v calls=%d", err, calls)
+		}
+	})
+
+	t.Run("canceled context stops before calling fn", func(t *testing.T) {
+		canceled, cancel := context.WithCancel(context.Background())
+		cancel()
+		calls := 0
+		err := WithRetry(canceled, fastRetry(3), func() error {
+			calls++
+			return nil
+		})
+		if !errors.Is(err, context.Canceled) || calls != 0 {
+			t.Errorf("err=%v calls=%d", err, calls)
+		}
+	})
+
+	t.Run("zero config picks up defaults", func(t *testing.T) {
+		// MaxAttempts == 0 must not mean "never run fn".
+		calls := 0
+		err := WithRetry(ctx, RetryConfig{}, func() error {
+			calls++
+			return errors.New("non-retryable")
+		})
+		if err == nil || calls != 1 {
+			t.Errorf("err=%v calls=%d", err, calls)
+		}
+	})
+}
+
+func TestIsRetryable(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"context canceled", context.Canceled, false},
+		{"deadline exceeded", context.DeadlineExceeded, false},
+		{"net timeout", &fakeNetError{timeout: true}, true},
+		{"net non-timeout", &fakeNetError{timeout: false}, false},
+		{"plain error", errors.New("x"), false},
+		{"wrapped net timeout", errors.Join(errors.New("ctx"), &fakeNetError{timeout: true}), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isRetryable(tt.err); got != tt.want {
+				t.Errorf("isRetryable(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAddJitter(t *testing.T) {
+	if got := addJitter(0); got != 0 {
+		t.Errorf("addJitter(0) = %v", got)
+	}
+	if got := addJitter(-time.Second); got != -time.Second {
+		t.Errorf("addJitter(-1s) = %v", got)
+	}
+	base := 100 * time.Millisecond
+	for i := 0; i < 50; i++ {
+		got := addJitter(base)
+		if got < base || got >= base+base/2 {
+			t.Fatalf("addJitter(%v) = %v, want [d, d+d/2)", base, got)
+		}
+	}
+}

--- a/cmd/scribe/resolve.go
+++ b/cmd/scribe/resolve.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -34,7 +35,7 @@ func runResolveContradictions(outputMD string, dryRun bool) error {
 	contraPath := filepath.Join(root, "wiki", "_contradictions.md")
 	data, err := os.ReadFile(contraPath)
 	if err != nil {
-		return fmt.Errorf("no _contradictions.md — run `scribe lint --contradictions` first")
+		return errors.New("no _contradictions.md — run `scribe lint --contradictions` first")
 	}
 
 	pairs := parseContradictionPairs(string(data))

--- a/cmd/scribe/scan_run_test.go
+++ b/cmd/scribe/scan_run_test.go
@@ -1,5 +1,5 @@
 // scan_run_test.go — driver tests for ScanCmd.Run. Scan is the one
-// nolint:gocognit driver with no LLM call of its own (it renders the
+// gocognit-exempt driver with no LLM call of its own (it renders the
 // context packet other LLM passes consume), so the tests pin the
 // report's section contract against fixture projects: stack detection,
 // knowledge-tree filtering, root-doc inlining, KB linkage, and drop-file

--- a/cmd/scribe/secrets.go
+++ b/cmd/scribe/secrets.go
@@ -461,7 +461,7 @@ func findSecretsInKB(root string, includeGeneric bool) []string {
 				if rel == "" {
 					continue
 				}
-				content, rerr := os.ReadFile(filepath.Join(root, rel)) //nolint:gosec // user-supplied KB root, deliberate scan
+				content, rerr := os.ReadFile(filepath.Join(root, rel))
 				if rerr != nil {
 					continue
 				}
@@ -475,7 +475,7 @@ func findSecretsInKB(root string, includeGeneric bool) []string {
 		if err != nil || info.IsDir() || !strings.HasSuffix(path, ".md") {
 			return nil //nolint:nilerr // skip unreadable, continue walk
 		}
-		content, rerr := os.ReadFile(path) //nolint:gosec // user-supplied KB root, deliberate walk
+		content, rerr := os.ReadFile(path)
 		if rerr != nil {
 			return nil //nolint:nilerr // skip unreadable, continue walk
 		}

--- a/cmd/scribe/secrets_test.go
+++ b/cmd/scribe/secrets_test.go
@@ -207,7 +207,7 @@ func TestStagedMarkdownPathRobustness(t *testing.T) {
 	// threshold, so without --no-renames the file vanishes from
 	// --diff-filter=ACM output entirely.
 	var big strings.Builder
-	for i := 0; i < 50; i++ {
+	for range 50 {
 		big.WriteString("filler line to keep rename similarity high\n")
 	}
 	writeKBFile(t, repo, "wiki/original.md", big.String())

--- a/cmd/scribe/sections.go
+++ b/cmd/scribe/sections.go
@@ -143,7 +143,7 @@ func byteOffsetToLine(body []byte, offset int) int {
 		offset = 0
 	}
 	line := 1
-	for i := 0; i < offset; i++ {
+	for i := range offset {
 		if body[i] == '\n' {
 			line++
 		}

--- a/cmd/scribe/sections.go
+++ b/cmd/scribe/sections.go
@@ -344,7 +344,10 @@ func (l *SectionsListCmd) Run() error {
 		}
 	}
 	if l.JSON {
-		out, _ := json.MarshalIndent(sidecar, "", "  ")
+		out, err := json.MarshalIndent(sidecar, "", "  ")
+		if err != nil {
+			return err
+		}
 		fmt.Println(string(out))
 		return nil
 	}

--- a/cmd/scribe/sections.go
+++ b/cmd/scribe/sections.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -333,7 +334,7 @@ func (l *SectionsListCmd) Run() error {
 		}
 		sections := extractSections(articleBody(content))
 		if len(sections) == 0 {
-			return fmt.Errorf("no sections (article has no H1-H3 headings, no sidecar)")
+			return errors.New("no sections (article has no H1-H3 headings, no sidecar)")
 		}
 		rel, _ := filepath.Rel(root, path)
 		sidecar = &SectionsSidecar{

--- a/cmd/scribe/sections_test.go
+++ b/cmd/scribe/sections_test.go
@@ -175,7 +175,10 @@ func TestReadSidecar_VersionMismatchIsCacheMiss(t *testing.T) {
 		t.Fatal(err)
 	}
 	bogus := SectionsSidecar{Version: 999, Article: "x", Sections: []Section{{ID: "x"}}}
-	data, _ := json.Marshal(bogus)
+	data, err := json.Marshal(bogus)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(out, data, 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/scribe/session_mine_envelope.go
+++ b/cmd/scribe/session_mine_envelope.go
@@ -278,7 +278,7 @@ func (s *SyncCmd) mineSessionBatchesEnvelope(root string, sessionIDs []string, p
 	ctx := context.Background()
 
 	promptBase := promptBaseForSessionLabel(label)
-	for w := 0; w < parallel; w++ {
+	for range parallel {
 		go func() {
 			for j := range in {
 				rateLimited, err := mineSessionEnvelope(ctx, root, dbPath, j.sid, provider, cfg.SessionMine, label, promptBase)
@@ -299,7 +299,7 @@ func (s *SyncCmd) mineSessionBatchesEnvelope(root string, sessionIDs []string, p
 	rateLimited := false
 	since := 0
 	var batchIDs []string
-	for i := 0; i < len(sessionIDs); i++ {
+	for range sessionIDs {
 		r := <-out
 		if r.rateLimited {
 			logMsg("sync", "%s envelope: rate limited on %s — will resume next run", label, r.sid)

--- a/cmd/scribe/sessions.go
+++ b/cmd/scribe/sessions.go
@@ -285,9 +285,10 @@ func (c *SessionsInspectCmd) Run() error {
 
 	fmt.Println()
 	fmt.Println("Sessions log:")
-	if !inLog {
+	switch {
+	case !inLog:
 		fmt.Println("  (not in log — unprocessed)")
-	} else if entryIsSkipped(logEntry) {
+	case entryIsSkipped(logEntry):
 		fmt.Println("  ⚠ marked skipped")
 		if m, ok := logEntry.(map[string]any); ok {
 			if r, _ := m["reason"].(string); r != "" {
@@ -297,7 +298,7 @@ func (c *SessionsInspectCmd) Run() error {
 				fmt.Printf("  skipped_at     : %s\n", t)
 			}
 		}
-	} else {
+	default:
 		fmt.Println("  ✓ extracted")
 		if m, ok := logEntry.(map[string]any); ok {
 			if p, _ := m["project"].(string); p != "" {

--- a/cmd/scribe/sessions.go
+++ b/cmd/scribe/sessions.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -432,7 +433,7 @@ func (c *SessionsFilterCmd) Run() error {
 
 	// Use the sync helper to run triage via the scribe binary itself.
 	syncCmd := &SyncCmd{SessionsMax: c.Top, SessionSort: "score"}
-	ids := syncCmd.triageSessionIDs(c.Top, "--message-limit", fmt.Sprintf("%d", c.MessageLimit))
+	ids := syncCmd.triageSessionIDs(c.Top, "--message-limit", strconv.Itoa(c.MessageLimit))
 	if len(ids) == 0 {
 		fmt.Println("Triage returned no sessions.")
 		return nil

--- a/cmd/scribe/sessions.go
+++ b/cmd/scribe/sessions.go
@@ -131,7 +131,10 @@ func (c *SessionsStatsCmd) Run() error {
 			"last_extract":  lastExtract,
 			"last_scan":     lastScan,
 		}
-		data, _ := json.MarshalIndent(out, "", "  ")
+		data, err := json.MarshalIndent(out, "", "  ")
+		if err != nil {
+			return err
+		}
 		fmt.Println(string(data))
 		return nil
 	}
@@ -255,7 +258,10 @@ func (c *SessionsInspectCmd) Run() error {
 			"total_chars":    stats.TotalChars,
 			"filter_verdict": verdict,
 		}
-		data, _ := json.MarshalIndent(out, "", "  ")
+		data, err := json.MarshalIndent(out, "", "  ")
+		if err != nil {
+			return err
+		}
 		fmt.Println(string(data))
 		return nil
 	}

--- a/cmd/scribe/sessions_test.go
+++ b/cmd/scribe/sessions_test.go
@@ -145,9 +145,13 @@ func TestPreFilterSessions(t *testing.T) {
 			insertFixtureMessage(t, db, rowid, "user", strings.Repeat("x", charsPerMsg), false)
 		}
 	}
-	seed("rich", "/p/alpha", 3, 800)
-	seed("thin", "/p/alpha", 2, 400)
-	seed("empty", "/p/alpha", 0, 0)
+	// Project path must clear isIgnored's depth floor (>=4 non-empty
+	// segments) or the scope gate drops these sessions as too-shallow
+	// system paths before the content verdict is ever reached.
+	const proj = "/home/dev/projects/alpha"
+	seed("rich", proj, 3, 800)
+	seed("thin", proj, 2, 400)
+	seed("empty", proj, 0, 0)
 	seed("inkb", root, 3, 800)
 	seed("pending", pendingProj, 3, 800)
 

--- a/cmd/scribe/sessions_test.go
+++ b/cmd/scribe/sessions_test.go
@@ -1,0 +1,521 @@
+package main
+
+import (
+	"database/sql"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// newCcriderDB creates an on-disk SQLite fixture using the minimal
+// ccrider schema in testdata/ccrider_schema.sql. Tests must never touch
+// the real ~/.config/ccrider/sessions.db.
+func newCcriderDB(t *testing.T) (*sql.DB, string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "sessions.db")
+	db, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+	schema, err := os.ReadFile(filepath.Join("testdata", "ccrider_schema.sql"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(string(schema)); err != nil { //nolint:noctx // test fixture
+		t.Fatalf("apply schema: %v", err)
+	}
+	return db, path
+}
+
+// insertFixtureSession adds a sessions row and returns its rowid.
+func insertFixtureSession(t *testing.T, db *sql.DB, sessionID, projectPath string, msgCount int, createdAt, updatedAt, summary string) int64 {
+	t.Helper()
+	//nolint:noctx // test fixture
+	res, err := db.Exec(`INSERT INTO sessions (session_id, project_path, message_count, created_at, updated_at, summary)
+		VALUES (?, ?, ?, ?, ?, ?)`, sessionID, projectPath, msgCount, createdAt, updatedAt, summary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	id, _ := res.LastInsertId()
+	return id
+}
+
+// insertFixtureMessage adds a messages row, mirrored into the FTS tables.
+func insertFixtureMessage(t *testing.T, db *sql.DB, sessionRowID int64, msgType, text string, code bool) {
+	t.Helper()
+	//nolint:noctx // test fixture
+	res, err := db.Exec(`INSERT INTO messages (session_id, type, text_content) VALUES (?, ?, ?)`,
+		sessionRowID, msgType, text)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rowid, _ := res.LastInsertId()
+	if _, err := db.Exec(`INSERT INTO messages_fts (rowid, text_content) VALUES (?, ?)`, rowid, text); err != nil { //nolint:noctx // test fixture
+		t.Fatal(err)
+	}
+	if code {
+		if _, err := db.Exec(`INSERT INTO messages_fts_code (rowid, text_content) VALUES (?, ?)`, rowid, text); err != nil { //nolint:noctx // test fixture
+			t.Fatal(err)
+		}
+	}
+}
+
+// sessionsTestKB scaffolds a KB whose scribe.yaml points ccrider_db at
+// the fixture database.
+func sessionsTestKB(t *testing.T, ccriderDB string) string {
+	t.Helper()
+	root := t.TempDir()
+	yaml := "domains: [acme]\n"
+	if ccriderDB != "" {
+		yaml += "ccrider_db: " + ccriderDB + "\n"
+	}
+	if err := os.WriteFile(filepath.Join(root, "scribe.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "wiki"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SCRIBE_KB", root)
+	return root
+}
+
+func TestFilterVerdict(t *testing.T) {
+	tests := []struct {
+		name  string
+		stats sessionFilterStats
+		want  string
+	}{
+		{"lookup error keeps", sessionFilterStats{Found: false}, ""},
+		{"no user turns", sessionFilterStats{Found: true, UserMsgs: 0, TotalChars: 9000}, "empty"},
+		{"under 500 chars", sessionFilterStats{Found: true, UserMsgs: 5, TotalChars: 499}, "empty"},
+		{"short and shallow", sessionFilterStats{Found: true, UserMsgs: 2, TotalChars: 1999}, "thin"},
+		{"short but rich one-shot", sessionFilterStats{Found: true, UserMsgs: 1, TotalChars: 2000}, ""},
+		{"three user turns", sessionFilterStats{Found: true, UserMsgs: 3, TotalChars: 600}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.stats.filterVerdict(); got != tt.want {
+				t.Errorf("filterVerdict() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestQuerySessionStats(t *testing.T) {
+	db, _ := newCcriderDB(t)
+	sid := insertFixtureSession(t, db, "rich", "/p/alpha", 10, "2026-06-01T10:00:00", "2026-06-01T12:00:00", "did things")
+	insertFixtureMessage(t, db, sid, "user", strings.Repeat("q", 300), false)
+	insertFixtureMessage(t, db, sid, "user", strings.Repeat("w", 300), false)
+	insertFixtureMessage(t, db, sid, "assistant", strings.Repeat("a", 1500), false)
+
+	st := querySessionStats(db, "rich")
+	if !st.Found {
+		t.Fatal("Found = false")
+	}
+	if st.UserMsgs != 2 {
+		t.Errorf("UserMsgs = %d, want 2", st.UserMsgs)
+	}
+	if st.TotalChars != 2100 {
+		t.Errorf("TotalChars = %d, want 2100", st.TotalChars)
+	}
+	if st.ProjectPath != "/p/alpha" {
+		t.Errorf("ProjectPath = %q", st.ProjectPath)
+	}
+
+	// Aggregate queries always return one row: an unknown session reads
+	// as Found with zeros, i.e. verdict "empty" — not a lookup error.
+	unknown := querySessionStats(db, "nope")
+	if !unknown.Found || unknown.filterVerdict() != "empty" {
+		t.Errorf("unknown session: %+v verdict=%q", unknown, unknown.filterVerdict())
+	}
+}
+
+func TestPreFilterSessions(t *testing.T) {
+	db, dbPath := newCcriderDB(t)
+	root := sessionsTestKB(t, dbPath)
+	pendingProj := filepath.Join(t.TempDir(), "pending-proj")
+
+	seed := func(sessionID, project string, userMsgs int, charsPerMsg int) {
+		rowid := insertFixtureSession(t, db, sessionID, project, userMsgs+1,
+			"2026-06-01T10:00:00", "2026-06-01T12:00:00", "s")
+		for i := 0; i < userMsgs; i++ {
+			insertFixtureMessage(t, db, rowid, "user", strings.Repeat("x", charsPerMsg), false)
+		}
+	}
+	seed("rich", "/p/alpha", 3, 800)
+	seed("thin", "/p/alpha", 2, 400)
+	seed("empty", "/p/alpha", 0, 0)
+	seed("inkb", root, 3, 800)
+	seed("pending", pendingProj, 3, 800)
+
+	manifest := `{"projects": {"pending-proj": {"path": ` + jsonQuote(pendingProj) + `, "status": "pending"}}}`
+	writeKBFile(t, root, "scripts/projects.json", manifest)
+
+	kept, skipped := preFilterSessions(root, dbPath,
+		[]string{"rich", "thin", "empty", "inkb", "pending"})
+
+	if len(kept) != 1 || kept[0] != "rich" {
+		t.Errorf("kept = %v, want [rich]", kept)
+	}
+	// thin + empty are marked skipped (recorded as processed); KB and
+	// pending-project sessions are dropped silently so they can resurface.
+	if len(skipped) != 2 {
+		t.Errorf("skipped = %v, want [thin empty] in some order", skipped)
+	}
+	for _, s := range skipped {
+		if s == "inkb" || s == "pending" {
+			t.Errorf("%s must be dropped silently, not marked skipped", s)
+		}
+	}
+}
+
+func TestPreFilterSessions_MissingDBKeepsAll(t *testing.T) {
+	root := sessionsTestKB(t, "")
+	ids := []string{"a", "b"}
+	kept, skipped := preFilterSessions(root, filepath.Join(t.TempDir(), "no.db"), ids)
+	if len(kept) != 2 || len(skipped) != 0 {
+		t.Errorf("kept=%v skipped=%v, want all kept on DB error", kept, skipped)
+	}
+}
+
+func jsonQuote(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
+
+func TestQueryRelatedSessions(t *testing.T) {
+	db, dbPath := newCcriderDB(t)
+	longSummary := strings.Repeat("s", 150)
+	insertFixtureSession(t, db, "target", "/p/alpha", 10, "2026-06-01T10:00:00", "2026-06-10T12:00:00", "target work")
+	insertFixtureSession(t, db, "near", "/p/alpha", 10, "2026-06-01T10:00:00", "2026-06-09T12:00:00", longSummary)
+	insertFixtureSession(t, db, "far", "/p/alpha", 10, "2026-04-01T10:00:00", "2026-04-01T12:00:00", "ancient")
+	insertFixtureSession(t, db, "other", "/p/beta", 10, "2026-06-01T10:00:00", "2026-06-10T11:00:00", "different project")
+	db.Close() // queryRelatedSessions opens its own handle
+
+	related := queryRelatedSessions(dbPath, "target", 7, 10)
+	if len(related) != 1 {
+		t.Fatalf("related = %+v, want exactly the near sibling", related)
+	}
+	r := related[0]
+	if r.SessionID != "near" {
+		t.Errorf("SessionID = %q", r.SessionID)
+	}
+	if len(r.Summary) != 140+len("…") || !strings.HasSuffix(r.Summary, "…") {
+		t.Errorf("summary not truncated to 140+ellipsis: %d chars", len(r.Summary))
+	}
+
+	if got := queryRelatedSessions(filepath.Join(t.TempDir(), "no.db"), "target", 7, 10); got != nil {
+		t.Errorf("missing DB should return nil, got %v", got)
+	}
+	if got := queryRelatedSessions(dbPath, "unknown", 7, 10); got != nil {
+		t.Errorf("unknown target should return nil, got %v", got)
+	}
+}
+
+func TestFormatRelatedSessions(t *testing.T) {
+	if got := formatRelatedSessions(nil); !strings.Contains(got, "none") {
+		t.Errorf("empty list = %q", got)
+	}
+	got := formatRelatedSessions([]relatedSession{
+		{SessionID: "s1", Date: "2026-06-09", Summary: "line one\nline two"},
+		{SessionID: "s2", Date: "2026-06-08", Summary: ""},
+	})
+	if !strings.Contains(got, "- s1 (2026-06-09): line one line two") {
+		t.Errorf("newlines not flattened: %q", got)
+	}
+	if !strings.Contains(got, "- s2 (2026-06-08): (no summary)") {
+		t.Errorf("missing-summary placeholder absent: %q", got)
+	}
+	if strings.HasSuffix(got, "\n") {
+		t.Errorf("trailing newline not trimmed: %q", got)
+	}
+}
+
+func TestLargeSessionBudget(t *testing.T) {
+	tests := []struct {
+		max  int
+		skip bool
+		want int
+	}{
+		{9, false, 3},
+		{1, false, 1}, // floor of 1
+		{0, false, 1},
+		{30, true, 0}, // --skip-large
+	}
+	for _, tt := range tests {
+		s := &SyncCmd{SessionsMax: tt.max, SkipLarge: tt.skip}
+		if got := s.largeSessionBudget(); got != tt.want {
+			t.Errorf("largeSessionBudget(max=%d skip=%v) = %d, want %d", tt.max, tt.skip, got, tt.want)
+		}
+	}
+}
+
+// --- sessions.go: log view + subcommands ---
+
+const sessionsLogFixture = `{
+  "processed": {
+    "s1": {"extracted": "2026-06-01T10:00:00Z", "project": "alpha"},
+    "s2": {"extracted": "2026-06-02T10:00:00Z", "project": "alpha"},
+    "s3": {"skipped": true, "reason": "mechanical", "extracted": "2026-06-03T00:00:00Z"}
+  },
+  "last_scan": "2026-06-03T12:00:00Z"
+}`
+
+func TestSessionsLogView(t *testing.T) {
+	root := sessionsTestKB(t, "")
+	writeKBFile(t, root, "wiki/_sessions_log.json", sessionsLogFixture)
+
+	view, err := loadSessionsLogView(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(view.processed) != 3 {
+		t.Fatalf("processed = %d entries, want 3", len(view.processed))
+	}
+	if !entryIsSkipped(view.processed["s3"]) {
+		t.Error("s3 should be skipped")
+	}
+	if entryIsSkipped(view.processed["s1"]) {
+		t.Error("s1 should not be skipped")
+	}
+	if entryProject(view.processed["s1"]) != "alpha" {
+		t.Errorf("project = %q", entryProject(view.processed["s1"]))
+	}
+	if entryExtracted(view.processed["s2"]) != "2026-06-02T10:00:00Z" {
+		t.Errorf("extracted = %q", entryExtracted(view.processed["s2"]))
+	}
+	// Non-map entries are tolerated.
+	if entryIsSkipped("garbage") || entryProject(42) != "" || entryExtracted(nil) != "" {
+		t.Error("non-map entries must read as zero values")
+	}
+
+	delete(view.processed, "s3")
+	if err := view.save(); err != nil {
+		t.Fatal(err)
+	}
+	again, err := loadSessionsLogView(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := again.processed["s3"]; ok {
+		t.Error("save did not persist the deletion")
+	}
+	if lastScan, _ := again.raw["last_scan"].(string); lastScan != "2026-06-03T12:00:00Z" {
+		t.Errorf("save dropped sibling keys: last_scan = %q", lastScan)
+	}
+}
+
+func TestSortedCountKeys(t *testing.T) {
+	got := sortedCountKeys(map[string]int{"b": 2, "a": 2, "z": 9, "m": 1})
+	want := []string{"z", "a", "b", "m"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v", got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("order[%d] = %q, want %q (full: %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+func TestSessionsStatsCmd_JSON(t *testing.T) {
+	root := sessionsTestKB(t, "")
+	writeKBFile(t, root, "wiki/_sessions_log.json", sessionsLogFixture)
+
+	var err error
+	out := captureLintStdout(t, func() {
+		err = (&SessionsStatsCmd{JSON: true}).Run()
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload struct {
+		Total        int            `json:"total"`
+		Extracted    int            `json:"extracted"`
+		Skipped      int            `json:"skipped"`
+		ByProject    map[string]int `json:"by_project"`
+		FirstExtract string         `json:"first_extract"`
+		LastExtract  string         `json:"last_extract"`
+		LastScan     string         `json:"last_scan"`
+	}
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("bad JSON output: %v\n%s", err, out)
+	}
+	if payload.Total != 3 || payload.Extracted != 2 || payload.Skipped != 1 {
+		t.Errorf("counts = %+v", payload)
+	}
+	if payload.ByProject["alpha"] != 2 {
+		t.Errorf("by_project = %v", payload.ByProject)
+	}
+	if payload.FirstExtract != "2026-06-01T10:00:00Z" || payload.LastExtract != "2026-06-02T10:00:00Z" {
+		t.Errorf("extract range = %q..%q", payload.FirstExtract, payload.LastExtract)
+	}
+	if payload.LastScan != "2026-06-03T12:00:00Z" {
+		t.Errorf("last_scan = %q", payload.LastScan)
+	}
+}
+
+func TestSessionsUnskipCmd(t *testing.T) {
+	db, dbPath := newCcriderDB(t)
+	// "wasrich" now passes the filter; "stillempty" doesn't.
+	rich := insertFixtureSession(t, db, "wasrich", "/p/alpha", 10, "2026-06-01T10:00:00", "2026-06-01T12:00:00", "s")
+	for i := 0; i < 3; i++ {
+		insertFixtureMessage(t, db, rich, "user", strings.Repeat("x", 800), false)
+	}
+	insertFixtureSession(t, db, "stillempty", "/p/alpha", 2, "2026-06-01T10:00:00", "2026-06-01T12:00:00", "s")
+
+	root := sessionsTestKB(t, dbPath)
+	logJSON := `{"processed": {
+		"wasrich": {"skipped": true, "reason": "mechanical"},
+		"stillempty": {"skipped": true, "reason": "mechanical"},
+		"extracted-one": {"extracted": "2026-06-01T00:00:00Z"}
+	}, "last_scan": null}`
+	writeKBFile(t, root, "wiki/_sessions_log.json", logJSON)
+
+	t.Run("dry run reports without writing", func(t *testing.T) {
+		var err error
+		out := captureLintStdout(t, func() {
+			err = (&SessionsUnskipCmd{DryRun: true}).Run()
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(out, "would unskip : 1") {
+			t.Errorf("expected 1 unskippable:\n%s", out)
+		}
+		view, _ := loadSessionsLogView(root)
+		if len(view.processed) != 3 {
+			t.Errorf("dry run modified the log: %d entries", len(view.processed))
+		}
+	})
+
+	t.Run("real run removes only passing entries", func(t *testing.T) {
+		var err error
+		captureLintStdout(t, func() {
+			err = (&SessionsUnskipCmd{}).Run()
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		view, _ := loadSessionsLogView(root)
+		if _, ok := view.processed["wasrich"]; ok {
+			t.Error("wasrich should have been unskipped")
+		}
+		if _, ok := view.processed["stillempty"]; !ok {
+			t.Error("stillempty must stay skipped")
+		}
+		if _, ok := view.processed["extracted-one"]; !ok {
+			t.Error("extracted entries must never be touched")
+		}
+	})
+
+	t.Run("all flag removes every skipped entry", func(t *testing.T) {
+		writeKBFile(t, root, "wiki/_sessions_log.json", logJSON)
+		var err error
+		captureLintStdout(t, func() {
+			err = (&SessionsUnskipCmd{All: true}).Run()
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		view, _ := loadSessionsLogView(root)
+		if len(view.processed) != 1 {
+			t.Errorf("want only the extracted entry left, got %v", view.processed)
+		}
+	})
+}
+
+func TestSessionsInspectCmd_JSON(t *testing.T) {
+	db, dbPath := newCcriderDB(t)
+	rich := insertFixtureSession(t, db, "abc-123", "/p/alpha", 12, "2026-06-01T10:00:00", "2026-06-01T12:00:00", "built a thing")
+	for i := 0; i < 3; i++ {
+		insertFixtureMessage(t, db, rich, "user", strings.Repeat("x", 800), false)
+	}
+
+	root := sessionsTestKB(t, dbPath)
+	writeKBFile(t, root, "wiki/_sessions_log.json",
+		`{"processed": {"skipped-one": {"skipped": true}}, "last_scan": null}`)
+
+	var err error
+	out := captureLintStdout(t, func() {
+		err = (&SessionsInspectCmd{ID: "abc-123", JSON: true}).Run()
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("bad JSON: %v\n%s", err, out)
+	}
+	if payload["in_db"] != true || payload["in_log"] != false {
+		t.Errorf("in_db/in_log = %v/%v", payload["in_db"], payload["in_log"])
+	}
+	if payload["filter_verdict"] != "keep" {
+		t.Errorf("filter_verdict = %v", payload["filter_verdict"])
+	}
+	if payload["project_path"] != "/p/alpha" {
+		t.Errorf("project_path = %v", payload["project_path"])
+	}
+	if payload["message_count"] != float64(12) {
+		t.Errorf("message_count = %v", payload["message_count"])
+	}
+}
+
+// --- hook.go DB query helpers (same fixture schema) ---
+
+func TestHookQueryHelpers(t *testing.T) {
+	db, _ := newCcriderDB(t)
+	insertFixtureSession(t, db, "older", "/p/alpha", 8, "2026-06-01T10:00:00", "2026-06-05T10:00:00", "real work")
+	insertFixtureSession(t, db, "newest", "/p/beta", 4, "2026-06-01T10:00:00", "2026-06-09T10:00:00", "more work")
+	insertFixtureSession(t, db, "bootstrap", "/p/beta", 9, "2026-06-01T10:00:00", "2026-06-10T10:00:00", "You are working in a directory")
+	insertFixtureSession(t, db, "empty-one", "/p/beta", 0, "2026-06-01T10:00:00", "2026-06-11T10:00:00", "x")
+
+	t.Run("queryMostRecentSessionID skips bootstrap and empty", func(t *testing.T) {
+		if got := queryMostRecentSessionID(db); got != "newest" {
+			t.Errorf("got %q, want newest", got)
+		}
+	})
+
+	t.Run("queryMessageCount", func(t *testing.T) {
+		if n, ok := queryMessageCount(db, "older"); !ok || n != 8 {
+			t.Errorf("got (%d, %v)", n, ok)
+		}
+		if _, ok := queryMessageCount(db, "ghost"); ok {
+			t.Error("unknown session should not be found")
+		}
+	})
+
+	t.Run("querySessionProjectPath", func(t *testing.T) {
+		if got := querySessionProjectPath(db, "older"); got != "/p/alpha" {
+			t.Errorf("got %q", got)
+		}
+		if got := querySessionProjectPath(db, "ghost"); got != "" {
+			t.Errorf("unknown session = %q, want empty", got)
+		}
+	})
+}
+
+func TestQuickScoreSession(t *testing.T) {
+	db, _ := newCcriderDB(t)
+	sid := insertFixtureSession(t, db, "scored", "/p/alpha", 5, "2026-06-01T10:00:00", "2026-06-01T12:00:00", "s")
+	// One decision hit (weight 3), one research hit (weight 3), one code
+	// pattern hit (weight 1) → 7. A message matching a category twice
+	// still counts once per row.
+	insertFixtureMessage(t, db, sid, "user", "we decided to ship it", false)
+	insertFixtureMessage(t, db, sid, "assistant", "research notes from the paper", false)
+	insertFixtureMessage(t, db, sid, "assistant", "defmodule MyApp.Worker uses GenServer", true)
+
+	// The code message also lands in messages_fts; make sure it carries
+	// no keyword from the six prose categories (it doesn't), so the
+	// expected total stays 3 + 3 + 1.
+	if got := quickScoreSession(db, "scored"); got != 7 {
+		t.Errorf("score = %d, want 7", got)
+	}
+
+	if got := quickScoreSession(db, "ghost"); got != 0 {
+		t.Errorf("unknown session score = %d, want 0", got)
+	}
+}

--- a/cmd/scribe/sessions_test.go
+++ b/cmd/scribe/sessions_test.go
@@ -141,7 +141,7 @@ func TestPreFilterSessions(t *testing.T) {
 	seed := func(sessionID, project string, userMsgs int, charsPerMsg int) {
 		rowid := insertFixtureSession(t, db, sessionID, project, userMsgs+1,
 			"2026-06-01T10:00:00", "2026-06-01T12:00:00", "s")
-		for i := 0; i < userMsgs; i++ {
+		for range userMsgs {
 			insertFixtureMessage(t, db, rowid, "user", strings.Repeat("x", charsPerMsg), false)
 		}
 	}
@@ -186,7 +186,7 @@ func TestPreFilterSessions_MissingDBKeepsAll(t *testing.T) {
 }
 
 func jsonQuote(s string) string {
-	b, _ := json.Marshal(s)
+	b, _ := json.Marshal(s) //nolint:errchkjson // marshaling a string is infallible
 	return string(b)
 }
 
@@ -366,7 +366,7 @@ func TestSessionsUnskipCmd(t *testing.T) {
 	db, dbPath := newCcriderDB(t)
 	// "wasrich" now passes the filter; "stillempty" doesn't.
 	rich := insertFixtureSession(t, db, "wasrich", "/p/alpha", 10, "2026-06-01T10:00:00", "2026-06-01T12:00:00", "s")
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		insertFixtureMessage(t, db, rich, "user", strings.Repeat("x", 800), false)
 	}
 	insertFixtureSession(t, db, "stillempty", "/p/alpha", 2, "2026-06-01T10:00:00", "2026-06-01T12:00:00", "s")
@@ -435,7 +435,7 @@ func TestSessionsUnskipCmd(t *testing.T) {
 func TestSessionsInspectCmd_JSON(t *testing.T) {
 	db, dbPath := newCcriderDB(t)
 	rich := insertFixtureSession(t, db, "abc-123", "/p/alpha", 12, "2026-06-01T10:00:00", "2026-06-01T12:00:00", "built a thing")
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		insertFixtureMessage(t, db, rich, "user", strings.Repeat("x", 800), false)
 	}
 

--- a/cmd/scribe/stale.go
+++ b/cmd/scribe/stale.go
@@ -444,7 +444,10 @@ func (c *StaleShowCmd) Run() error {
 	target := filepath.ToSlash(c.Target)
 	for _, e := range entries {
 		if e.ID == c.Target || e.Path == target {
-			data, _ := json.MarshalIndent(e, "", "  ")
+			data, err := json.MarshalIndent(e, "", "  ")
+			if err != nil {
+				return err
+			}
 			fmt.Println(string(data))
 			return nil
 		}

--- a/cmd/scribe/stale.go
+++ b/cmd/scribe/stale.go
@@ -338,7 +338,7 @@ func probeStaleURLs(entries []StalenessEntry, maxProbes int, timeout time.Durati
 			defer func() { <-sem }()
 			ctx, cancel := context.WithTimeout(context.Background(), timeout)
 			defer cancel()
-			req, err := http.NewRequestWithContext(ctx, "HEAD", entries[idx].SourceURL, nil)
+			req, err := http.NewRequestWithContext(ctx, http.MethodHead, entries[idx].SourceURL, nil)
 			if err != nil {
 				return
 			}

--- a/cmd/scribe/stale.go
+++ b/cmd/scribe/stale.go
@@ -147,7 +147,7 @@ func buildStalenessLedger(root string, opts BuildStaleOpts, now time.Time) (Stal
 	err := walkArticles(root, func(path string, content []byte) error {
 		fm, err := parseFrontmatter(content)
 		if err != nil {
-			return nil //nolint:nilerr
+			return nil //nolint:nilerr // unparseable article: skip it, keep walking
 		}
 		rel, _ := filepath.Rel(root, path)
 		rel = filepath.ToSlash(rel)

--- a/cmd/scribe/status.go
+++ b/cmd/scribe/status.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -294,7 +295,7 @@ func qmdIndexSize() (string, error) {
 			return strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(line), "Size:")), nil
 		}
 	}
-	return "", fmt.Errorf("size line not found")
+	return "", errors.New("size line not found")
 }
 
 // renderBacklog prints "what's not yet processed" so the user can

--- a/cmd/scribe/status.go
+++ b/cmd/scribe/status.go
@@ -252,7 +252,7 @@ func formatRunLine(line string) string {
 }
 
 func extractJSONField(line, key string) string {
-	needle := fmt.Sprintf(`"%s":`, key)
+	needle := fmt.Sprintf("%q:", key)
 	_, after, ok := strings.Cut(line, needle)
 	if !ok {
 		return ""

--- a/cmd/scribe/status.go
+++ b/cmd/scribe/status.go
@@ -310,17 +310,27 @@ func qmdIndexSize() (string, error) {
 //     pre-filter ceiling so mechanical/short sessions don't inflate
 //     the backlog.
 //  3. Pending drop files staged inside other projects'
-//     `.claude/scriptorium/` directories — these get collected at
+//     `.claude/<kb-name>/` directories — these get collected at
 //     the start of `scribe sync` but show up here too so the user
 //     can spot accumulated drops without running a full sync.
+//
+// "Pending" means the next sync will actually process it. Work a
+// policy gate holds back forever — drop files without an absorb
+// opt-in under strictness=high, projects over sync.max_extract_files
+// — is reported separately as "held" so the backlog never promises
+// work sync won't do. The classification reuses the same rules sync
+// itself applies (strictnessHoldsFile, exceedsExtractFileCap), so
+// status and the sync-time hold summary can't drift apart.
 //
 // Each subsection is silenced if the underlying state file is
 // missing — a fresh KB shouldn't get a wall of "0 pending" lines.
 func renderBacklog(w io.Writer, root string, cfg *ScribeConfig) {
 	type backlog struct {
-		label string
-		done  int
-		todo  int
+		label    string
+		done     int
+		todo     int
+		held     int
+		heldNote string
 	}
 	var rows []backlog
 
@@ -328,29 +338,44 @@ func renderBacklog(w io.Writer, root string, cfg *ScribeConfig) {
 	if manifest, err := loadManifest(root); err == nil {
 		total := 0
 		needing := 0
+		capped := 0
 		for _, entry := range manifest.Projects {
 			if !dirExists(entry.Path) {
 				continue
 			}
 			total++
-			if entry.LastSHA == "" {
-				needing++
-				continue
-			}
-			if hasGit(entry.Path) {
+			needs := false
+			switch {
+			case entry.LastSHA == "":
+				needs = true
+			case hasGit(entry.Path):
 				cur := gitSHA(entry.Path)
-				if cur != "" && cur != entry.LastSHA {
-					needing++
-				}
+				needs = cur != "" && cur != entry.LastSHA
+			default:
+				// Non-git projects: stat-walk fallback, conservative.
+				needs = entry.LastExtracted == ""
+			}
+			if !needs {
 				continue
 			}
-			// Non-git projects: stat-walk fallback, conservative.
-			if entry.LastExtracted == "" {
+			// Same size gate sync applies: a project over
+			// sync.max_extract_files is skipped every run until the user
+			// runs `scribe deep`, so it's held, not pending.
+			if cfg.Sync.MaxExtractFiles > 0 &&
+				exceedsExtractFileCap(cfg, len(gitChangedFiles(entry.Path, entry.LastSHA, extractScanPatterns))) {
+				capped++
+			} else {
 				needing++
 			}
 		}
 		if total > 0 {
-			rows = append(rows, backlog{label: "projects (extract):", done: total - needing, todo: needing})
+			rows = append(rows, backlog{
+				label:    "projects (extract):",
+				done:     total - needing - capped,
+				todo:     needing,
+				held:     capped,
+				heldNote: ">max_extract_files — run `scribe deep`",
+			})
 		}
 	}
 
@@ -371,9 +396,23 @@ func renderBacklog(w io.Writer, root string, cfg *ScribeConfig) {
 		}
 	}
 
-	// Drop files staged in other projects.
-	if pending := countPendingDropFiles(root); pending > 0 {
-		rows = append(rows, backlog{label: "drop files:", done: 0, todo: pending})
+	// Drop files staged in other projects, split by the same strictness
+	// gate sync's absorb applies: under strictness=high a drop without
+	// an opt-in (`absorb: true` or a named domain) never drains, so
+	// it's held, not pending.
+	if drops := pendingDropFiles(root); len(drops) > 0 {
+		held := 0
+		for _, f := range drops {
+			if strictnessHoldsFile(cfg.Absorb.Strictness, f) {
+				held++
+			}
+		}
+		rows = append(rows, backlog{
+			label:    "drop files:",
+			todo:     len(drops) - held,
+			held:     held,
+			heldNote: "strictness=high — need opt-in",
+		})
 	}
 
 	if len(rows) == 0 {
@@ -382,11 +421,15 @@ func renderBacklog(w io.Writer, root string, cfg *ScribeConfig) {
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "  backlog (run `scribe sync` to process):")
 	for _, r := range rows {
-		if r.done == 0 {
-			fmt.Fprintf(w, "    %-22s %d pending\n", r.label, r.todo)
-		} else {
-			fmt.Fprintf(w, "    %-22s %d done, %d pending\n", r.label, r.done, r.todo)
+		parts := make([]string, 0, 3)
+		if r.done > 0 {
+			parts = append(parts, fmt.Sprintf("%d done", r.done))
 		}
+		if r.held > 0 {
+			parts = append(parts, fmt.Sprintf("%d held (%s)", r.held, r.heldNote))
+		}
+		parts = append(parts, fmt.Sprintf("%d pending", r.todo))
+		fmt.Fprintf(w, "    %-22s %s\n", r.label, strings.Join(parts, ", "))
 	}
 }
 
@@ -408,32 +451,25 @@ func countSessionsInDB(dbPath string) (int, bool) {
 	return n, true
 }
 
-// countPendingDropFiles walks the manifest's project paths and
-// counts unprocessed `.claude/scriptorium/*.md` drop files. A drop
-// file is "pending" if it exists; the sync sweep moves processed
-// files to `.claude/scriptorium/.processed/` so anything still at
-// the top level is awaiting absorption.
-func countPendingDropFiles(root string) int {
+// pendingDropFiles lists the unprocessed drop files staged inside
+// other projects' `.claude/<kb-name>/` directories — the exact set the
+// next sync's collect phase would pick up (same enumeration via
+// unprocessedDropFiles: approved projects only, main checkout plus
+// worktrees, newer than last_drop_processed). Returns paths, not a
+// count, so the caller can classify each file against the strictness
+// gate.
+func pendingDropFiles(root string) []string {
 	manifest, err := loadManifest(root)
 	if err != nil {
-		return 0
+		return nil
 	}
-	total := 0
+	kb := kbName(root)
+	var files []string
 	for _, entry := range manifest.Projects {
-		dropDir := filepath.Join(entry.Path, ".claude", "scriptorium")
-		if !dirExists(dropDir) {
+		if !entry.IsApproved() {
 			continue
 		}
-		files, err := os.ReadDir(dropDir)
-		if err != nil {
-			continue
-		}
-		for _, f := range files {
-			if f.IsDir() || !strings.HasSuffix(f.Name(), ".md") {
-				continue
-			}
-			total++
-		}
+		files = append(files, unprocessedDropFiles(kb, entry)...)
 	}
-	return total
+	return files
 }

--- a/cmd/scribe/status.go
+++ b/cmd/scribe/status.go
@@ -345,7 +345,7 @@ func renderBacklog(w io.Writer, root string, cfg *ScribeConfig) {
 				continue
 			}
 			total++
-			needs := false
+			var needs bool
 			switch {
 			case entry.LastSHA == "":
 				needs = true

--- a/cmd/scribe/status_test.go
+++ b/cmd/scribe/status_test.go
@@ -1,0 +1,215 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestStrictnessHoldsFile pins the shared hold-classification rule used by
+// both sync's absorb gate and the status backlog: strictness=high holds a
+// file unless its frontmatter opts in via `absorb: true` or a named domain.
+func TestStrictnessHoldsFile(t *testing.T) {
+	cases := []struct {
+		name       string
+		strictness string
+		content    string
+		held       bool
+	}{
+		{"high absorb opt-in", "high", "---\nabsorb: true\n---\nbody\n", false},
+		{"high named domain", "high", "---\ndomain: widgets\n---\nbody\n", false},
+		{"high general domain", "high", "---\ndomain: general\n---\nbody\n", true},
+		{"high empty domain", "high", "---\ndomain: \"\"\n---\nbody\n", true},
+		{"high absorb false", "high", "---\nabsorb: false\n---\nbody\n", true},
+		{"high no frontmatter", "high", "just a body\n", true},
+		{"high malformed frontmatter", "high", "---\n: [unbalanced\n", true},
+		{"medium general domain", "medium", "---\ndomain: general\n---\nbody\n", false},
+		{"low no frontmatter", "low", "just a body\n", false},
+	}
+	dir := t.TempDir()
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(dir, fmt.Sprintf("f%d.md", i))
+			if err := os.WriteFile(path, []byte(tc.content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if got := strictnessHoldsFile(tc.strictness, path); got != tc.held {
+				t.Errorf("strictnessHoldsFile(%q, %s) = %v, want %v", tc.strictness, tc.name, got, tc.held)
+			}
+		})
+	}
+}
+
+// statusBacklogFixture builds a minimal KB plus external project dirs for
+// renderBacklog tests. Drop files land in one non-git "dropper" project
+// (marked extracted so it doesn't pollute the projects row); mdProjects
+// are never-extracted projects holding N markdown files each so the
+// max_extract_files gate has something to measure.
+type statusBacklogFixture struct {
+	strictness string
+	maxExtract int
+	drops      map[string]string // drop filename → content
+	mdProjects map[string]int    // project name → number of .md files
+}
+
+func (f statusBacklogFixture) build(t *testing.T) (root string, cfg *ScribeConfig) {
+	t.Helper()
+	root = t.TempDir()
+
+	yaml := fmt.Sprintf("kb_name: testkb\nabsorb:\n  strictness: %s\nsync:\n  max_extract_files: %d\n",
+		f.strictness, f.maxExtract)
+	if err := os.WriteFile(filepath.Join(root, "scribe.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	projects := map[string]map[string]string{}
+
+	if len(f.drops) > 0 {
+		pdir := t.TempDir()
+		dropDir := filepath.Join(pdir, ".claude", "testkb")
+		if err := os.MkdirAll(dropDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		for name, content := range f.drops {
+			if err := os.WriteFile(filepath.Join(dropDir, name), []byte(content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+		// last_sha + last_extracted set, non-git dir → counts as done in
+		// the projects row, so drop assertions stay isolated.
+		projects["dropper"] = map[string]string{
+			"path":           pdir,
+			"domain":         "general",
+			"last_sha":       "abc123",
+			"last_extracted": "2026-01-01T00:00:00Z",
+		}
+	}
+
+	for name, n := range f.mdProjects {
+		pdir := t.TempDir()
+		for i := range n {
+			file := filepath.Join(pdir, fmt.Sprintf("doc%d.md", i))
+			if err := os.WriteFile(file, []byte("# doc\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+		// last_sha empty → "never extracted" → needs extraction without
+		// any git subprocess (gitChangedFiles falls back to findFiles).
+		projects[name] = map[string]string{"path": pdir, "domain": "general"}
+	}
+
+	scriptsDir := filepath.Join(root, "scripts")
+	if err := os.MkdirAll(scriptsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := json.Marshal(map[string]any{"projects": projects})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(scriptsDir, "projects.json"), manifest, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg = loadConfig(root)
+	cfg.CcriderDB = "" // never touch a real sessions DB from tests
+	return root, cfg
+}
+
+// TestRenderBacklogHeldSplit covers the held-by-policy vs genuinely-pending
+// split in the status backlog (issue #17): drop files held by the
+// strictness gate and projects held by the max_extract_files cap must not
+// read as work the next sync will do.
+func TestRenderBacklogHeldSplit(t *testing.T) {
+	optIn := "---\nabsorb: true\n---\nbody\n"
+	namedDomain := "---\ndomain: widgets\n---\nbody\n"
+	generalDomain := "---\ndomain: general\n---\nbody\n"
+	noFrontmatter := "just a body\n"
+
+	cases := []struct {
+		name    string
+		fixture statusBacklogFixture
+		want    []string
+	}{
+		{
+			name: "strictness high splits drops into held and pending",
+			fixture: statusBacklogFixture{
+				strictness: "high",
+				maxExtract: 100,
+				drops: map[string]string{
+					"a.md": optIn,
+					"b.md": namedDomain,
+					"c.md": generalDomain,
+					"d.md": noFrontmatter,
+				},
+			},
+			want: []string{
+				"drop files: 2 held (strictness=high — need opt-in), 2 pending",
+			},
+		},
+		{
+			name: "strictness medium leaves all drops pending",
+			fixture: statusBacklogFixture{
+				strictness: "medium",
+				maxExtract: 100,
+				drops: map[string]string{
+					"a.md": optIn,
+					"c.md": generalDomain,
+					"d.md": noFrontmatter,
+				},
+			},
+			want: []string{
+				"drop files: 3 pending",
+			},
+		},
+		{
+			name: "project over max_extract_files is held not pending",
+			fixture: statusBacklogFixture{
+				strictness: "medium",
+				maxExtract: 2,
+				mdProjects: map[string]int{"big": 3, "small": 1},
+			},
+			want: []string{
+				"projects (extract): 1 held (>max_extract_files — run `scribe deep`), 1 pending",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root, cfg := tc.fixture.build(t)
+			var buf bytes.Buffer
+			renderBacklog(&buf, root, cfg)
+			lines := normalizeLines(buf.String())
+			for _, want := range tc.want {
+				if !containsLine(lines, want) {
+					t.Errorf("backlog missing line %q\ngot:\n%s", want, buf.String())
+				}
+			}
+		})
+	}
+}
+
+// normalizeLines collapses each non-empty output line's whitespace to
+// single spaces so assertions don't encode the %-22s column padding.
+func normalizeLines(out string) []string {
+	var lines []string
+	for line := range strings.SplitSeq(out, "\n") {
+		if fields := strings.Fields(line); len(fields) > 0 {
+			lines = append(lines, strings.Join(fields, " "))
+		}
+	}
+	return lines
+}
+
+func containsLine(lines []string, want string) bool {
+	for _, l := range lines {
+		if l == want {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/scribe/stubs.go
+++ b/cmd/scribe/stubs.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -201,11 +202,11 @@ func rewriteRawArticleBody(path string, res fetchResult) error {
 	}
 	s := string(data)
 	if !strings.HasPrefix(s, "---") {
-		return fmt.Errorf("no frontmatter")
+		return errors.New("no frontmatter")
 	}
 	end := strings.Index(s[3:], "\n---")
 	if end < 0 {
-		return fmt.Errorf("no closing frontmatter")
+		return errors.New("no closing frontmatter")
 	}
 	fmBlock := s[3 : end+3]
 

--- a/cmd/scribe/sync_absorb.go
+++ b/cmd/scribe/sync_absorb.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	gosync "sync"
 	"time"
@@ -232,10 +233,10 @@ func (s *SyncCmd) absorbSinglePass(root, rawFile string) error {
 	prompt, err := loadPrompt(promptName, map[string]string{
 		"KB_DIR":         root,
 		"RAW_FILE":       rawFile,
-		"BRIEF_WORDS":    fmt.Sprintf("%d", cfg.Absorb.BriefThresholdWords),
-		"BRIEF_HEADINGS": fmt.Sprintf("%d", cfg.Absorb.BriefThresholdHeadings),
-		"DENSE_WORDS":    fmt.Sprintf("%d", cfg.Absorb.DenseThresholdWords),
-		"DENSE_HEADINGS": fmt.Sprintf("%d", cfg.Absorb.DenseThresholdHeadings),
+		"BRIEF_WORDS":    strconv.Itoa(cfg.Absorb.BriefThresholdWords),
+		"BRIEF_HEADINGS": strconv.Itoa(cfg.Absorb.BriefThresholdHeadings),
+		"DENSE_WORDS":    strconv.Itoa(cfg.Absorb.DenseThresholdWords),
+		"DENSE_HEADINGS": strconv.Itoa(cfg.Absorb.DenseThresholdHeadings),
 		"RAW_BODY":       string(rawBody),
 		"TODAY":          time.Now().UTC().Format("2006-01-02"),
 	})

--- a/cmd/scribe/sync_absorb.go
+++ b/cmd/scribe/sync_absorb.go
@@ -109,7 +109,7 @@ func (s *SyncCmd) absorbRaw(root string) (int, error) {
 		}
 
 		// Strictness gate: high = explicit opt-in required.
-		if strictness == "high" && !rawArticleOptsIntoAbsorb(rawFile) {
+		if strictnessHoldsFile(strictness, rawFile) {
 			// One summary line after the loop, not one line per file:
 			// a held backlog is steady-state under strictness=high and
 			// re-listing it (80+ identical lines on scriptorium) buried
@@ -633,6 +633,15 @@ func (e *absorbEntity) UnmarshalJSON(data []byte) error {
 	}
 	*e = absorbEntity(a)
 	return nil
+}
+
+// strictnessHoldsFile reports whether the absorb policy holds a file back
+// instead of processing it: strictness=high with no explicit opt-in in the
+// file's frontmatter. Single source of truth for the hold rule — sync's
+// absorb loop and `scribe status` both call this, so the sync-time "held N
+// back" summary and the status held count can't drift apart.
+func strictnessHoldsFile(strictness, path string) bool {
+	return strictness == "high" && !rawArticleOptsIntoAbsorb(path)
 }
 
 // rawArticleOptsIntoAbsorb returns true if a raw article's frontmatter

--- a/cmd/scribe/sync_absorb.go
+++ b/cmd/scribe/sync_absorb.go
@@ -164,7 +164,7 @@ func (s *SyncCmd) absorbRaw(root string) (int, error) {
 			if scribeExe == "" {
 				scribeExe = "scribe"
 			}
-			_, _ = runCmdErr(root, scribeExe, "lint", "--changed")
+			_, _ = runCmdErr(root, scribeExe, "lint", "--changed", "--quiet")
 		}
 	}
 

--- a/cmd/scribe/sync_discover.go
+++ b/cmd/scribe/sync_discover.go
@@ -257,6 +257,29 @@ func ensureRepoYAML(root, projectPath, pname, domain string) {
 	logMsg("sync", "   created %s", repoYAML)
 }
 
+// unprocessedDropFiles returns the drop files in a project's checkout(s)
+// that the next sync would collect: top-level *.md under .claude/<kb>/
+// in the main checkout plus recorded worktrees (drop files written in a
+// worktree can be branch-specific and never appear in the main checkout),
+// filtered to those newer than last_drop_processed. Shared by
+// collectDropFiles and `scribe status` so the status backlog counts
+// exactly the set sync will pick up.
+func unprocessedDropFiles(kb string, entry *ProjectEntry) []string {
+	var unprocessed []string
+	for _, base := range entry.collectionPaths() {
+		dropDir := filepath.Join(base, ".claude", kb)
+		if !dirExists(dropDir) {
+			continue
+		}
+		drops, err := filepath.Glob(filepath.Join(dropDir, "*.md"))
+		if err != nil || len(drops) == 0 {
+			continue
+		}
+		unprocessed = append(unprocessed, filterNewerThan(drops, entry.LastDropProcessed)...)
+	}
+	return unprocessed
+}
+
 // collectDropFiles gathers unprocessed drop files from each project's
 // .claude/<kb-name>/ dir (e.g. .claude/scribe/, or a renamed KB's own
 // folder). Returns total count of collected drops.
@@ -268,23 +291,7 @@ func (s *SyncCmd) collectDropFiles(root string, manifest *Manifest) int {
 		if !entry.IsApproved() {
 			continue
 		}
-		// Scan the main checkout plus recorded worktrees — drop files
-		// written in a worktree can be branch-specific and never appear
-		// in the main checkout.
-		var unprocessed []string
-		for _, base := range entry.collectionPaths() {
-			dropDir := filepath.Join(base, ".claude", kb)
-			if !dirExists(dropDir) {
-				continue
-			}
-			drops, err := filepath.Glob(filepath.Join(dropDir, "*.md"))
-			if err != nil || len(drops) == 0 {
-				continue
-			}
-			// Filter to unprocessed drops (newer than last_drop_processed).
-			unprocessed = append(unprocessed, filterNewerThan(drops, entry.LastDropProcessed)...)
-		}
-
+		unprocessed := unprocessedDropFiles(kb, entry)
 		if len(unprocessed) == 0 {
 			continue
 		}

--- a/cmd/scribe/sync_discover.go
+++ b/cmd/scribe/sync_discover.go
@@ -428,7 +428,7 @@ func (s *SyncCmd) collectOneResearchFile(f researchFile, destDir, domain, pname 
 
 	// Add frontmatter if missing.
 	if !strings.HasPrefix(strings.TrimSpace(content), "---") {
-		fm := fmt.Sprintf("---\ntitle: \"%s\"\nsource_path: \"%s\"\ningested_at: \"%s\"\nformat: markdown\ndomain: %s\nproject: %s\n---\n\n",
+		fm := fmt.Sprintf("---\ntitle: %q\nsource_path: %q\ningested_at: %q\nformat: markdown\ndomain: %s\nproject: %s\n---\n\n",
 			deriveResearchTitle(flatName), f.path, time.Now().UTC().Format(time.RFC3339), domain, pname)
 		content = fm + content
 	}

--- a/cmd/scribe/sync_extract.go
+++ b/cmd/scribe/sync_extract.go
@@ -17,6 +17,19 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+// extractScanPatterns is the glob set sync scans for changed files when
+// sizing an extraction. `scribe status` reuses it so its held-by-cap
+// classification counts exactly the files sync will.
+var extractScanPatterns = []string{"*.md", "*.txt", "*.exs", "*.ex"}
+
+// exceedsExtractFileCap reports whether a changed-file count trips the
+// sync.max_extract_files size gate — the rule that makes sync skip a
+// project and point at `scribe deep`. Shared by sync (skip + log) and
+// `scribe status` (held classification) so the two surfaces can't drift.
+func exceedsExtractFileCap(cfg *ScribeConfig, changedCount int) bool {
+	return cfg.Sync.MaxExtractFiles > 0 && changedCount > cfg.Sync.MaxExtractFiles
+}
+
 // extract processes projects that need extraction.
 // Projects run concurrently up to s.Parallel (default 3, capped at 5 to
 // avoid Anthropic rate limits). A rate-limit error cancels pending work
@@ -51,8 +64,7 @@ func (s *SyncCmd) extract(root string, manifest *Manifest) (int, error) {
 	if s.DryRun {
 		for _, pname := range toExtract {
 			entry := manifest.Projects[pname]
-			patterns := []string{"*.md", "*.txt", "*.exs", "*.ex"}
-			changed := gitChangedFiles(entry.Path, entry.LastSHA, patterns)
+			changed := gitChangedFiles(entry.Path, entry.LastSHA, extractScanPatterns)
 			logMsg("sync", " [%s] DRY RUN -- changed files (%d):", pname, len(changed))
 			limit := min(len(changed), 20)
 			for _, f := range changed[:limit] {
@@ -80,8 +92,7 @@ func (s *SyncCmd) extract(root string, manifest *Manifest) (int, error) {
 				return err
 			}
 
-			patterns := []string{"*.md", "*.txt", "*.exs", "*.ex"}
-			changed := gitChangedFiles(entry.Path, entry.LastSHA, patterns)
+			changed := gitChangedFiles(entry.Path, entry.LastSHA, extractScanPatterns)
 
 			// Size gate: one `claude -p` pass reliably blows the 10-min
 			// timeout above ~100 changed files. Rather than eat the
@@ -89,7 +100,7 @@ func (s *SyncCmd) extract(root string, manifest *Manifest) (int, error) {
 			// sync (where it will just fail again), skip the project in
 			// normal sync and point the user at `scribe deep <name>`,
 			// which batches-by-directory and fits in the timeout.
-			if cfg.Sync.MaxExtractFiles > 0 && len(changed) > cfg.Sync.MaxExtractFiles {
+			if exceedsExtractFileCap(cfg, len(changed)) {
 				logMsg("sync", " [%s] SKIP: %d files > sync.max_extract_files (%d). Run: scribe deep %s",
 					pname, len(changed), cfg.Sync.MaxExtractFiles, pname)
 				return nil

--- a/cmd/scribe/sync_extract.go
+++ b/cmd/scribe/sync_extract.go
@@ -156,6 +156,7 @@ func (s *SyncCmd) projectsNeedingExtraction(root string, manifest *Manifest) []s
 	var result []string
 	ledger := loadLedger(root)
 	manifestDirty := false
+	unchanged := 0
 
 	for pname, entry := range manifest.Projects {
 		// If --extract specified, only consider that project.
@@ -232,7 +233,15 @@ func (s *SyncCmd) projectsNeedingExtraction(root string, manifest *Manifest) []s
 			}
 		}
 
-		logMsg("sync", " [%s] unchanged, skipping", pname)
+		// One summary line after the loop, not one line per project: an
+		// enrolled-but-idle project is steady-state, and re-listing all
+		// of them (~20 identical lines per run on a populated KB) buried
+		// every real event in the sync log.
+		unchanged++
+	}
+
+	if unchanged > 0 {
+		logMsg("sync", "%d project(s) unchanged", unchanged)
 	}
 
 	if manifestDirty && !s.DryRun {

--- a/cmd/scribe/sync_extract.go
+++ b/cmd/scribe/sync_extract.go
@@ -353,8 +353,12 @@ func (s *SyncCmd) extractProject(root string, manifest *Manifest, pname string, 
 		}
 	}
 
-	// Post-extraction lint on changed files.
-	lintOut, _ := runCmdErr(root, scribeExe, "lint", "--changed")
+	// Post-extraction lint on changed files. --quiet keeps the
+	// mid-extract relay to per-file ERROR lines plus the one-line
+	// summary ("PASSED with N warnings") — a single noisy project was
+	// observed re-printing 300+ WARN lines into the sync log. The full
+	// grouped warning report belongs to a standalone `scribe lint` run.
+	lintOut, _ := runCmdErr(root, scribeExe, "lint", "--changed", "--quiet")
 	if lintOut != "" {
 		for line := range strings.SplitSeq(lintOut, "\n") {
 			if line != "" {

--- a/cmd/scribe/sync_extract.go
+++ b/cmd/scribe/sync_extract.go
@@ -225,12 +225,10 @@ func (s *SyncCmd) projectsNeedingExtraction(root string, manifest *Manifest) []s
 				result = append(result, pname)
 				continue
 			}
-		} else {
-			// No git: check if any .md files are newer than last extraction.
-			if s.hasNewerFiles(entry) {
-				result = append(result, pname)
-				continue
-			}
+		} else if s.hasNewerFiles(entry) {
+			// No git: any .md file newer than the last extraction counts as changed.
+			result = append(result, pname)
+			continue
 		}
 
 		// One summary line after the loop, not one line per project: an

--- a/cmd/scribe/sync_extract_test.go
+++ b/cmd/scribe/sync_extract_test.go
@@ -40,7 +40,7 @@ func TestProjectsNeedingExtractionUnchangedSummary(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			m := &Manifest{Projects: map[string]*ProjectEntry{}}
-			for i := 0; i < tc.unchanged; i++ {
+			for i := range tc.unchanged {
 				// Non-git dir, previously extracted, no .md files newer
 				// than the marker → counted as unchanged.
 				m.Projects[fmt.Sprintf("idle-%d", i)] = &ProjectEntry{
@@ -49,7 +49,7 @@ func TestProjectsNeedingExtractionUnchangedSummary(t *testing.T) {
 					LastExtracted: time.Now().UTC().Format(time.RFC3339),
 				}
 			}
-			for i := 0; i < tc.changed; i++ {
+			for i := range tc.changed {
 				// Never extracted → needs extraction.
 				m.Projects[fmt.Sprintf("busy-%d", i)] = &ProjectEntry{
 					Path: t.TempDir(),

--- a/cmd/scribe/sync_extract_test.go
+++ b/cmd/scribe/sync_extract_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+)
+
+// captureSyncLog swaps the default slog logger for one writing to a buffer,
+// so tests can assert on what logMsg emits. Restored on cleanup.
+func captureSyncLog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return &buf
+}
+
+// TestProjectsNeedingExtractionUnchangedSummary locks the collapsed
+// unchanged-skip output (issue #20): no per-project "unchanged, skipping"
+// lines, one "N project(s) unchanged" summary when anything was skipped —
+// including when ALL projects are unchanged, so cron logs still show the
+// run scanned them.
+func TestProjectsNeedingExtractionUnchangedSummary(t *testing.T) {
+	cases := []struct {
+		name        string
+		unchanged   int
+		changed     int
+		wantSummary string // "" = summary line must be absent
+	}{
+		{name: "no unchanged projects", unchanged: 0, changed: 2, wantSummary: ""},
+		{name: "some unchanged", unchanged: 2, changed: 1, wantSummary: "2 project(s) unchanged"},
+		{name: "all unchanged", unchanged: 3, changed: 0, wantSummary: "3 project(s) unchanged"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &Manifest{Projects: map[string]*ProjectEntry{}}
+			for i := 0; i < tc.unchanged; i++ {
+				// Non-git dir, previously extracted, no .md files newer
+				// than the marker → counted as unchanged.
+				m.Projects[fmt.Sprintf("idle-%d", i)] = &ProjectEntry{
+					Path:          t.TempDir(),
+					LastSHA:       "deadbeef",
+					LastExtracted: time.Now().UTC().Format(time.RFC3339),
+				}
+			}
+			for i := 0; i < tc.changed; i++ {
+				// Never extracted → needs extraction.
+				m.Projects[fmt.Sprintf("busy-%d", i)] = &ProjectEntry{
+					Path: t.TempDir(),
+				}
+			}
+
+			buf := captureSyncLog(t)
+			s := &SyncCmd{}
+			got := s.projectsNeedingExtraction(t.TempDir(), m)
+
+			if len(got) != tc.changed {
+				t.Errorf("projectsNeedingExtraction returned %v, want %d project(s)", got, tc.changed)
+			}
+
+			out := buf.String()
+			if strings.Contains(out, "unchanged, skipping") {
+				t.Errorf("per-project unchanged-skip line should be collapsed, got:\n%s", out)
+			}
+			if tc.wantSummary == "" {
+				if strings.Contains(out, "unchanged") {
+					t.Errorf("no summary expected with 0 unchanged projects, got:\n%s", out)
+				}
+				return
+			}
+			if !strings.Contains(out, tc.wantSummary) {
+				t.Errorf("summary %q missing from output:\n%s", tc.wantSummary, out)
+			}
+		})
+	}
+}

--- a/cmd/scribe/sync_sessions.go
+++ b/cmd/scribe/sync_sessions.go
@@ -255,6 +255,11 @@ func queryRelatedSessions(dbPath, sessionID string, daysWindow, limit int) []rel
 			out = append(out, rs)
 		}
 	}
+	if rows.Err() != nil {
+		// Best-effort contract: a truncated iteration means the related
+		// list can't be trusted — drop it rather than hint from partials.
+		return nil
+	}
 	return out
 }
 

--- a/cmd/scribe/sync_sessions.go
+++ b/cmd/scribe/sync_sessions.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	gosync "sync"
 	"time"
@@ -287,7 +288,7 @@ func (s *SyncCmd) triageSessionIDs(top int, extraArgs ...string) []string {
 		scribeExe = "scribe"
 	}
 	args := make([]string, 0, 6+len(extraArgs))
-	args = append(args, "triage", "--ids", "--top", fmt.Sprintf("%d", top), "--sort", s.SessionSort)
+	args = append(args, "triage", "--ids", "--top", strconv.Itoa(top), "--sort", s.SessionSort)
 	args = append(args, extraArgs...)
 	idsOutput, err := runCmdErr("", scribeExe, args...)
 	if err != nil {
@@ -565,7 +566,7 @@ func (s *SyncCmd) mineSessions(root string) (int, error) {
 		if scribeExe == "" {
 			scribeExe = "scribe"
 		}
-		out, _ := runCmdErr("", scribeExe, "triage", "--top", fmt.Sprintf("%d", s.SessionsMax), "--sort", s.SessionSort)
+		out, _ := runCmdErr("", scribeExe, "triage", "--top", strconv.Itoa(s.SessionsMax), "--sort", s.SessionSort)
 		if out != "" {
 			fmt.Println(out)
 		}

--- a/cmd/scribe/team_integration_test.go
+++ b/cmd/scribe/team_integration_test.go
@@ -146,9 +146,7 @@ func scaffoldTeamKB(t *testing.T, root, kbName, lockDir string) {
 // --sessions, no discoverable projects → discover/extract/mining are no-ops).
 func runSyncIn(t *testing.T, kb string) {
 	t.Helper()
-	if err := os.Setenv("SCRIBE_KB", kb); err != nil {
-		t.Fatal(err)
-	}
+	t.Setenv("SCRIBE_KB", kb)
 	s := &SyncCmd{Max: 3, Parallel: 1, Model: "sonnet", SessionsMax: 3, SessionSort: "score"}
 	if err := s.Run(); err != nil {
 		t.Fatalf("sync %s: %v", kb, err)
@@ -207,7 +205,7 @@ func TestTeamWorkflow_EndToEnd(t *testing.T) {
 	// writeDigestFile regenerates from *committed* history, and ratelimit.md
 	// is only committed later in this same sync — so it surfaces in Alice's
 	// activity on the next sync (asserted after the secret-gate sync below).
-	if !fileExists(filepath.Join(alice, "wiki/_digest.md")) {
+	if !fileExists(filepath.Join(alice, "wiki", "_digest.md")) {
 		t.Error("team digest wiki/_digest.md not generated")
 	}
 
@@ -244,10 +242,10 @@ func TestTeamWorkflow_EndToEnd(t *testing.T) {
 		!strings.Contains(sub, "Alice") {
 		t.Errorf("subscription did not surface the backend article by Alice; logs:\n%s", sub)
 	}
-	if !fileExists(filepath.Join(bob, "wiki/patterns/ratelimit.md")) {
+	if !fileExists(filepath.Join(bob, "wiki", "patterns", "ratelimit.md")) {
 		t.Error("bob did not pull the published article")
 	}
-	if fileExists(filepath.Join(bob, "wiki/patterns/leak.md")) {
+	if fileExists(filepath.Join(bob, "wiki", "patterns", "leak.md")) {
 		t.Error("held credential file leaked to the remote and reached bob")
 	}
 }
@@ -296,7 +294,7 @@ func TestTeamConflict_DigestAutoResolves(t *testing.T) {
 	if rebaseInProgress(bob) {
 		t.Error("rebase left mid-flight after auto-resolve")
 	}
-	if !fileExists(filepath.Join(bob, "wiki/_digest.md")) {
+	if !fileExists(filepath.Join(bob, "wiki", "_digest.md")) {
 		t.Error("digest missing after auto-resolve (should regenerate)")
 	}
 }

--- a/cmd/scribe/testdata/ccrider_schema.sql
+++ b/cmd/scribe/testdata/ccrider_schema.sql
@@ -1,0 +1,36 @@
+-- Minimal ccrider sessions.db fixture schema for tests.
+-- Mirrors only the columns scribe actually queries (sessions.go,
+-- sync_sessions.go, hook.go, triage.go). Never point tests at the real
+-- ~/.config/ccrider/sessions.db.
+CREATE TABLE sessions (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id    TEXT UNIQUE,
+    project_path  TEXT,
+    message_count INTEGER DEFAULT 0,
+    created_at    TEXT,
+    updated_at    TEXT,
+    summary       TEXT,
+    llm_summary   TEXT
+);
+
+CREATE TABLE messages (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id   INTEGER REFERENCES sessions(id),
+    type         TEXT,
+    text_content TEXT
+);
+
+-- External-content FTS5 tables; tests insert rows manually with
+-- INSERT INTO messages_fts(rowid, text_content) so the rowid matches
+-- messages.id, the join key scribe's queries rely on.
+CREATE VIRTUAL TABLE messages_fts USING fts5(
+    text_content,
+    content='messages',
+    content_rowid='id'
+);
+
+CREATE VIRTUAL TABLE messages_fts_code USING fts5(
+    text_content,
+    content='messages',
+    content_rowid='id'
+);

--- a/cmd/scribe/tier.go
+++ b/cmd/scribe/tier.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -201,7 +202,7 @@ func (l *TierListCmd) Run() error {
 		return err
 	}
 	if l.Tier != "" && !validIndexTiers[l.Tier] {
-		return fmt.Errorf("--tier must be one of: stub, brief, standard, deep, reference")
+		return errors.New("--tier must be one of: stub, brief, standard, deep, reference")
 	}
 	counts := map[string]int{}
 	err = walkArticles(root, func(path string, content []byte) error {
@@ -321,7 +322,7 @@ type TierWriteCmd struct {
 
 func (w *TierWriteCmd) Run() error {
 	if !w.All && !w.MissingOnly {
-		return fmt.Errorf("pick one: --all (rewrite every article) or --missing-only (only articles without a stored tier)")
+		return errors.New("pick one: --all (rewrite every article) or --missing-only (only articles without a stored tier)")
 	}
 	root, err := kbDir()
 	if err != nil {
@@ -390,11 +391,11 @@ func updateFrontmatterField(path, key, value string) error {
 	}
 	s := string(data)
 	if !strings.HasPrefix(s, "---") {
-		return fmt.Errorf("no frontmatter delimiter")
+		return errors.New("no frontmatter delimiter")
 	}
 	end := strings.Index(s[3:], "\n---")
 	if end < 0 {
-		return fmt.Errorf("no closing frontmatter delimiter")
+		return errors.New("no closing frontmatter delimiter")
 	}
 	fmBlock := s[3 : end+3]
 	rest := s[end+7:] // skip `\n---\n`

--- a/cmd/scribe/toc_sidecar.go
+++ b/cmd/scribe/toc_sidecar.go
@@ -11,7 +11,7 @@ import (
 // TOCSidecar is the schema we write to raw/articles/<slug>.toc.json
 // when a long PDF gets ingested through marker. Its job is to give
 // the absorb chunker (Phase 3A.5) deterministic semantic boundaries:
-// "split this 73-page paper here, here, and here." qmd indexes the
+// "split this 73-page paper at exactly these points." qmd indexes the
 // full markdown; the wiki absorb pass produces summaries; this
 // sidecar tells those steps where the chapter boundaries are.
 //

--- a/cmd/scribe/triage.go
+++ b/cmd/scribe/triage.go
@@ -169,7 +169,7 @@ func (t *TriageCmd) runScoring(db *sql.DB, _ string, excludeIDs []string) error 
 		ctes, homeProjects, scoreExpr, selectCols, anyHitExpr,
 		excludeClause, kbExcludeClause, projectClause, t.messageLimitClause(), t.orderClause(), t.Top)
 
-	rows, err := db.Query(query) //nolint:noctx,gosec // G701: scribe-owned SQL; CLI top-level
+	rows, err := db.Query(query) //nolint:noctx // CLI top-level, no ctx in scope
 	if err != nil {
 		return fmt.Errorf("scoring query: %w", err)
 	}

--- a/cmd/scribe/triage.go
+++ b/cmd/scribe/triage.go
@@ -118,6 +118,9 @@ func (t *TriageCmd) runStats(db *sql.DB, excludeIDs []string) error {
 		}
 		fmt.Printf("%-25s %8d %10d %8.1f\n", bucket, sessions, totalMsgs, avgHits)
 	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate stats rows: %w", err)
+	}
 	return nil
 }
 
@@ -203,6 +206,9 @@ func (t *TriageCmd) runScoring(db *sql.DB, _ string, excludeIDs []string) error 
 		r.Hours = hours.Float64
 		r.Summary = summary.String
 		results = append(results, r)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate scoring rows: %w", err)
 	}
 
 	if t.Interactive {

--- a/cmd/scribe/triage.go
+++ b/cmd/scribe/triage.go
@@ -215,7 +215,7 @@ func (t *TriageCmd) runScoring(db *sql.DB, _ string, excludeIDs []string) error 
 		// Build fzf input: "session_id\tscore\tproject\tmsgs\tdate\tsummary"
 		// fzf displays columns 2.., preview runs `ccrider show {1}` against col 1.
 		if _, err := exec.LookPath("fzf"); err != nil {
-			return fmt.Errorf("fzf not installed — install via `brew install fzf`")
+			return errors.New("fzf not installed — install via `brew install fzf`")
 		}
 		var buf strings.Builder
 		for _, r := range results {

--- a/cmd/scribe/validate.go
+++ b/cmd/scribe/validate.go
@@ -155,7 +155,7 @@ func validateFile(root, path string) []string {
 	}
 	if len(missing) > 0 {
 		sort.Strings(missing)
-		errs = append(errs, fmt.Sprintf("missing required fields: %s", strings.Join(missing, ", ")))
+		errs = append(errs, "missing required fields: "+strings.Join(missing, ", "))
 	}
 
 	// Validate type

--- a/cmd/scribe/view.go
+++ b/cmd/scribe/view.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/csv"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -119,11 +120,11 @@ func validateFilterNode(n FilterNode) error {
 	hasContainer := len(n.And) > 0 || len(n.Or) > 0 || n.Not != nil
 	hasLeaf := n.Field != "" || n.Op != "" || n.Value != nil
 	if hasContainer && hasLeaf {
-		return fmt.Errorf("node mixes container (and/or/not) with leaf (field/op/value)")
+		return errors.New("node mixes container (and/or/not) with leaf (field/op/value)")
 	}
 	if hasLeaf {
 		if n.Field == "" || n.Op == "" {
-			return fmt.Errorf("leaf node missing field or op")
+			return errors.New("leaf node missing field or op")
 		}
 		switch n.Op {
 		case OpEq, OpNe, OpLt, OpLe, OpGt, OpGe, OpIn, OpHas, OpContain:
@@ -487,7 +488,7 @@ func (c *ViewCmd) Run() error {
 		return listViews(root)
 	}
 	if c.Name == "" {
-		return fmt.Errorf("usage: scribe view <name> | scribe view --list")
+		return errors.New("usage: scribe view <name> | scribe view --list")
 	}
 	path := resolveViewPath(root, c.Name)
 	vf, err := loadViewFile(path)

--- a/cmd/scribe/watch.go
+++ b/cmd/scribe/watch.go
@@ -190,6 +190,10 @@ func (w *WatchCmd) scan(root, dbPath string) {
 		}
 		candidates = append(candidates, c)
 	}
+	if err := rows.Err(); err != nil {
+		logMsg("watch", "iterate sessions: %v", err)
+		return
+	}
 	rows.Close()
 
 	if len(candidates) == 0 {

--- a/cmd/scribe/wiki_actions.go
+++ b/cmd/scribe/wiki_actions.go
@@ -327,7 +327,7 @@ func entityWriterApplyOptions() ApplyOptions {
 func applyWikiActions(root string, env WikiActionEnvelope, opts ApplyOptions) (ApplyResult, error) {
 	res := ApplyResult{}
 	if root == "" {
-		return res, fmt.Errorf("apply wiki actions: empty root")
+		return res, errors.New("apply wiki actions: empty root")
 	}
 	// Content robustness seam — runs before the action loop so it sits
 	// at the same centralized boundary as the path guards
@@ -637,7 +637,7 @@ func metaActionLabel(m MetaAction) string {
 func applyMetaLogAppend(root string, m MetaAction, opts ApplyOptions) error {
 	line := strings.ReplaceAll(strings.TrimRight(m.Line, "\r\n"), "\n", " ")
 	if line == "" {
-		return fmt.Errorf("log_append: empty line")
+		return errors.New("log_append: empty line")
 	}
 	if opts.DryRun {
 		return nil
@@ -661,7 +661,7 @@ func applyMetaLogAppend(root string, m MetaAction, opts ApplyOptions) error {
 // goroutines stomping each other's JSON edits.
 func applyMetaSessionsLogAppend(root string, m MetaAction, opts ApplyOptions) error {
 	if m.SessionID == "" {
-		return fmt.Errorf("sessions_log_append: session_id required")
+		return errors.New("sessions_log_append: session_id required")
 	}
 	if opts.DryRun {
 		return nil
@@ -702,10 +702,10 @@ func applyMetaSessionsLogAppend(root string, m MetaAction, opts ApplyOptions) er
 // the lock.
 func applyMetaRollingAppend(root string, m MetaAction, opts ApplyOptions) error {
 	if m.Domain == "" {
-		return fmt.Errorf("rolling_memory_append: domain required")
+		return errors.New("rolling_memory_append: domain required")
 	}
 	if m.Target == "" {
-		return fmt.Errorf("rolling_memory_append: target required")
+		return errors.New("rolling_memory_append: target required")
 	}
 	allowedTargets := allowedRollingTargetsForRoot(root)
 	if !allowedTargets[m.Target] {
@@ -720,7 +720,7 @@ func applyMetaRollingAppend(root string, m MetaAction, opts ApplyOptions) error 
 	}
 	content := strings.TrimRight(m.Content, "\n")
 	if content == "" {
-		return fmt.Errorf("rolling_memory_append: empty content")
+		return errors.New("rolling_memory_append: empty content")
 	}
 	if opts.DryRun {
 		return nil
@@ -803,10 +803,10 @@ var (
 // the symlink in their KB and has accepted that trust boundary.
 func validateActionPath(root, rel string) (string, error) {
 	if rel == "" {
-		return "", fmt.Errorf("empty path")
+		return "", errors.New("empty path")
 	}
 	if filepath.IsAbs(rel) {
-		return "", fmt.Errorf("absolute paths refused (must be relative to KB root)")
+		return "", errors.New("absolute paths refused (must be relative to KB root)")
 	}
 	cleaned := filepath.Clean(rel)
 	// Reject explicit traversal. filepath.Clean turns "a/../b" into
@@ -1418,7 +1418,7 @@ func parseEnvelope(jsonText string) (WikiActionEnvelope, error) {
 		return env, fmt.Errorf("unmarshal envelope: %w", err)
 	}
 	if len(env.Actions) == 0 {
-		return env, fmt.Errorf("envelope has no actions")
+		return env, errors.New("envelope has no actions")
 	}
 	for i, a := range env.Actions {
 		if a.Op == "" {

--- a/cmd/scribe/wiki_actions_fuzz_test.go
+++ b/cmd/scribe/wiki_actions_fuzz_test.go
@@ -216,7 +216,7 @@ func FuzzNormalizeRelatedFrontmatter(f *testing.F) {
 		if want := relIdx + 1 + (len(lines) - end); len(outLines) != want {
 			t.Fatalf("unexpected output shape: got %d lines, want %d\nin:  %q\nout: %q", len(outLines), want, content, out)
 		}
-		for i := 0; i < relIdx; i++ {
+		for i := range relIdx {
 			if outLines[i] != lines[i] {
 				t.Fatalf("prefix line %d mutated: %q -> %q", i, lines[i], outLines[i])
 			}

--- a/cmd/scribe/wiki_actions_test.go
+++ b/cmd/scribe/wiki_actions_test.go
@@ -916,7 +916,7 @@ func TestApplyWikiActions_ClampFrontmatter(t *testing.T) {
 		if len(res.Applied) != 0 {
 			t.Errorf("unparseable action must not be applied, got: %v", res.Applied)
 		}
-		if _, statErr := os.Stat(filepath.Join(root, "decisions/broken.md")); statErr == nil {
+		if _, statErr := os.Stat(filepath.Join(root, "decisions", "broken.md")); statErr == nil {
 			t.Error("broken frontmatter was written to disk; clamp must drop it")
 		}
 	})
@@ -1065,7 +1065,7 @@ func TestApplyWikiActions_SanitizeContentEnablesRemap(t *testing.T) {
 	if len(res.Errors) != 0 {
 		t.Fatalf("invented top dir must be remapped, not rejected: %v", res.Errors)
 	}
-	if _, statErr := os.Stat(filepath.Join(root, "wiki/debugging/plugin-activation-caveat.md")); statErr != nil {
+	if _, statErr := os.Stat(filepath.Join(root, "wiki", "debugging", "plugin-activation-caveat.md")); statErr != nil {
 		t.Errorf("entity not re-homed under wiki/: %v", statErr)
 	}
 }

--- a/cmd/scribe/write.go
+++ b/cmd/scribe/write.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -53,7 +54,7 @@ func (w *WriteCmd) Run() error {
 	}
 
 	if w.Title == "" {
-		return fmt.Errorf("--title is required")
+		return errors.New("--title is required")
 	}
 
 	body, err := w.readBody()
@@ -74,14 +75,14 @@ func (w *WriteCmd) Run() error {
 // runCreate writes a brand-new article with full frontmatter.
 func (w *WriteCmd) runCreate(root, body string) error {
 	if w.Type == "" {
-		return fmt.Errorf("--type is required (or use --rolling for rolling memory)")
+		return errors.New("--type is required (or use --rolling for rolling memory)")
 	}
 	dir, ok := typeDirs[w.Type]
 	if !ok {
 		return fmt.Errorf("invalid --type %q (must be one of: decision, research, solution, tool, pattern, person, project)", w.Type)
 	}
 	if w.Domain == "" {
-		return fmt.Errorf("--domain is required")
+		return errors.New("--domain is required")
 	}
 	if !validDomainsForRoot(root)[w.Domain] {
 		return fmt.Errorf("invalid --domain %q", w.Domain)
@@ -138,7 +139,7 @@ func (w *WriteCmd) runCreate(root, body string) error {
 // tags list) that should be authored deliberately.
 func (w *WriteCmd) runRolling(root, body string) error {
 	if w.Project == "" {
-		return fmt.Errorf("--project is required for --rolling mode")
+		return errors.New("--project is required for --rolling mode")
 	}
 	var filename string
 	switch w.Rolling {
@@ -192,11 +193,11 @@ func (w *WriteCmd) runRolling(root, body string) error {
 // convention.
 func insertAfterFrontmatter(content, entry string) (string, error) {
 	if !strings.HasPrefix(content, "---\n") {
-		return "", fmt.Errorf("no frontmatter found")
+		return "", errors.New("no frontmatter found")
 	}
 	end := strings.Index(content[4:], "\n---\n")
 	if end < 0 {
-		return "", fmt.Errorf("no closing frontmatter delimiter")
+		return "", errors.New("no closing frontmatter delimiter")
 	}
 	splitAt := 4 + end + len("\n---\n")
 	head := content[:splitAt]

--- a/cmd/scribe/write.go
+++ b/cmd/scribe/write.go
@@ -90,11 +90,12 @@ func (w *WriteCmd) runCreate(root, body string) error {
 	// Build target path. Projects live at projects/{slug}/overview.md,
 	// everything else at {dir}/{slug}.md.
 	var rel string
-	if w.Path != "" {
+	switch {
+	case w.Path != "":
 		rel = w.Path
-	} else if w.Type == "project" {
+	case w.Type == "project":
 		rel = filepath.Join(dir, slugify(w.Title), "overview.md")
-	} else {
+	default:
 		rel = filepath.Join(dir, slugify(w.Title)+".md")
 	}
 	target := filepath.Join(root, rel)


### PR DESCRIPTION
## Why

Deleting the old base branch auto-closed a batch of PRs that had **not** been merged into `main`. Their head branches survived on `origin` (backup-safe), but the work was missing from `main`. This relands all of it, patch-equivalent, with the conflicts and analyzer drift reconciled against current `main`.

Verified each branch against `main` with `git cherry` (patch-id) so only genuinely-missing commits were replayed — the large shared prefix already in `main` was skipped.

## What's relanded (in dependency order)

**Features #35–#39** (5 commits, clean cherry-picks except #37):
- `feat(lint): group warnings by class; sync relays errors only` (#35)
- `feat(help): group root subcommands into titled --help sections` (#36)
- `feat(status): split held-by-policy from genuinely-pending backlog` (#37) — conflict resolved: kept both `absorbEntity.UnmarshalJSON` (main) and `strictnessHoldsFile` (#37)
- `build(make): split build from deploy` (#38)
- `feat(sync): collapse per-project unchanged-skip lines into one summary` (#39)

**Coverage tests #34** (6 commits + 1 reconcile):
- Structural lint / identities / sessions / graph / capture / estimate coverage.
- `test(reland): reconcile #34 coverage tests with #35 report API + depth-floor guard` — #34's lint tests predate #35's `*lintReport` refactor (functions no longer return counts); `TestPreFilterSessions` used a 2-segment project path that `isIgnored`'s ≥4-segment depth floor now rejects.

**Lint-ratchet #32** (13 commits + 1 reconcile):
- Enables gocritic, intrange, perfsprint, errchkjson, usestdlibvars, usetesting, wastedassign, nolintlint, rowserrcheck/sqlclosecheck and the zero-hit bug-class set.
- `fix(lint): apply ratchet to code merged from sibling reland branches` — the newly-enabled analyzers flagged the relanded feature/coverage code and the dependabot dep bumps that the ratchet branch never saw; same mechanical fixes the ratchet applied to its contemporaneous tree (mirrors the original `565aea5`, wider sibling set).

## Verification

- `go build -tags sqlite_fts5` ✓
- `go vet` ✓
- `golangci-lint run` → **0 issues** (full ratchet config)
- `go test -tags sqlite_fts5 ./...` → all pass
- pre-push `test-race` → no data races

Closes #32, #34, #35, #36, #37, #38, #39 (relands work originally proposed there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)