### PR TITLE
docs: changelog + readme for relanded features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,48 @@ spend is legible and reconciles with the provider's own dashboard.
   ledger; `scribe cost` rows sort by the dollar figure they actually display
   and the table renderer tolerates ragged rows.
 
+### Added — output & CLI ergonomics (#15, #16, #17)
+- `scribe lint` groups warnings by class in the default view — e.g.
+  `412× index_tier missing  (run: scribe tier write --missing-only)` — instead
+  of a flat per-file stream that buried real signal under hundreds of identical
+  lines. `--verbose`/`-v` restores the per-file lines; `--quiet`/`-q` (used by
+  `sync` mid-extract) prints only per-file ERRORs plus the verdict. Errors stay
+  per-file in every mode. (#15)
+- `scribe --help` groups the 60+ subcommands into titled sections — Core,
+  Content, Quality, Team, System, Debug — via Kong `group:` tags, with a
+  regression test that fails if a new command lands ungrouped. (#16)
+- `scribe status` separates the backlog **held by policy** (strictness=high with
+  no absorb opt-in, or projects over `sync.max_extract_files`) from genuinely
+  **pending** work, so a steady-state held backlog no longer reads as actionable.
+  (#17)
+
+### Changed — build/deploy split & quieter discovery (#18, #20)
+- `make build` now compiles only to the repo-local `./bin/scribe` and never
+  touches `~/.local/bin`; the deploy moved to a separate `make install`. On
+  macOS this stops a routine rebuild from invalidating the chat.db Full Disk
+  Access grant — only `install` replaces the live binary (and reminds you to
+  re-run `scribe fda`). (#18)
+- `sync --discover` collapses the per-project "unchanged, skipping" lines into a
+  single summary instead of one line per project, so the cron log surfaces real
+  activity. (#20)
+
+### Internal — lint ratchet, coverage, dependencies
+- The lint ratchet enables 17+ more golangci-lint analyzers (gocritic, intrange,
+  perfsprint, errchkjson, usestdlibvars, usetesting, wastedassign,
+  rowserrcheck/sqlclosecheck, …) and fixes every hit; `nolintlint` now requires
+  each `//nolint` to name its linter and a reason. (#32)
+- Substantially expanded `cmd/scribe` test coverage — structural lint phases,
+  identity proposals, session-log repair/pre-filter, graph subcommands, capture
+  I/O, cost estimation and retry policy. (#34)
+- Dependency bumps: `go-sqlite3` 1.14.47, `html-to-markdown` 2.5.2, plus CI
+  actions (`actions/checkout`, `actions/setup-go`, `golangci-lint-action`, …)
+  via Dependabot (#44–#49).
+
+> Note: features #15–#18 and #20 above were originally developed before the
+> hosted-provider work but were accidentally closed unmerged when a base branch
+> was deleted; they were relanded (patch-equivalent, reconciled against current
+> `main`) via #50.
+
 ## [0.2.29] — 2026-06-03
 
 Harden the shared LLM-action executor against the failure class behind a real

--- a/README.md
+++ b/README.md
@@ -614,9 +614,9 @@ scribe capture      # pull links you iMessaged to yourself as bookmarks (macOS o
 scribe ingest url <url> --absorb   # queue-less ingest + contextualize + absorb
 scribe absorb <file>         # absorb a local file (md/txt/html) end-to-end
 scribe contextualize --scope raw|wiki|all   # insert retrieval-context paragraphs
-scribe status       # one-shot KB scoreboard (raw/wiki/ollama/last-sync)
+scribe status       # one-shot KB scoreboard (raw/wiki/backlog) — splits held-by-policy from genuinely-pending
 scribe dream        # weekly memory consolidation (4-phase)
-scribe lint         # frontmatter + size + orphan checks
+scribe lint         # frontmatter + size + orphan checks (warnings grouped by class; -v per-file, -q errors-only)
 scribe lint --contradictions # LLM pass for factual disagreements across articles
 scribe link         # link orphan articles to contextual hosts via See Also sections
 scribe watch        # long-running fsnotify watcher on ccrider DB (near-real-time session extraction)
@@ -632,6 +632,8 @@ scribe skill {install,list}                 # embedded scribe-kb agent skill bun
 scribe install-tools         # bootstrap optional tools (uv + marker-pdf) for full PDF/DOCX/PPTX/XLSX/EPUB ingestion
 scribe doctor       # deps + config + cron + freshness + errors + localmode + vault + stale + contradictions
 scribe fda          # macOS Full Disk Access probe + interactive grant flow
+scribe kb {add,list,remove}  # machine-level KB registry the scheduler iterates
+scribe each -- <subcommand>  # run a subcommand in every registered KB (cron uses this)
 scribe cron {install,status,uninstall}
 ```
 


### PR DESCRIPTION
Documents the features that landed via #50 but weren't yet reflected in the docs.

## CHANGELOG `[Unreleased]`
- **#15** lint groups warnings by class + `-v`/`-q`
- **#16** `--help` command groups (Core/Content/Quality/Team/System/Debug)
- **#17** `status` splits held-by-policy from genuinely-pending backlog
- **#18** `make build` no longer deploys (split from `make install`)
- **#20** `sync --discover` collapses unchanged-skip lines into one summary
- **#32** lint ratchet (17+ analyzers, nolintlint reasons)
- **#34** coverage expansion
- Dependabot bumps (#44–#49)
- A note explaining #15–#18/#20 were relanded via #50 after the base-branch deletion

## README
- Adds the missing `scribe kb {add,list,remove}` and `scribe each -- <sub>` registry/scheduler commands to the command reference
- Notes lint grouping + `-v`/`-q` and the `status` held-vs-pending split

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)