### PR TITLE
feat(pull): Pinboard pull-adapter framework with scope + tag filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,13 @@ stars…) is a small file against the same `Source` interface.
 - **Config** in `scribe.yaml` under `integrations.pinboard`:
   - `scope: recent+unread | unread | all` — selects bookmarks by
     read-state/recency (`recent+unread` is the default).
-  - `tags: []` — an **OR filter**: only ingest bookmarks carrying at least one
-    of these tags (case-insensitive); empty ingests everything the scope
-    returns. Composes with `scope` (e.g. `scope: all` + `tags: [kb]`).
+  - `tags: []` — tag filter (case-insensitive); empty ingests everything the
+    scope returns. Composes with `scope` (e.g. `scope: all` + `tags: [kb]`).
+  - `tags_mode: any | all` — how multiple tags combine: `any` (default) keeps
+    bookmarks carrying at least one listed tag (the ingest-gate shape), `all`
+    requires every listed tag — the narrowing semantics of Pinboard's own
+    `/t:a/t:b/` URL filtering. Unknown values fail loudly instead of silently
+    widening the filter.
   - `public_only: false` — an authenticated pull sees private bookmarks too;
     set `true` (or pass `--public-only`) to skip them, so private links don't
     reach a KB that might be shared or promoted.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ stars…) is a small file against the same `Source` interface.
   - `tags: []` — an **OR filter**: only ingest bookmarks carrying at least one
     of these tags (case-insensitive); empty ingests everything the scope
     returns. Composes with `scope` (e.g. `scope: all` + `tags: [kb]`).
+  - `public_only: false` — an authenticated pull sees private bookmarks too;
+    set `true` (or pass `--public-only`) to skip them, so private links don't
+    reach a KB that might be shared or promoted.
   - `skip_domains: []` — substring URL filter, same as `capture.skip_domains`.
 - **Token** is a secret: `integration_tokens.pinboard` in
   `~/.config/scribe/config.yaml` or `SCRIBE_PINBOARD_TOKEN` — never the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,29 @@ stars…) is a small file against the same `Source` interface.
   tags (plus a `pinboard` provenance tag, and `to-read` for unread) carry into
   frontmatter. Zero new Go dependencies (Pinboard v1 is JSON over HTTPS).
 
+Four hardening fixes landed in review, all with regression tests:
+
+- **API tokens can no longer reach a log, a run record, or the terminal.** Go
+  builds transport failures as `*url.Error` and strips only *userinfo*
+  passwords — query parameters survive, so a plain DNS failure rendered
+  `auth_token=user:HEX` verbatim into `output/runs/*.jsonl`,
+  `/tmp/scribe-pull.log`, and `scribe doctor --section errors`. The adapter now
+  redacts every error leaving it (and flattens the chain, so the raw URL is not
+  reachable via `errors.Unwrap`), `writeRunRecord` redacts error text the same
+  way it already redacted args, and the redaction pattern now actually matches
+  prefixed parameter names like `auth_token`.
+- **A bookmark title can no longer forge a queue entry.** The `output/inbox/`
+  format is one `key: value` per line, and titles are remote-controlled
+  (Pinboard's bookmarklet fills them from the page's own `<title>`), so a
+  newline let a page inject its own `url:` line and redirect what `ingest
+  drain` fetched. Single-line fields are now flattened when written, and
+  `parseQueueEntry` takes the first occurrence of a key rather than the last.
+- **Cross-host redirects are refused** while the token rides in the query
+  string; same-host redirects still follow.
+- **Pull state is checkpointed every 25 queued items**, so an interrupted
+  `--all-history` backfill resumes instead of re-queuing everything it already
+  wrote. The cursor still advances only on a complete pass.
+
 ### Fixed
 - `scribe init --check` no longer prompts for scaffold values, preserving its
   documented read-only, non-interactive contract.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to scribe are documented here. Format follows [Keep a Change
 
 ## [Unreleased]
 
+### Added — pull adapters (`scribe pull`), starting with Pinboard
+
+A generic **pull-adapter framework** for ingesting bookmarks from external
+accounts into the KB, and **Pinboard** (<https://pinboard.in>) as its first
+adapter. Adapters are URL producers only: they queue bookmarks into
+`output/inbox/`, and the existing `ingest drain` path fetches →
+contextualizes → absorbs them. Deterministic and fast — no LLM, no page
+fetching in `pull` itself — so the next source (Raindrop, Instapaper, GitHub
+stars…) is a small file against the same `Source` interface.
+
+- **`scribe pull [source]`** — pull one integration or, bare, every configured
+  one (what the new hourly `pull-sources` cron job runs). Flags: `--list`
+  (status of each integration), `--scope`, `--tag` (repeatable), `--all-history`
+  (one-shot full backfill), `--max` (pace a big backfill), `--force`, `-n`
+  (dry-run).
+- **Config** in `scribe.yaml` under `integrations.pinboard`:
+  - `scope: recent+unread | unread | all` — selects bookmarks by
+    read-state/recency (`recent+unread` is the default).
+  - `tags: []` — an **OR filter**: only ingest bookmarks carrying at least one
+    of these tags (case-insensitive); empty ingests everything the scope
+    returns. Composes with `scope` (e.g. `scope: all` + `tags: [kb]`).
+  - `skip_domains: []` — substring URL filter, same as `capture.skip_domains`.
+- **Token** is a secret: `integration_tokens.pinboard` in
+  `~/.config/scribe/config.yaml` or `SCRIBE_PINBOARD_TOKEN` — never the
+  committed `scribe.yaml`. Env wins over the file (same rule as `llm_api_keys`).
+- **Rate-limit friendly:** a cheap `posts/update` probe short-circuits a run
+  when nothing changed before touching `posts/all`/`posts/recent`; per-source
+  state (cursor + seen-set) lives in `output/sources/<name>.json` (gitignored).
+- **Team KBs:** integrations are a personal source — hard-off from the repo
+  `scribe.yaml` like capture, re-enabled per-person in `scribe.local.yaml`, and
+  trust-locked in the config-trust layer.
+- Bookmark `extended` notes are preserved into the article body, and Pinboard
+  tags (plus a `pinboard` provenance tag, and `to-read` for unread) carry into
+  frontmatter. Zero new Go dependencies (Pinboard v1 is JSON over HTTPS).
+
 ### Fixed
 - `scribe init --check` no longer prompts for scaffold values, preserving its
   documented read-only, non-interactive contract.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,8 +68,10 @@ make check        # test + vet
 | Codex handshake block       | `~/.codex/AGENTS.md`                         | same markers/block as the Claude one; written by `init` so Codex CLI sessions query the KB + write drop files |
 | Amp handshake block         | `~/.config/amp/AGENTS.md`                    | same markers/block; `$HOME`-relative on purpose (Amp documents that path, XDG would miss it). Amp *also* reads `~/.config/AGENTS.md` + project-root `AGENTS.md` — scribe manages neither |
 | iMessage chat DB            | `~/Library/Messages/chat.db`                | needs Full Disk Access            |
-| scribe user config          | `~/.config/scribe/config.yaml`              | global defaults                   |
+| scribe user config          | `~/.config/scribe/config.yaml`              | global defaults; `integration_tokens.<name>` holds pull-adapter API tokens (never in a KB's scribe.yaml) |
 | pending sessions queue      | `~/.config/scribe/pending-sessions.txt`     | drained by `sync --sessions`      |
+| pull-adapter state          | `$KB/output/sources/<name>.json`            | per-source cursor + seen set for `scribe pull` (gitignored) |
+| Pinboard API                | `https://api.pinboard.in/v1/`               | `scribe pull pinboard`; token via `SCRIBE_PINBOARD_TOKEN` or `integration_tokens.pinboard` |
 | LaunchAgents                | `~/Library/LaunchAgents/com.scribe.*.plist` | installed by `cron install`       |
 | KB root                     | `$SCRIBE_KB` or `scribe.yaml` in cwd        | every command resolves this first |
 

--- a/README.md
+++ b/README.md
@@ -374,6 +374,70 @@ triage:
     # ... matching weights for each category
 ```
 
+### Pull integrations (Pinboard)
+
+`scribe pull` fetches bookmarks from external accounts into the ingest queue,
+where the same drain path as `ingest url` fetches → contextualizes → absorbs
+them. Pinboard is the first adapter; the framework is generic, so more can slot
+in later. Adapters only produce URLs — no page content is fetched by `pull`
+itself, so it's deterministic and fast (no LLM).
+
+**1. Get your token.** Grab it from <https://pinboard.in/settings/password> (it's
+`username:HEXTOKEN`, and grants full read+write, so treat it like a password).
+The token is a **secret** — it lives in `~/.config/scribe/config.yaml`
+(`integration_tokens.pinboard`) or the `SCRIBE_PINBOARD_TOKEN` env var, **never**
+the committed `scribe.yaml`:
+
+```yaml
+# ~/.config/scribe/config.yaml (per-machine, gitignored)
+integration_tokens:
+  pinboard: "username:HEXTOKEN"
+```
+
+Sanity-check it (`posts/update` is the cheapest, side-effect-free call):
+
+```sh
+curl -s "https://api.pinboard.in/v1/posts/update?format=json&auth_token=$SCRIBE_PINBOARD_TOKEN"
+# → {"update_time":"2026-07-01T..."}  means auth works
+```
+
+**2. Enable it** in `scribe.yaml` (non-secret knobs only):
+
+```yaml
+integrations:
+  pinboard:
+    enabled: true
+    scope: recent+unread    # recent+unread | unread | all  (by read-state/recency)
+    tags: []                # OR filter: only ingest bookmarks with >=1 of these
+                            # tags (case-insensitive); empty = all
+    skip_domains: []        # substring filter, same as capture.skip_domains
+```
+
+- **`scope`** picks the set by read-state/recency: `recent+unread` (default —
+  recent bookmarks plus anything flagged to-read), `unread` (only to-read), or
+  `all` (whole archive).
+- **`tags`** is an independent OR filter: with `tags: [kb, elixir]`, only
+  bookmarks carrying `kb` **or** `elixir` are ingested; empty ingests everything
+  the scope returned. The two compose — `scope: all` + `tags: [kb]` means
+  "every bookmark I ever tagged `kb`".
+
+**3. Run it:**
+
+```sh
+scribe pull --list                    # integrations + status (configured? last pull?)
+scribe pull pinboard -n               # dry-run: show what WOULD be queued, write nothing
+scribe pull pinboard                  # pull the configured scope + tags
+scribe pull pinboard --tag kb --tag elixir   # override the tag filter for this run
+scribe pull pinboard --all-history --max 200 # paced full backfill; re-run until it reports 0 new
+```
+
+Queued URLs land in `output/inbox/` and are fetched → contextualized → absorbed
+by the existing `ingest drain` (every 30 min) — or run `scribe ingest drain` to
+process them now. A cheap `posts/update` probe short-circuits runs when nothing
+changed, so the cron job (`scribe pull`, hourly) is kind to Pinboard's rate
+limits. In a **team** KB, integrations are hard-off from the repo config like
+capture — re-enable per-person in `scribe.local.yaml`.
+
 ### Local-mode — 100% Ollama (free, offline)
 
 As of 0.2.14, **every LLM-driven subcommand can run end-to-end against a local [Ollama](https://ollama.com) server** with zero Anthropic calls. `dream`, `assess`, `deep`, `session-mine`, `relations migrate`, all four absorb passes, and `contextualize` resolve their backend through a single top-level `llm:` block. The Anthropic path stays the default; flipping the whole pipeline to free/offline is one line of yaml.
@@ -590,6 +654,11 @@ llm_api_key: tok-xxxxxxxx          # single key, covers whichever provider llm.p
 # llm_api_keys:                    # OR per-provider, if you route ops to different providers
 #   together: tok-aaaa
 #   groq:     gsk_bbbb
+
+# Pull-adapter API tokens (Pinboard, …). Same rule as the LLM key: lives here,
+# never in a KB's scribe.yaml, so it can't be committed to a shared KB.
+# integration_tokens:
+#   pinboard: "username:HEXTOKEN"  # from pinboard.in/settings/password
 ```
 
 Resolution order is **env var → this file**: a one-off `export GROQ_API_KEY=…` still wins, but with the key in this file nothing needs exporting (this is what makes cron work without touching `~/.zshenv`). `chmod 600` it. The key never goes in a KB's `scribe.yaml`.
@@ -600,6 +669,7 @@ Resolution order is **env var → this file**: a one-off `export GROQ_API_KEY=�
 | -------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
 | `SCRIBE_KB`                | Override KB root for one command                                                                                          |
 | `SCRIBE_SELF_CHAT_ID`      | Override `capture.self_chat_handle` (accepts comma-separated values for accounts with phone + Apple-ID email)             |
+| `SCRIBE_PINBOARD_TOKEN`    | Pinboard API token (`username:HEXTOKEN`) for `scribe pull pinboard`; overrides `integration_tokens.pinboard`             |
 | `SCRIBE_SKIP_REINDEX`      | Skip the final `qmd` reindex (useful in tests / CI)                                                                       |
 | `SCRIBE_PROJECT_ROOTS`     | Colon-separated list of parent dirs treated as top-level project roots (default: `Projects:projects:src:code:repos:work`) |
 | `SCRIBE_PASS2_MODE`        | Override `absorb.pass2_mode` (`tools` or `json`) for one run without editing scribe.yaml                                  |

--- a/README.md
+++ b/README.md
@@ -408,8 +408,9 @@ integrations:
   pinboard:
     enabled: true
     scope: recent+unread    # recent+unread | unread | all  (by read-state/recency)
-    tags: []                # OR filter: only ingest bookmarks with >=1 of these
-                            # tags (case-insensitive); empty = all
+    tags: []                # tag filter (case-insensitive); empty = all
+    tags_mode: any          # any = bookmark carries >=1 listed tag (default)
+                            # all = must carry EVERY listed tag (Pinboard-style)
     public_only: false      # true = skip private bookmarks; default ingests all
     skip_domains: []        # substring filter, same as capture.skip_domains
 ```
@@ -417,10 +418,16 @@ integrations:
 - **`scope`** picks the set by read-state/recency: `recent+unread` (default —
   recent bookmarks plus anything flagged to-read), `unread` (only to-read), or
   `all` (whole archive).
-- **`tags`** is an independent OR filter: with `tags: [kb, elixir]`, only
-  bookmarks carrying `kb` **or** `elixir` are ingested; empty ingests everything
-  the scope returned. The two compose — `scope: all` + `tags: [kb]` means
-  "every bookmark I ever tagged `kb`".
+- **`tags`** is an independent tag filter; empty ingests everything the scope
+  returned. It composes with scope — `scope: all` + `tags: [kb]` means "every
+  bookmark I ever tagged `kb`".
+- **`tags_mode`** picks how multiple tags combine. The default `any` is an
+  ingest gate: `tags: [kb, elixir]` keeps bookmarks carrying `kb` **or**
+  `elixir` — the right shape when the list is "all my KB-worthy markers". Set
+  `all` to require **every** listed tag (`elixir` **and** `concurrency`),
+  which matches how Pinboard's own `/t:elixir/t:concurrency/` URL filtering
+  narrows. Note this deliberately differs from Pinboard's site default —
+  stacking tags there narrows, while an ingest filter usually widens.
 - **`public_only`** — an authenticated pull sees your **private** bookmarks too,
   and by default they're ingested. Set `public_only: true` (or pass
   `--public-only` for one run) to skip private (non-shared) bookmarks — worth it

--- a/README.md
+++ b/README.md
@@ -410,6 +410,7 @@ integrations:
     scope: recent+unread    # recent+unread | unread | all  (by read-state/recency)
     tags: []                # OR filter: only ingest bookmarks with >=1 of these
                             # tags (case-insensitive); empty = all
+    public_only: false      # true = skip private bookmarks; default ingests all
     skip_domains: []        # substring filter, same as capture.skip_domains
 ```
 
@@ -420,6 +421,11 @@ integrations:
   bookmarks carrying `kb` **or** `elixir` are ingested; empty ingests everything
   the scope returned. The two compose — `scope: all` + `tags: [kb]` means
   "every bookmark I ever tagged `kb`".
+- **`public_only`** — an authenticated pull sees your **private** bookmarks too,
+  and by default they're ingested. Set `public_only: true` (or pass
+  `--public-only` for one run) to skip private (non-shared) bookmarks — worth it
+  if this KB might ever be shared or `scribe promote`d, so private links don't
+  ride along.
 
 **3. Run it:**
 

--- a/cmd/scribe/config.go
+++ b/cmd/scribe/config.go
@@ -533,12 +533,17 @@ type IntegrationConfig struct {
 	// interpreted; Pinboard understands recent+unread | unread | all.
 	// Empty → adapter default (recent+unread).
 	Scope string `yaml:"scope"`
-	// Tags is an OR filter applied by the generic driver: a bookmark is
-	// ingested only if it carries at least one of these tags (case-
-	// insensitive). Empty (the default) ingests everything the scope
-	// returns. Orthogonal to Scope — e.g. scope: all + tags: [kb] means
-	// "every bookmark I ever tagged kb".
+	// Tags is a tag filter applied by the generic driver (case-insensitive).
+	// Empty (the default) ingests everything the scope returns. Orthogonal
+	// to Scope — e.g. scope: all + tags: [kb] means "every bookmark I ever
+	// tagged kb". How multiple tags combine is TagsMode's call.
 	Tags []string `yaml:"tags"`
+	// TagsMode selects how Tags matches: "any" (the default — a bookmark
+	// carrying at least one listed tag passes; the natural mode for an
+	// ingest gate over several KB-worthy markers) or "all" (it must carry
+	// every listed tag — the narrowing semantics Pinboard's own /t:a/t:b/
+	// URL filtering uses). Ignored while Tags is empty.
+	TagsMode string `yaml:"tags_mode"`
 	// PublicOnly, when true, skips private (non-shared) bookmarks so only
 	// public ones reach the KB. Default false ingests everything, since an
 	// authenticated pull sees private bookmarks too. Useful when the KB may

--- a/cmd/scribe/config.go
+++ b/cmd/scribe/config.go
@@ -130,7 +130,12 @@ type ScribeConfig struct {
 	Sync    SyncConfig    `yaml:"sync"`
 	Deep    DeepConfig    `yaml:"deep"`
 	Capture CaptureConfig `yaml:"capture"`
-	Triage  TriageConfig  `yaml:"triage"`
+	// Integrations holds the non-secret config for pull adapters (`scribe
+	// pull` — Pinboard, and future bookmark sources). API tokens NEVER live
+	// here; they go in ~/.config/scribe/config.yaml under integration_tokens.
+	// Personal source like Capture: zeroed in team mode, re-enabled locally.
+	Integrations IntegrationsConfig `yaml:"integrations"`
+	Triage       TriageConfig       `yaml:"triage"`
 	// PriorityLanes tunes how sync drains pending-sessions.txt (issue
 	// #22) — see PriorityLanesConfig.
 	PriorityLanes PriorityLanesConfig `yaml:"priority_lanes"`
@@ -513,6 +518,42 @@ type CaptureConfig struct {
 	SkipDomains []string `yaml:"skip_domains"`
 }
 
+// IntegrationsConfig maps an integration name (e.g. "pinboard") to its
+// non-secret settings. Secrets (API tokens) never live here — they go in
+// ~/.config/scribe/config.yaml under integration_tokens, so a token can never
+// be committed to a shared KB. `scribe pull` iterates the source registry
+// (source.go) and pulls each configured integration.
+type IntegrationsConfig map[string]IntegrationConfig
+
+// IntegrationConfig holds the shared, non-secret knobs a pull adapter reads.
+type IntegrationConfig struct {
+	// Enabled gates the integration; a pull run soft-skips when false.
+	Enabled bool `yaml:"enabled"`
+	// Scope selects which items to pull by read-state/recency. Adapter-
+	// interpreted; Pinboard understands recent+unread | unread | all.
+	// Empty → adapter default (recent+unread).
+	Scope string `yaml:"scope"`
+	// Tags is an OR filter applied by the generic driver: a bookmark is
+	// ingested only if it carries at least one of these tags (case-
+	// insensitive). Empty (the default) ingests everything the scope
+	// returns. Orthogonal to Scope — e.g. scope: all + tags: [kb] means
+	// "every bookmark I ever tagged kb".
+	Tags []string `yaml:"tags"`
+	// SkipDomains drops queued URLs containing any of these substrings —
+	// the same substring filter as capture.skip_domains.
+	SkipDomains []string `yaml:"skip_domains"`
+}
+
+// integrationConfig returns the config block for a named integration and
+// whether it was present.
+func integrationConfig(cfg *ScribeConfig, name string) (IntegrationConfig, bool) {
+	if cfg == nil || cfg.Integrations == nil {
+		return IntegrationConfig{}, false
+	}
+	ic, ok := cfg.Integrations[name]
+	return ic, ok
+}
+
 type SyncConfig struct {
 	MaxExtractions      int `yaml:"max_extractions"`
 	MaxSessions         int `yaml:"max_sessions"`
@@ -848,6 +889,23 @@ type userConfig struct {
 	// not in any KB's scribe.yaml, so one KB can't set the machine budget
 	// for the others. Zero = disabled. See budget.go.
 	DailyOutputTokenCeiling int64 `yaml:"daily_output_token_ceiling,omitempty"`
+	// IntegrationTokens maps a pull-adapter name (pinboard, …) to its API
+	// token. It lives HERE — the per-machine user config — and never in a
+	// KB's scribe.yaml, so a token can't be committed to a shared KB (same
+	// rule as LLMAPIKeys). Env SCRIBE_<NAME>_TOKEN overrides an entry.
+	IntegrationTokens map[string]string `yaml:"integration_tokens,omitempty"`
+}
+
+// integrationToken resolves the API token for a pull integration. Env wins
+// (SCRIBE_<NAME>_TOKEN, so a one-off export overrides), then the per-machine
+// user config (integration_tokens.<name>). Never read from a KB's scribe.yaml
+// — a token must not be committable to a shared KB.
+func integrationToken(name string) string {
+	env := "SCRIBE_" + strings.ToUpper(name) + "_TOKEN"
+	if v := strings.TrimSpace(os.Getenv(env)); v != "" {
+		return v
+	}
+	return strings.TrimSpace(loadUserConfig().IntegrationTokens[name])
 }
 
 // loadUserConfig reads the user-level config. Returns zero value if missing.

--- a/cmd/scribe/config.go
+++ b/cmd/scribe/config.go
@@ -539,6 +539,11 @@ type IntegrationConfig struct {
 	// returns. Orthogonal to Scope — e.g. scope: all + tags: [kb] means
 	// "every bookmark I ever tagged kb".
 	Tags []string `yaml:"tags"`
+	// PublicOnly, when true, skips private (non-shared) bookmarks so only
+	// public ones reach the KB. Default false ingests everything, since an
+	// authenticated pull sees private bookmarks too. Useful when the KB may
+	// be shared/promoted and private bookmarks shouldn't ride along.
+	PublicOnly bool `yaml:"public_only"`
 	// SkipDomains drops queued URLs containing any of these substrings —
 	// the same substring filter as capture.skip_domains.
 	SkipDomains []string `yaml:"skip_domains"`

--- a/cmd/scribe/config_trust.go
+++ b/cmd/scribe/config_trust.go
@@ -79,17 +79,21 @@ const localConfigName = "scribe.local.yaml"
 //   - SecretScan: the credential gate — a pushed disable/allow_paths
 //     change must not weaken what another member's machine commits.
 type sensitiveConfig struct {
-	Team              bool             `json:"team"`
-	Sources           SourcesConfig    `json:"sources"`
-	ClaudeProjectsDir string           `json:"claude_projects_dir"`
-	CodexSessionsDir  string           `json:"codex_sessions_dir"`
-	CcriderDB         string           `json:"ccrider_db"`
-	Capture           CaptureConfig    `json:"capture"`
-	OllamaURL         string           `json:"ollama_url"`
-	BaseURL           string           `json:"base_url"`
-	APIKeyEnv         string           `json:"api_key_env"`
-	CodexMine         bool             `json:"codex_mine"`
-	SecretScan        SecretScanConfig `json:"secret_scan"`
+	Team              bool          `json:"team"`
+	Sources           SourcesConfig `json:"sources"`
+	ClaudeProjectsDir string        `json:"claude_projects_dir"`
+	CodexSessionsDir  string        `json:"codex_sessions_dir"`
+	CcriderDB         string        `json:"ccrider_db"`
+	Capture           CaptureConfig `json:"capture"`
+	// Integrations is a personal ingestion source (pull adapters). Locked for
+	// the same reason as Capture: a pushed change widens what's ingested and
+	// from where. Also hard-off in team mode below.
+	Integrations IntegrationsConfig `json:"integrations"`
+	OllamaURL    string             `json:"ollama_url"`
+	BaseURL      string             `json:"base_url"`
+	APIKeyEnv    string             `json:"api_key_env"`
+	CodexMine    bool               `json:"codex_mine"`
+	SecretScan   SecretScanConfig   `json:"secret_scan"`
 
 	ExtractOllamaURL       string `json:"extract_ollama_url"`
 	DreamOllamaURL         string `json:"dream_ollama_url"`
@@ -154,6 +158,7 @@ func sensitiveFrom(cfg *ScribeConfig) sensitiveConfig {
 		CodexSessionsDir:  cfg.CodexSessionsDir,
 		CcriderDB:         cfg.CcriderDB,
 		Capture:           cfg.Capture,
+		Integrations:      cfg.Integrations,
 		OllamaURL:         cfg.LLM.OllamaURL,
 		BaseURL:           cfg.LLM.BaseURL,
 		APIKeyEnv:         cfg.LLM.APIKeyEnv,
@@ -199,6 +204,7 @@ func (s sensitiveConfig) applyTo(cfg *ScribeConfig) {
 	cfg.CodexSessionsDir = s.CodexSessionsDir
 	cfg.CcriderDB = s.CcriderDB
 	cfg.Capture = s.Capture
+	cfg.Integrations = s.Integrations
 	cfg.LLM.OllamaURL = s.OllamaURL
 	cfg.LLM.BaseURL = s.BaseURL
 	cfg.LLM.APIKeyEnv = s.APIKeyEnv
@@ -341,6 +347,12 @@ func enforceConfigTrust(root string, cfg *ScribeConfig) {
 		// ingestion is strictly a local decision: scribe.local.yaml or
 		// SCRIBE_SELF_CHAT_ID re-enable it after this point.
 		cfg.Capture = CaptureConfig{}
+		// Pull integrations (Pinboard, …) are personal sources for the same
+		// reason: a pushed `integrations.*.enabled: true` must not make every
+		// teammate pull from an account. Re-enable per-person via
+		// scribe.local.yaml. (Tokens live only in user config/env, so this is
+		// belt-and-suspenders — an unconfigured member already no-ops.)
+		cfg.Integrations = nil
 	}
 }
 
@@ -434,6 +446,7 @@ func sensitiveDiff(trusted, current sensitiveConfig) []string {
 		{"codex_sessions_dir", trusted.CodexSessionsDir, current.CodexSessionsDir},
 		{"ccrider_db", trusted.CcriderDB, current.CcriderDB},
 		{"capture", trusted.Capture, current.Capture},
+		{"integrations", trusted.Integrations, current.Integrations},
 		{"llm.ollama_url", trusted.OllamaURL, current.OllamaURL},
 		{"llm.base_url", trusted.BaseURL, current.BaseURL},
 		{"llm.api_key_env", trusted.APIKeyEnv, current.APIKeyEnv},

--- a/cmd/scribe/config_trust_test.go
+++ b/cmd/scribe/config_trust_test.go
@@ -111,6 +111,27 @@ func TestTeamCaptureHardOff(t *testing.T) {
 	}
 }
 
+func TestTeamIntegrationsHardOff(t *testing.T) {
+	// Repo config enables a pull integration in a team KB — must be ignored
+	// even with no trust record yet (personal source, like capture).
+	root := setupTrustKB(t,
+		"team: true\nintegrations:\n  pinboard:\n    enabled: true\n    scope: all\n", "")
+	cfg := loadConfig(root)
+	if len(cfg.Integrations) != 0 {
+		t.Errorf("team KB took integrations config from the repo file: %+v", cfg.Integrations)
+	}
+
+	// scribe.local.yaml re-enables it — local layer is sovereign.
+	if err := os.WriteFile(filepath.Join(root, localConfigName),
+		[]byte("integrations:\n  pinboard:\n    enabled: true\n    scope: unread\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg = loadConfig(root)
+	if ic, ok := cfg.Integrations["pinboard"]; !ok || !ic.Enabled || ic.Scope != "unread" {
+		t.Errorf("local integrations override lost: %+v", cfg.Integrations)
+	}
+}
+
 func TestSoloKBUnaffected(t *testing.T) {
 	root := setupTrustKB(t,
 		"capture:\n  self_chat_handle: \"+421900000000\"\nsources:\n  include: [\"/my/path\"]\n", "")

--- a/cmd/scribe/cron.go
+++ b/cmd/scribe/cron.go
@@ -141,6 +141,13 @@ func scribeJobs(binary string) []cronJob {
 			Schedule: schedSpec{Calendar: everyNMinutes(30)},
 		},
 		{
+			Name:     "pull-sources",
+			Desc:     "Pull configured integrations (Pinboard, …) into the ingest queue hourly at :17",
+			Command:  each("pull"),
+			LogFile:  filepath.Join(logDir, "scribe-pull.log"),
+			Schedule: schedSpec{Calendar: hourlyAt(17)},
+		},
+		{
 			Name:     "capture-refetch",
 			Desc:     "Retry stub links daily at 06:30 (parks failures in _unfetched-links.md)",
 			Command:  each("capture --refetch"),

--- a/cmd/scribe/ingest.go
+++ b/cmd/scribe/ingest.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -145,47 +146,152 @@ func markContextualized(root, rawBase string) {
 	}
 }
 
-// ingestQueue writes a small .url file to output/inbox/ and returns.
-func ingestQueue(root, rawURL, title string, tags []string, domain, fetcher string, dryRun bool) error {
-	inbox := filepath.Join(root, "output", "inbox")
+// queueFields is the content of one output/inbox/*.url entry. Shared by
+// `ingest url` and the pull adapters (source.go) so both agree on the on-disk
+// format that drainOne consumes. Note and Source are the adapter extensions:
+// Note is the user's own annotation (Pinboard `extended`), prepended to the
+// fetched body as a blockquote by drainOne; Source is a provenance tag
+// (e.g. "pinboard") merged into the article's frontmatter tags.
+type queueFields struct {
+	URL      string
+	Title    string
+	Tags     []string
+	Domain   string
+	Fetcher  string
+	Note     string
+	Source   string
+	QueuedAt time.Time
+}
 
-	ts := time.Now()
+func (f *queueFields) applyDefaults() {
+	if f.QueuedAt.IsZero() {
+		f.QueuedAt = time.Now()
+	}
+	if f.Domain == "" {
+		f.Domain = "general"
+	}
+}
+
+// renderQueueEntry serializes a queue entry to the line-based `key: value`
+// format parseQueueEntry reads. Callers apply defaults first.
+func renderQueueEntry(f queueFields) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "url: %s\n", f.URL)
+	if f.Title != "" {
+		fmt.Fprintf(&sb, "title: %s\n", f.Title)
+	}
+	if len(f.Tags) > 0 {
+		fmt.Fprintf(&sb, "tags: %s\n", strings.Join(f.Tags, ", "))
+	}
+	fmt.Fprintf(&sb, "domain: %s\n", f.Domain)
+	if f.Fetcher != "" && f.Fetcher != "auto" {
+		fmt.Fprintf(&sb, "fetcher: %s\n", f.Fetcher)
+	}
+	if f.Source != "" {
+		fmt.Fprintf(&sb, "source: %s\n", f.Source)
+	}
+	if f.Note != "" {
+		// The queue format is line-based, so the note is single-line encoded
+		// (newlines → \n sentinel) and decoded back in drainOne.
+		fmt.Fprintf(&sb, "note: %s\n", encodeQueueNote(f.Note))
+	}
+	fmt.Fprintf(&sb, "queued_at: %s\n", f.QueuedAt.Format(time.RFC3339))
+	return sb.String()
+}
+
+// uniqueQueuePath builds a collision-free inbox path. Bulk adapter pulls queue
+// many entries in the same second, so a numeric suffix disambiguates when the
+// timestamp+slug base already exists on disk.
+func uniqueQueuePath(inbox, rawURL string, ts time.Time) string {
 	stamp := ts.Format("2006-01-02-150405")
 	slug := slugify(rawURL)
 	if len(slug) > 40 {
 		slug = slug[:40]
 	}
-	fname := fmt.Sprintf("%s-%s.url", stamp, slug)
-	path := filepath.Join(inbox, fname)
+	base := stamp + "-" + slug
+	path := filepath.Join(inbox, base+".url")
+	for n := 2; fileExists(path); n++ {
+		path = filepath.Join(inbox, fmt.Sprintf("%s-%d.url", base, n))
+	}
+	return path
+}
 
-	var sb strings.Builder
-	fmt.Fprintf(&sb, "url: %s\n", rawURL)
-	if title != "" {
-		fmt.Fprintf(&sb, "title: %s\n", title)
+// writeQueueEntry atomically writes one queue entry into inbox and returns its
+// path. Temp-then-rename keeps a concurrent `ingest drain` from ever reading a
+// half-written *.url file.
+func writeQueueEntry(inbox string, f queueFields) (string, error) {
+	f.applyDefaults()
+	if err := os.MkdirAll(inbox, 0o755); err != nil {
+		return "", fmt.Errorf("create inbox: %w", err)
 	}
-	if len(tags) > 0 {
-		fmt.Fprintf(&sb, "tags: %s\n", strings.Join(tags, ", "))
+	path := uniqueQueuePath(inbox, f.URL, f.QueuedAt)
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, []byte(renderQueueEntry(f)), 0o644); err != nil {
+		return "", fmt.Errorf("write queue entry: %w", err)
 	}
-	fmt.Fprintf(&sb, "domain: %s\n", domain)
-	if fetcher != "" && fetcher != "auto" {
-		fmt.Fprintf(&sb, "fetcher: %s\n", fetcher)
+	if err := os.Rename(tmp, path); err != nil {
+		os.Remove(tmp)
+		return "", fmt.Errorf("finalize queue entry: %w", err)
 	}
-	fmt.Fprintf(&sb, "queued_at: %s\n", ts.Format(time.RFC3339))
+	return path, nil
+}
+
+// encodeQueueNote flattens a possibly multi-line note to a single line so it
+// survives the line-based queue format. decodeQueueNote reverses it.
+func encodeQueueNote(s string) string {
+	s = strings.ReplaceAll(s, "\\", "\\\\")
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	s = strings.ReplaceAll(s, "\r", "\n")
+	return strings.ReplaceAll(s, "\n", "\\n")
+}
+
+func decodeQueueNote(s string) string {
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' && i+1 < len(s) {
+			switch s[i+1] {
+			case 'n':
+				b.WriteByte('\n')
+				i++
+				continue
+			case '\\':
+				b.WriteByte('\\')
+				i++
+				continue
+			}
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
+}
+
+// queueNoteBlockquote renders a decoded note as a markdown blockquote so it
+// reads as the user's annotation above the fetched content.
+func queueNoteBlockquote(note string) string {
+	lines := strings.Split(strings.TrimSpace(note), "\n")
+	for i, ln := range lines {
+		lines[i] = strings.TrimRight("> "+ln, " ")
+	}
+	return strings.Join(lines, "\n")
+}
+
+// ingestQueue writes a small .url file to output/inbox/ and returns.
+func ingestQueue(root, rawURL, title string, tags []string, domain, fetcher string, dryRun bool) error {
+	inbox := filepath.Join(root, "output", "inbox")
+	f := queueFields{URL: rawURL, Title: title, Tags: tags, Domain: domain, Fetcher: fetcher}
+	f.applyDefaults()
 
 	if dryRun {
-		fmt.Printf("[dry-run] would queue: %s\n", path)
+		fmt.Printf("[dry-run] would queue: %s\n", uniqueQueuePath(inbox, rawURL, f.QueuedAt))
 		fmt.Println("---")
-		fmt.Println(sb.String())
+		fmt.Println(renderQueueEntry(f))
 		return nil
 	}
 
-	if err := os.MkdirAll(inbox, 0o755); err != nil {
-		return fmt.Errorf("create inbox: %w", err)
+	path, err := writeQueueEntry(inbox, f)
+	if err != nil {
+		return err
 	}
-	if err := os.WriteFile(path, []byte(sb.String()), 0o644); err != nil {
-		return fmt.Errorf("write queue entry: %w", err)
-	}
-
 	fmt.Printf("queued: %s\n", path)
 	return nil
 }
@@ -457,7 +563,19 @@ func drainOne(root, queuePath string, dryRun bool) error {
 		finalTitle = "Untitled"
 	}
 
-	path, content := buildRawArticle(root, rawURL, finalTitle, res.Body, res.Via, domain, tags)
+	// Adapter extensions: preserve the user's own annotation (note:) as a
+	// leading blockquote, and stamp the provenance tag (source:) into
+	// frontmatter. Both survive a successful fetch (the fetched body alone
+	// would otherwise drop the pull-time context).
+	body := res.Body
+	if note := decodeQueueNote(entry["note"]); strings.TrimSpace(note) != "" {
+		body = queueNoteBlockquote(note) + "\n\n" + body
+	}
+	if src := entry["source"]; src != "" && !slices.Contains(tags, src) {
+		tags = append(tags, src)
+	}
+
+	path, content := buildRawArticle(root, rawURL, finalTitle, body, res.Via, domain, tags)
 
 	if dryRun {
 		logMsg("ingest", "[dry-run] would write %s (via %s, %d bytes)", filepath.Base(path), res.Via, len(content))

--- a/cmd/scribe/ingest.go
+++ b/cmd/scribe/ingest.go
@@ -172,23 +172,50 @@ func (f *queueFields) applyDefaults() {
 	}
 }
 
+// queueLineReplacer flattens the line terminators that would break the
+// one-key-per-line queue format.
+var queueLineReplacer = strings.NewReplacer("\r\n", " ", "\r", " ", "\n", " ")
+
+// queueLineValue makes a value safe to emit as a single `key: value` line.
+//
+// This is a security boundary, not cosmetics. Pull adapters feed REMOTE-
+// controlled strings (a bookmark title, which Pinboard's bookmarklet fills
+// from the page's own <title>) into this format, and parseQueueEntry is
+// line-based. A raw newline therefore lets that remote text inject its own
+// `url:` line and redirect what drainOne fetches and absorbs. Newlines become
+// spaces — every field using this is single-line by definition, so nothing
+// meaningful is lost. (Note: is exempt; it round-trips through
+// encodeQueueNote, which already escapes newlines rather than dropping them.)
+func queueLineValue(s string) string {
+	return strings.TrimSpace(queueLineReplacer.Replace(s))
+}
+
 // renderQueueEntry serializes a queue entry to the line-based `key: value`
-// format parseQueueEntry reads. Callers apply defaults first.
+// format parseQueueEntry reads. Callers apply defaults first. Every
+// single-line field goes through queueLineValue — see its doc for why.
 func renderQueueEntry(f queueFields) string {
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "url: %s\n", f.URL)
-	if f.Title != "" {
-		fmt.Fprintf(&sb, "title: %s\n", f.Title)
+	fmt.Fprintf(&sb, "url: %s\n", queueLineValue(f.URL))
+	if title := queueLineValue(f.Title); title != "" {
+		fmt.Fprintf(&sb, "title: %s\n", title)
 	}
 	if len(f.Tags) > 0 {
-		fmt.Fprintf(&sb, "tags: %s\n", strings.Join(f.Tags, ", "))
+		tags := make([]string, 0, len(f.Tags))
+		for _, t := range f.Tags {
+			if t = queueLineValue(t); t != "" {
+				tags = append(tags, t)
+			}
+		}
+		if len(tags) > 0 {
+			fmt.Fprintf(&sb, "tags: %s\n", strings.Join(tags, ", "))
+		}
 	}
-	fmt.Fprintf(&sb, "domain: %s\n", f.Domain)
-	if f.Fetcher != "" && f.Fetcher != "auto" {
-		fmt.Fprintf(&sb, "fetcher: %s\n", f.Fetcher)
+	fmt.Fprintf(&sb, "domain: %s\n", queueLineValue(f.Domain))
+	if fetcher := queueLineValue(f.Fetcher); fetcher != "" && fetcher != "auto" {
+		fmt.Fprintf(&sb, "fetcher: %s\n", fetcher)
 	}
-	if f.Source != "" {
-		fmt.Fprintf(&sb, "source: %s\n", f.Source)
+	if source := queueLineValue(f.Source); source != "" {
+		fmt.Fprintf(&sb, "source: %s\n", source)
 	}
 	if f.Note != "" {
 		// The queue format is line-based, so the note is single-line encoded
@@ -597,6 +624,13 @@ func drainOne(root, queuePath string, dryRun bool) error {
 }
 
 // parseQueueEntry reads the simple "key: value\n" format.
+//
+// FIRST occurrence of a key wins. renderQueueEntry already strips the line
+// terminators that would let a value forge an extra line, so this is
+// belt-and-braces — but it is the half that protects entries this process did
+// not write (a hand-edited file, or a future producer that forgets to
+// sanitize): the real fields are emitted first, so anything appended later
+// cannot override them. Last-wins would invert exactly that.
 func parseQueueEntry(s string) map[string]string {
 	out := make(map[string]string)
 	for line := range strings.SplitSeq(s, "\n") {
@@ -609,8 +643,10 @@ func parseQueueEntry(s string) map[string]string {
 			continue
 		}
 		key := strings.TrimSpace(before)
-		val := strings.TrimSpace(after)
-		out[key] = val
+		if _, seen := out[key]; seen {
+			continue
+		}
+		out[key] = strings.TrimSpace(after)
 	}
 	return out
 }

--- a/cmd/scribe/main.go
+++ b/cmd/scribe/main.go
@@ -40,6 +40,7 @@ type CLI struct {
 	Ingest        IngestCmd        `cmd:"" group:"content" help:"Ingest a URL into raw/articles/ (queue or synchronous)."`
 	Absorb        AbsorbCmd        `cmd:"" group:"content" help:"Absorb a local file (md/txt/html) into the KB end-to-end: ingest → contextualize → absorb."`
 	Capture       CaptureCmd       `cmd:"" group:"content" help:"Capture iMessage self-chat URLs/notes into raw/articles/."`
+	Pull          PullCmd          `cmd:"" group:"content" help:"Pull bookmarks from configured integrations (Pinboard, …) into the ingest queue."`
 	Contextualize ContextualizeCmd `cmd:"" group:"content" help:"Insert LLM-generated retrieval-context paragraph into raw articles for better qmd search."`
 	Projects      ProjectsCmd      `cmd:"" group:"content" help:"List, approve, ignore, or review discovered projects."`
 	Scan          ScanCmd          `cmd:"" group:"content" help:"Pre-scan a project for extraction."`

--- a/cmd/scribe/main.go
+++ b/cmd/scribe/main.go
@@ -217,7 +217,14 @@ func redactArgs(args []string) []string {
 	return out
 }
 
-var urlTokenRE = regexp.MustCompile(`(?i)([?&])(token|api_key|apikey|access_token|auth|key|sig|signature)=[^&\s]+`)
+// The leading [a-z0-9_.-]* lets a PREFIXED parameter name match too. Without
+// it, `auth_token=` slipped through: the `auth` alternative needs `=` right
+// after it, and the `token` alternative needs `?`/`&` right before it, so a
+// Pinboard URL redacted to nothing. The value stops at a quote as well as at
+// `&`/whitespace, so a token quoted inside a Go *url.Error message
+// (`Get "https://…?auth_token=user:HEX": dial tcp …`) is fully replaced while
+// the rest of the message stays readable.
+var urlTokenRE = regexp.MustCompile(`(?i)([?&])([a-z0-9_.\-]*(?:token|api_key|apikey|access_token|auth|key|sig|signature))=[^&\s"]+`)
 
 func redactURLToken(s string) string {
 	return urlTokenRE.ReplaceAllString(s, "${1}${2}=REDACTED")
@@ -244,7 +251,14 @@ func writeRunRecord(cmdPath string, started time.Time, runErr error) {
 	errMsg := ""
 	if runErr != nil {
 		status = "error"
-		errMsg = runErr.Error()
+		// Redact BEFORE truncating: an error text is as likely to carry a
+		// token-bearing URL as an arg is (a failed HTTP call against any
+		// authenticated endpoint wraps the full request URL — Go only strips
+		// userinfo passwords, not query parameters). This file is read back by
+		// `scribe doctor --section errors`, which prints it. Producers should
+		// sanitize at their own seam; this is the catch-all that also covers
+		// every future source.
+		errMsg = redactURLToken(runErr.Error())
 		if len(errMsg) > 500 {
 			errMsg = errMsg[:500]
 		}

--- a/cmd/scribe/source.go
+++ b/cmd/scribe/source.go
@@ -28,7 +28,7 @@ type Source interface {
 	Configured(cfg *ScribeConfig) (ok bool, reason string)
 	// Fetch returns fresh items given the opaque prior cursor, plus the cursor
 	// to persist for the next run. Implementations own their cursor shape and
-	// resolve their own config (scope defaults, token) off cfg. The OR tag
+	// resolve their own config (scope defaults, token) off cfg. The tag
 	// filter and skip_domains are applied generically by the driver afterward.
 	Fetch(ctx context.Context, cfg *ScribeConfig, prev json.RawMessage, opts FetchOpts) (items []SourceItem, next json.RawMessage, err error)
 }
@@ -48,11 +48,12 @@ type SourceItem struct {
 }
 
 // FetchOpts carries the per-run knobs a Source honors. Empty Scope means
-// "use the configured default". Tags is the per-run override of the OR tag
-// filter the driver applies (empty → use the integration's configured tags).
+// "use the configured default". Tags is the per-run override of the tag
+// filter the driver applies (empty → use the integration's configured tags;
+// tags_mode always comes from config).
 type FetchOpts struct {
 	Scope      string   // "recent+unread" | "unread" | "all" | ""
-	Tags       []string // OR filter override; empty = use config
+	Tags       []string // tag filter override; empty = use config
 	PublicOnly bool     // force-skip private bookmarks for this run
 	Force      bool     // bypass the source's cheap unchanged-since-last-run probe
 }
@@ -178,9 +179,14 @@ func pullSource(root string, src Source, opts FetchOpts, maxItems int, dryRun bo
 	}
 
 	skip := integrationSkipDomains(cfg, src.Name())
-	// OR tag filter: a per-run --tag override wins, else the integration's
-	// configured tags. Empty → keep everything the scope returned.
-	tagFilter := effectiveTags(opts.Tags, integrationTags(cfg, src.Name()))
+	// Tag filter: a per-run --tag override wins, else the integration's
+	// configured tags; tags_mode picks any-vs-all matching. Empty → keep
+	// everything the scope returned.
+	tagsMode, err := integrationTagsMode(cfg, src.Name())
+	if err != nil {
+		return 0, err
+	}
+	tagFilter := effectiveTags(opts.Tags, integrationTags(cfg, src.Name()), tagsMode)
 	// public_only: skip private bookmarks. --public-only forces it on for a run.
 	publicOnly := opts.PublicOnly || integrationPublicOnly(cfg, src.Name())
 	inbox := filepath.Join(root, "output", "inbox")
@@ -297,13 +303,29 @@ func integrationSkipDomains(cfg *ScribeConfig, name string) []string {
 	return cfg.Integrations[name].SkipDomains
 }
 
-// integrationTags returns the configured OR tag filter for an integration
+// integrationTags returns the configured tag filter for an integration
 // (empty when the block is absent).
 func integrationTags(cfg *ScribeConfig, name string) []string {
 	if cfg == nil || cfg.Integrations == nil {
 		return nil
 	}
 	return cfg.Integrations[name].Tags
+}
+
+// integrationTagsMode returns the validated tags_mode for an integration:
+// ""/"any" → at-least-one matching, "all" → every-tag matching. Any other
+// value is a config error — a typo silently widening an ingest filter would
+// be worse than failing loudly.
+func integrationTagsMode(cfg *ScribeConfig, name string) (string, error) {
+	if cfg == nil || cfg.Integrations == nil {
+		return "", nil
+	}
+	raw := cfg.Integrations[name].TagsMode
+	switch mode := strings.ToLower(strings.TrimSpace(raw)); mode {
+	case "", "any", "all":
+		return mode, nil
+	}
+	return "", fmt.Errorf("integrations.%s.tags_mode: unknown value %q (want any or all)", name, raw)
 }
 
 // integrationPublicOnly reports whether an integration is configured to skip
@@ -315,39 +337,51 @@ func integrationPublicOnly(cfg *ScribeConfig, name string) bool {
 	return cfg.Integrations[name].PublicOnly
 }
 
-// tagSet is a case-insensitive OR filter over item tags. An empty set allows
-// everything (no filtering).
-type tagSet map[string]bool
-
-func (ts tagSet) allows(itemTags []string) bool {
-	if len(ts) == 0 {
-		return true
-	}
-	for _, t := range itemTags {
-		if ts[strings.ToLower(strings.TrimSpace(t))] {
-			return true
-		}
-	}
-	return false
+// tagSet is a case-insensitive filter over item tags. An empty set allows
+// everything (no filtering). requireAll=false (tags_mode: any, the default)
+// passes an item carrying at least one listed tag; requireAll=true
+// (tags_mode: all) demands every listed tag, matching the narrowing
+// semantics of Pinboard's own /t:a/t:b/ URL filtering.
+type tagSet struct {
+	set        map[string]bool
+	requireAll bool
 }
 
-// effectiveTags builds the OR filter for a run: the per-run override wins over
-// the configured tags; empty either way disables filtering.
-func effectiveTags(override, configured []string) tagSet {
+func (ts tagSet) allows(itemTags []string) bool {
+	if len(ts.set) == 0 {
+		return true
+	}
+	matched := make(map[string]bool, len(ts.set))
+	for _, t := range itemTags {
+		t = strings.ToLower(strings.TrimSpace(t))
+		if ts.set[t] {
+			if !ts.requireAll {
+				return true
+			}
+			matched[t] = true
+		}
+	}
+	return ts.requireAll && len(matched) == len(ts.set)
+}
+
+// effectiveTags builds the tag filter for a run: the per-run override wins
+// over the configured tags; empty either way disables filtering. mode is the
+// integration's validated tags_mode (""/"any" = at-least-one, "all" = every).
+func effectiveTags(override, configured []string, mode string) tagSet {
 	src := override
 	if len(src) == 0 {
 		src = configured
 	}
 	if len(src) == 0 {
-		return nil
+		return tagSet{}
 	}
-	ts := make(tagSet, len(src))
+	set := make(map[string]bool, len(src))
 	for _, t := range src {
 		if t = strings.ToLower(strings.TrimSpace(t)); t != "" {
-			ts[t] = true
+			set[t] = true
 		}
 	}
-	return ts
+	return tagSet{set: set, requireAll: mode == "all"}
 }
 
 // --- CLI ---
@@ -359,7 +393,7 @@ type PullCmd struct {
 	Source     string   `arg:"" optional:"" help:"Integration to pull (e.g. pinboard). Omit to pull every configured integration."`
 	Scope      string   `help:"Override scope for this run: recent+unread|unread|all." enum:"recent+unread,unread,all," default:""`
 	AllHistory bool     `help:"Backfill the entire archive this run (≡ --scope all). Pair with --max on a first big pull." name:"all-history"`
-	Tag        []string `help:"Only ingest bookmarks carrying at least one of these tags (repeatable, OR). Overrides the integration's configured tags for this run."`
+	Tag        []string `help:"Only ingest bookmarks matching these tags (repeatable; any-vs-all per the integration's tags_mode, default any). Overrides the integration's configured tags for this run."`
 	PublicOnly bool     `help:"Skip private bookmarks for this run (forces public_only on)." name:"public-only"`
 	Force      bool     `help:"Bypass the source's cheap unchanged-since-last-run probe."`
 	Max        int      `help:"Cap items queued this run (0 = no limit). Useful to pace a first --all-history backfill." default:"0"`

--- a/cmd/scribe/source.go
+++ b/cmd/scribe/source.go
@@ -1,0 +1,409 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Source is an external provider of bookmark-like items that scribe pulls
+// incrementally and queues into output/inbox/ for the existing ingest-drain
+// path to fetch → contextualize → absorb. Deterministic, no LLM — the same
+// budget class as capture/triage/hook.
+//
+// Pinboard is the first implementation (source_pinboard.go). The interface is
+// deliberately narrow so future sources with different pagination models — a
+// timestamp cursor (Pinboard), a page token (GitHub stars), a last-id marker
+// (Reddit saved) — all fit without widening it: each owns its opaque cursor.
+type Source interface {
+	// Name is the registry key: state-file stem, provenance tag, log prefix.
+	Name() string
+	// Configured reports whether the source is enabled and credentialed. The
+	// reason explains a false result for the CLI/log (soft-skip, not an error).
+	Configured(cfg *ScribeConfig) (ok bool, reason string)
+	// Fetch returns fresh items given the opaque prior cursor, plus the cursor
+	// to persist for the next run. Implementations own their cursor shape and
+	// resolve their own config (scope defaults, token) off cfg. The OR tag
+	// filter and skip_domains are applied generically by the driver afterward.
+	Fetch(ctx context.Context, cfg *ScribeConfig, prev json.RawMessage, opts FetchOpts) (items []SourceItem, next json.RawMessage, err error)
+}
+
+// SourceItem is one normalized bookmark from any Source.
+type SourceItem struct {
+	URL       string
+	Title     string
+	Tags      []string
+	Note      string    // the user's own annotation → article body
+	CreatedAt time.Time // when the bookmark was saved (best-effort)
+	ID        string    // stable dedup key (provider hash; falls back to URL)
+	Unread    bool
+}
+
+// FetchOpts carries the per-run knobs a Source honors. Empty Scope means
+// "use the configured default". Tags is the per-run override of the OR tag
+// filter the driver applies (empty → use the integration's configured tags).
+type FetchOpts struct {
+	Scope string   // "recent+unread" | "unread" | "all" | ""
+	Tags  []string // OR filter override; empty = use config
+	Force bool     // bypass the source's cheap unchanged-since-last-run probe
+}
+
+// sourceRegistry maps integration name → adapter. Adding an adapter is one
+// entry here plus a file implementing Source.
+var sourceRegistry = map[string]Source{
+	"pinboard": pinboardSource{},
+}
+
+// registeredSources returns every adapter, sorted by name for stable output.
+func registeredSources() []Source {
+	out := make([]Source, 0, len(sourceRegistry))
+	for _, s := range sourceRegistry {
+		out = append(out, s)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name() < out[j].Name() })
+	return out
+}
+
+func sourceNames() []string {
+	out := make([]string, 0, len(sourceRegistry))
+	for name := range sourceRegistry {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// sourceState is the persisted per-source state under output/sources/<name>.json.
+// output/ is gitignored, so this per-machine cursor never lands in a shared KB.
+type sourceState struct {
+	Cursor   json.RawMessage `json:"cursor,omitempty"` // opaque, owned by the Source
+	Seen     []string        `json:"seen"`             // dedup IDs already queued
+	LastPull string          `json:"last_pull,omitempty"`
+}
+
+func sourceStatePath(root, name string) string {
+	return filepath.Join(root, "output", "sources", name+".json")
+}
+
+func loadSourceState(path string) (*sourceState, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &sourceState{}, nil
+		}
+		return nil, err
+	}
+	var st sourceState
+	if err := json.Unmarshal(data, &st); err != nil {
+		return nil, fmt.Errorf("parse state json: %w", err)
+	}
+	return &st, nil
+}
+
+func saveSourceState(path string, st *sourceState) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(st, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	return nil
+}
+
+// pullSource runs one adapter end-to-end: configured gate → load state →
+// fetch → dedup + skip-domains → write queue entries → persist state. Returns
+// the number of items queued. An unconfigured source is a soft-skip (0, nil):
+// `scribe pull` over every registered source must not fail because one lacks a
+// token. A per-source lock keeps a manual run and the cron run from racing the
+// state file.
+func pullSource(root string, src Source, opts FetchOpts, maxItems int, dryRun bool) (int, error) {
+	cfg := loadConfig(root)
+	if err := cfg.requireParseable(); err != nil {
+		return 0, err
+	}
+	if ok, reason := src.Configured(cfg); !ok {
+		logMsg("pull", "%s: skipped (%s)", src.Name(), reason)
+		return 0, nil
+	}
+
+	if !dryRun {
+		lockPath := lockPathFor(cfg.LockDir, "pull-"+src.Name(), root)
+		lf, ok, err := acquireLock(lockPath)
+		if err != nil {
+			return 0, fmt.Errorf("lock %s: %w", lockPath, err)
+		}
+		if !ok {
+			logMsg("pull", "%s: blocked by existing pull-%s lock", src.Name(), src.Name())
+			return 0, nil
+		}
+		defer releaseLock(lf)
+	}
+
+	statePath := sourceStatePath(root, src.Name())
+	state, err := loadSourceState(statePath)
+	if err != nil {
+		return 0, fmt.Errorf("load %s state: %w", src.Name(), err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	items, cursor, err := src.Fetch(ctx, cfg, state.Cursor, opts)
+	if err != nil {
+		return 0, fmt.Errorf("%s fetch: %w", src.Name(), err)
+	}
+
+	seen := make(map[string]bool, len(state.Seen))
+	for _, id := range state.Seen {
+		seen[id] = true
+	}
+
+	skip := integrationSkipDomains(cfg, src.Name())
+	// OR tag filter: a per-run --tag override wins, else the integration's
+	// configured tags. Empty → keep everything the scope returned.
+	tagFilter := effectiveTags(opts.Tags, integrationTags(cfg, src.Name()))
+	inbox := filepath.Join(root, "output", "inbox")
+
+	queued := 0
+	capped := false
+	for _, it := range items {
+		id := it.ID
+		if id == "" {
+			id = it.URL
+		}
+		if id == "" || seen[id] {
+			continue
+		}
+		if it.URL == "" || shouldSkipURL(it.URL, skip) {
+			// Don't mark skipped as seen — a later config change that drops
+			// the skip rule should let the item through (mirrors capture).
+			continue
+		}
+		if !tagFilter.allows(it.Tags) {
+			// Same reasoning as skip: not marked seen, so widening the filter
+			// later (or --force / --all-history) re-includes it.
+			continue
+		}
+		if maxItems > 0 && queued >= maxItems {
+			capped = true
+			break
+		}
+
+		if dryRun {
+			fmt.Printf("  WOULD QUEUE: %s (%s)\n", it.URL, it.Title)
+			seen[id] = true
+			queued++
+			continue
+		}
+
+		if _, err := writeQueueEntry(inbox, sourceItemToQueue(src.Name(), it)); err != nil {
+			logMsg("pull", "%s: queue %s failed: %v", src.Name(), it.URL, err)
+			continue
+		}
+		seen[id] = true
+		queued++
+	}
+
+	if dryRun {
+		suffix := ""
+		if capped {
+			suffix = fmt.Sprintf(" (capped at --max %d)", maxItems)
+		}
+		logMsg("pull", "%s: %d item(s) would be queued%s (dry-run, state unchanged)", src.Name(), queued, suffix)
+		return queued, nil
+	}
+
+	// Advance the cursor only on a complete pass. When --max capped the run,
+	// keeping the old cursor lets the next `pull … --all-history` resume the
+	// backfill (seen dedups what already went through) instead of the cheap
+	// unchanged-probe short-circuiting it away.
+	if !capped {
+		state.Cursor = cursor
+	}
+	state.Seen = sortedKeys(seen)
+	state.LastPull = time.Now().UTC().Format(time.RFC3339)
+	if err := saveSourceState(statePath, state); err != nil {
+		return queued, fmt.Errorf("save %s state: %w", src.Name(), err)
+	}
+
+	if capped {
+		logMsg("pull", "%s: queued %d new item(s); --max %d reached, re-run to continue backfill", src.Name(), queued, maxItems)
+	} else {
+		logMsg("pull", "%s: queued %d new item(s)", src.Name(), queued)
+	}
+	return queued, nil
+}
+
+// sourceItemToQueue maps a normalized item to the shared inbox queue format.
+// The source name becomes a provenance tag; unread items also get "to-read".
+func sourceItemToQueue(name string, it SourceItem) queueFields {
+	tags := append([]string(nil), it.Tags...)
+	if it.Unread && !containsFold(tags, "to-read") {
+		tags = append(tags, "to-read")
+	}
+	f := queueFields{
+		URL:    it.URL,
+		Title:  it.Title,
+		Tags:   tags,
+		Domain: "general",
+		Note:   it.Note,
+		Source: name,
+	}
+	if !it.CreatedAt.IsZero() {
+		f.QueuedAt = it.CreatedAt
+	}
+	return f
+}
+
+func containsFold(ss []string, want string) bool {
+	for _, s := range ss {
+		if strings.EqualFold(s, want) {
+			return true
+		}
+	}
+	return false
+}
+
+// integrationSkipDomains returns the skip_domains configured for an
+// integration (empty when the block is absent).
+func integrationSkipDomains(cfg *ScribeConfig, name string) []string {
+	if cfg == nil || cfg.Integrations == nil {
+		return nil
+	}
+	return cfg.Integrations[name].SkipDomains
+}
+
+// integrationTags returns the configured OR tag filter for an integration
+// (empty when the block is absent).
+func integrationTags(cfg *ScribeConfig, name string) []string {
+	if cfg == nil || cfg.Integrations == nil {
+		return nil
+	}
+	return cfg.Integrations[name].Tags
+}
+
+// tagSet is a case-insensitive OR filter over item tags. An empty set allows
+// everything (no filtering).
+type tagSet map[string]bool
+
+func (ts tagSet) allows(itemTags []string) bool {
+	if len(ts) == 0 {
+		return true
+	}
+	for _, t := range itemTags {
+		if ts[strings.ToLower(strings.TrimSpace(t))] {
+			return true
+		}
+	}
+	return false
+}
+
+// effectiveTags builds the OR filter for a run: the per-run override wins over
+// the configured tags; empty either way disables filtering.
+func effectiveTags(override, configured []string) tagSet {
+	src := override
+	if len(src) == 0 {
+		src = configured
+	}
+	if len(src) == 0 {
+		return nil
+	}
+	ts := make(tagSet, len(src))
+	for _, t := range src {
+		if t = strings.ToLower(strings.TrimSpace(t)); t != "" {
+			ts[t] = true
+		}
+	}
+	return ts
+}
+
+// --- CLI ---
+
+// PullCmd pulls bookmarks from configured integrations (Pinboard, …) into the
+// ingest queue. Bare `scribe pull` pulls every configured source — that is
+// what the pull-sources cron job runs.
+type PullCmd struct {
+	Source     string   `arg:"" optional:"" help:"Integration to pull (e.g. pinboard). Omit to pull every configured integration."`
+	Scope      string   `help:"Override scope for this run: recent+unread|unread|all." enum:"recent+unread,unread,all," default:""`
+	AllHistory bool     `help:"Backfill the entire archive this run (≡ --scope all). Pair with --max on a first big pull." name:"all-history"`
+	Tag        []string `help:"Only ingest bookmarks carrying at least one of these tags (repeatable, OR). Overrides the integration's configured tags for this run."`
+	Force      bool     `help:"Bypass the source's cheap unchanged-since-last-run probe."`
+	Max        int      `help:"Cap items queued this run (0 = no limit). Useful to pace a first --all-history backfill." default:"0"`
+	List       bool     `help:"List integrations and their status; pull nothing."`
+	DryRun     bool     `help:"Print what would be queued without writing." short:"n"`
+}
+
+func (c *PullCmd) Run() error {
+	root, err := kbDir()
+	if err != nil {
+		return err
+	}
+	if c.List {
+		return listIntegrations(root)
+	}
+
+	scope := c.Scope
+	if c.AllHistory {
+		scope = "all"
+	}
+	opts := FetchOpts{Scope: scope, Tags: c.Tag, Force: c.Force || c.AllHistory}
+
+	var srcs []Source
+	if c.Source != "" {
+		s, ok := sourceRegistry[c.Source]
+		if !ok {
+			return fmt.Errorf("unknown integration %q (known: %s)", c.Source, strings.Join(sourceNames(), ", "))
+		}
+		srcs = []Source{s}
+	} else {
+		srcs = registeredSources()
+	}
+
+	total := 0
+	var firstErr error
+	for _, s := range srcs {
+		n, err := pullSource(root, s, opts, c.Max, c.DryRun)
+		total += n
+		if err != nil {
+			logMsg("pull", "%s: %v", s.Name(), err)
+			if firstErr == nil {
+				firstErr = err
+			}
+		}
+	}
+	logMsg("pull", "done: %d item(s) queued across %d integration(s)", total, len(srcs))
+	return firstErr
+}
+
+// listIntegrations prints each registered adapter with whether it is
+// configured and when it last pulled.
+func listIntegrations(root string) error {
+	cfg := loadConfig(root)
+	for _, s := range registeredSources() {
+		status := "ready"
+		if ok, reason := s.Configured(cfg); !ok {
+			status = "not configured: " + reason
+		}
+		last := "never"
+		if st, err := loadSourceState(sourceStatePath(root, s.Name())); err == nil && st.LastPull != "" {
+			last = st.LastPull
+		}
+		fmt.Printf("%-12s  %-40s  last pull: %s\n", s.Name(), status, last)
+	}
+	return nil
+}

--- a/cmd/scribe/source.go
+++ b/cmd/scribe/source.go
@@ -42,15 +42,19 @@ type SourceItem struct {
 	CreatedAt time.Time // when the bookmark was saved (best-effort)
 	ID        string    // stable dedup key (provider hash; falls back to URL)
 	Unread    bool
+	// Private marks a non-public bookmark. Sources without a public/private
+	// notion leave it false, so the public_only filter is a no-op for them.
+	Private bool
 }
 
 // FetchOpts carries the per-run knobs a Source honors. Empty Scope means
 // "use the configured default". Tags is the per-run override of the OR tag
 // filter the driver applies (empty → use the integration's configured tags).
 type FetchOpts struct {
-	Scope string   // "recent+unread" | "unread" | "all" | ""
-	Tags  []string // OR filter override; empty = use config
-	Force bool     // bypass the source's cheap unchanged-since-last-run probe
+	Scope      string   // "recent+unread" | "unread" | "all" | ""
+	Tags       []string // OR filter override; empty = use config
+	PublicOnly bool     // force-skip private bookmarks for this run
+	Force      bool     // bypass the source's cheap unchanged-since-last-run probe
 }
 
 // sourceRegistry maps integration name → adapter. Adding an adapter is one
@@ -177,6 +181,8 @@ func pullSource(root string, src Source, opts FetchOpts, maxItems int, dryRun bo
 	// OR tag filter: a per-run --tag override wins, else the integration's
 	// configured tags. Empty → keep everything the scope returned.
 	tagFilter := effectiveTags(opts.Tags, integrationTags(cfg, src.Name()))
+	// public_only: skip private bookmarks. --public-only forces it on for a run.
+	publicOnly := opts.PublicOnly || integrationPublicOnly(cfg, src.Name())
 	inbox := filepath.Join(root, "output", "inbox")
 
 	queued := 0
@@ -197,6 +203,9 @@ func pullSource(root string, src Source, opts FetchOpts, maxItems int, dryRun bo
 		if !tagFilter.allows(it.Tags) {
 			// Same reasoning as skip: not marked seen, so widening the filter
 			// later (or --force / --all-history) re-includes it.
+			continue
+		}
+		if publicOnly && it.Private {
 			continue
 		}
 		if maxItems > 0 && queued >= maxItems {
@@ -297,6 +306,15 @@ func integrationTags(cfg *ScribeConfig, name string) []string {
 	return cfg.Integrations[name].Tags
 }
 
+// integrationPublicOnly reports whether an integration is configured to skip
+// private bookmarks.
+func integrationPublicOnly(cfg *ScribeConfig, name string) bool {
+	if cfg == nil || cfg.Integrations == nil {
+		return false
+	}
+	return cfg.Integrations[name].PublicOnly
+}
+
 // tagSet is a case-insensitive OR filter over item tags. An empty set allows
 // everything (no filtering).
 type tagSet map[string]bool
@@ -342,6 +360,7 @@ type PullCmd struct {
 	Scope      string   `help:"Override scope for this run: recent+unread|unread|all." enum:"recent+unread,unread,all," default:""`
 	AllHistory bool     `help:"Backfill the entire archive this run (≡ --scope all). Pair with --max on a first big pull." name:"all-history"`
 	Tag        []string `help:"Only ingest bookmarks carrying at least one of these tags (repeatable, OR). Overrides the integration's configured tags for this run."`
+	PublicOnly bool     `help:"Skip private bookmarks for this run (forces public_only on)." name:"public-only"`
 	Force      bool     `help:"Bypass the source's cheap unchanged-since-last-run probe."`
 	Max        int      `help:"Cap items queued this run (0 = no limit). Useful to pace a first --all-history backfill." default:"0"`
 	List       bool     `help:"List integrations and their status; pull nothing."`
@@ -361,7 +380,7 @@ func (c *PullCmd) Run() error {
 	if c.AllHistory {
 		scope = "all"
 	}
-	opts := FetchOpts{Scope: scope, Tags: c.Tag, Force: c.Force || c.AllHistory}
+	opts := FetchOpts{Scope: scope, Tags: c.Tag, PublicOnly: c.PublicOnly, Force: c.Force || c.AllHistory}
 
 	var srcs []Source
 	if c.Source != "" {

--- a/cmd/scribe/source.go
+++ b/cmd/scribe/source.go
@@ -110,6 +110,34 @@ func loadSourceState(path string) (*sourceState, error) {
 	return &st, nil
 }
 
+// sourceCheckpointEvery is how many queued items pass between mid-run state
+// writes. CLAUDE.md requires checkpointed writes so an interrupted run doesn't
+// lose work; without this, a killed `--all-history` backfill that had already
+// written hundreds of inbox entries would persist no seen-set at all and
+// re-queue every one of them on the next run (duplicate articles, duplicate
+// absorb spend). 25 keeps the worst-case rework to 24 items while adding one
+// small write per 25 — negligible against the inbox writes themselves.
+const sourceCheckpointEvery = 25
+
+// saveSourceStateFn is a test seam (mirrors eachRunner in each.go) so tests can
+// observe mid-run checkpoints without killing the process.
+var saveSourceStateFn = saveSourceState
+
+// checkpointSourceState persists the seen-set mid-run.
+//
+// The cursor is deliberately NOT advanced here. It may only move on a
+// complete pass: if a crash left an advanced cursor behind, the next run's
+// cheap unchanged-since-last-run probe would short-circuit and the un-queued
+// remainder would be skipped for good. Persisting `seen` alone is monotonic —
+// it can only ever prevent duplicate work.
+func checkpointSourceState(path string, st *sourceState, seen map[string]bool) error {
+	return saveSourceStateFn(path, &sourceState{
+		Cursor:   st.Cursor,
+		Seen:     sortedKeys(seen),
+		LastPull: time.Now().UTC().Format(time.RFC3339),
+	})
+}
+
 func saveSourceState(path string, st *sourceState) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
@@ -232,6 +260,14 @@ func pullSource(root string, src Source, opts FetchOpts, maxItems int, dryRun bo
 		}
 		seen[id] = true
 		queued++
+
+		// Checkpoint so an interrupted backfill resumes instead of re-queuing
+		// everything it already wrote.
+		if queued%sourceCheckpointEvery == 0 {
+			if err := checkpointSourceState(statePath, state, seen); err != nil {
+				logMsg("pull", "%s: checkpoint failed: %v", src.Name(), err)
+			}
+		}
 	}
 
 	if dryRun {
@@ -252,7 +288,7 @@ func pullSource(root string, src Source, opts FetchOpts, maxItems int, dryRun bo
 	}
 	state.Seen = sortedKeys(seen)
 	state.LastPull = time.Now().UTC().Format(time.RFC3339)
-	if err := saveSourceState(statePath, state); err != nil {
+	if err := saveSourceStateFn(statePath, state); err != nil {
 		return queued, fmt.Errorf("save %s state: %w", src.Name(), err)
 	}
 

--- a/cmd/scribe/source_checkpoint_test.go
+++ b/cmd/scribe/source_checkpoint_test.go
@@ -1,0 +1,260 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+// --- D1: queue-entry injection via remote-controlled fields ---
+
+// TestQueueEntryTitleCannotInjectURL is the D1 regression. A pull adapter
+// feeds REMOTE text into the line-based queue format — Pinboard's bookmarklet
+// fills a bookmark's title from the page's own <title>. Before the fix,
+// renderQueueEntry emitted the title raw and parseQueueEntry took the LAST
+// occurrence of a key, so a newline in the title let the page forge its own
+// `url:` line and redirect what drainOne fetched and absorbed.
+func TestQueueEntryTitleCannotInjectURL(t *testing.T) {
+	const realURL = "https://real.example/article"
+	const payload = "https://attacker.example/payload"
+
+	inbox := t.TempDir()
+	path, err := writeQueueEntry(inbox, sourceItemToQueue("pinboard", SourceItem{
+		URL:   realURL,
+		Title: "Benign Title\nurl: " + payload,
+		ID:    "h1",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "\nurl: "+payload) {
+		t.Errorf("injected line survived into the queue file:\n%s", data)
+	}
+	entry := parseQueueEntry(string(data))
+	if entry["url"] != realURL {
+		t.Errorf("drainOne would fetch %q, want %q\nfile:\n%s", entry["url"], realURL, data)
+	}
+	// The title text itself is preserved, just flattened onto one line.
+	if !strings.Contains(entry["title"], "Benign Title") {
+		t.Errorf("title lost its content: %q", entry["title"])
+	}
+}
+
+// TestQueueEntryFieldsRejectLineBreaks covers every single-line field, not
+// just the title, so a future adapter mapping remote data onto tags/domain/
+// source can't reopen the hole.
+func TestQueueEntryFieldsRejectLineBreaks(t *testing.T) {
+	const realURL = "https://real.example/x"
+	inbox := t.TempDir()
+	// The URL itself is the one field scribe intends to fetch, so it is not
+	// the attack surface — everything else here is remote-controlled text a
+	// pull adapter maps straight off a bookmark.
+	path, err := writeQueueEntry(inbox, queueFields{
+		URL:    realURL,
+		Title:  "T\r\nurl: https://evil.example/2",
+		Tags:   []string{"ok", "bad\nurl: https://evil.example/3"},
+		Domain: "general\nurl: https://evil.example/4",
+		Source: "pinboard\nurl: https://evil.example/5",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry := parseQueueEntry(string(data))
+	if entry["url"] != realURL {
+		t.Errorf("url = %q, want %q\nfile:\n%s", entry["url"], realURL, data)
+	}
+	// Exactly one LINE may begin with `url:`. The injected text survives as
+	// inline characters inside a flattened value, which is harmless — what
+	// matters is that it can never start a line of its own.
+	urlLines := 0
+	for _, ln := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(strings.TrimSpace(ln), "url:") {
+			urlLines++
+		}
+	}
+	if urlLines != 1 {
+		t.Errorf("want exactly one url: line, found %d:\n%s", urlLines, data)
+	}
+}
+
+// TestParseQueueEntryFirstKeyWins pins the belt-and-braces half: even for a
+// file this process did not render (hand-edited, or a future producer that
+// forgets to sanitize), an appended duplicate key cannot override the real
+// value.
+func TestParseQueueEntryFirstKeyWins(t *testing.T) {
+	raw := "url: https://real.example/a\ntitle: T\nurl: https://attacker.example/b\n"
+	if got := parseQueueEntry(raw)["url"]; got != "https://real.example/a" {
+		t.Errorf("url = %q, want the first occurrence to win", got)
+	}
+}
+
+// TestQueueLineValueKeepsOrdinaryText guards against over-correcting: normal
+// titles must pass through untouched.
+func TestQueueLineValueKeepsOrdinaryText(t *testing.T) {
+	for _, s := range []string{
+		"A Perfectly Normal Title",
+		"Title with: a colon",
+		"Ünïcödé — em dash, quotes “x”",
+	} {
+		if got := queueLineValue(s); got != s {
+			t.Errorf("queueLineValue(%q) = %q, want unchanged", s, got)
+		}
+	}
+}
+
+// --- C1: mid-run checkpointing ---
+
+// TestPullSourceCheckpointsMidRun is the C1 regression. CLAUDE.md requires
+// checkpointed writes; before the fix pullSource persisted state exactly once,
+// after the loop, so a killed --all-history backfill that had already written
+// hundreds of inbox entries recorded no seen-set and re-queued every one of
+// them on the next run.
+func TestPullSourceCheckpointsMidRun(t *testing.T) {
+	root := testKB(t, "")
+
+	// Observe every state write through the seam (mirrors eachRunner's shape).
+	type snapshot struct {
+		seen   int
+		cursor string
+	}
+	var writes []snapshot
+	orig := saveSourceStateFn
+	saveSourceStateFn = func(path string, st *sourceState) error {
+		writes = append(writes, snapshot{seen: len(st.Seen), cursor: string(st.Cursor)})
+		return orig(path, st)
+	}
+	t.Cleanup(func() { saveSourceStateFn = orig })
+
+	const total = 60
+	items := make([]SourceItem, 0, total)
+	for i := range total {
+		items = append(items, item(fmt.Sprintf("https://x%d.example", i), fmt.Sprintf("id-%d", i)))
+	}
+	src := &fakeSource{name: "fake", cursor: "v1", items: items}
+
+	n, err := pullSource(root, src, FetchOpts{}, 0, false)
+	if err != nil {
+		t.Fatalf("pullSource: %v", err)
+	}
+	if n != total {
+		t.Fatalf("queued %d, want %d", n, total)
+	}
+
+	// 60 items at one checkpoint per 25, plus the final write = 3.
+	wantCheckpoints := total / sourceCheckpointEvery
+	if len(writes) != wantCheckpoints+1 {
+		t.Errorf("state written %d times, want %d checkpoints + 1 final", len(writes), wantCheckpoints)
+	}
+	if writes[0].seen != sourceCheckpointEvery {
+		t.Errorf("first checkpoint recorded %d seen ids, want %d", writes[0].seen, sourceCheckpointEvery)
+	}
+
+	// The cursor must NOT advance on a mid-run checkpoint: a crash with an
+	// advanced cursor would let the next run's unchanged-probe short-circuit
+	// the un-queued remainder away for good.
+	for i, w := range writes[:len(writes)-1] {
+		if w.cursor != "" {
+			t.Errorf("checkpoint %d advanced the cursor to %q; only a complete pass may", i, w.cursor)
+		}
+	}
+	if last := writes[len(writes)-1]; last.cursor == "" {
+		t.Error("final write did not advance the cursor after a complete pass")
+	}
+}
+
+// TestCheckpointedStateResumesWithoutRequeueing proves the property the
+// checkpoint exists for: after an interrupted run, the items already written
+// are not queued a second time.
+func TestCheckpointedStateResumesWithoutRequeueing(t *testing.T) {
+	root := testKB(t, "")
+	statePath := sourceStatePath(root, "fake")
+
+	// Simulate a run killed after 30 of 60 items: the checkpoint at 25 is on
+	// disk, the final write never happened.
+	seen := map[string]bool{}
+	for i := range 25 {
+		seen[fmt.Sprintf("id-%d", i)] = true
+	}
+	if err := checkpointSourceState(statePath, &sourceState{}, seen); err != nil {
+		t.Fatal(err)
+	}
+
+	st, err := loadSourceState(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(st.Seen) != 25 {
+		t.Fatalf("checkpoint persisted %d ids, want 25", len(st.Seen))
+	}
+	if len(st.Cursor) != 0 {
+		t.Errorf("checkpoint persisted a cursor (%s); it must stay unset until a complete pass", st.Cursor)
+	}
+
+	const total = 60
+	items := make([]SourceItem, 0, total)
+	for i := range total {
+		items = append(items, item(fmt.Sprintf("https://x%d.example", i), fmt.Sprintf("id-%d", i)))
+	}
+	n, err := pullSource(root, &fakeSource{name: "fake", cursor: "v1", items: items}, FetchOpts{}, 0, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != total-25 {
+		t.Errorf("resumed run queued %d, want %d (the 25 checkpointed ids must not re-queue)", n, total-25)
+	}
+	if got := inboxFiles(t, root); len(got) != total-25 {
+		t.Errorf("inbox has %d entries, want %d — checkpointed items were re-queued", len(got), total-25)
+	}
+}
+
+// TestCheckpointFailureDoesNotAbortRun — a checkpoint is an optimization, not
+// a correctness requirement, so a failing one must be logged and stepped over
+// rather than losing the whole pull.
+func TestCheckpointFailureDoesNotAbortRun(t *testing.T) {
+	root := testKB(t, "")
+	orig := saveSourceStateFn
+	calls := 0
+	saveSourceStateFn = func(path string, st *sourceState) error {
+		calls++
+		if calls == 1 { // the first mid-run checkpoint
+			return errors.New("simulated disk failure")
+		}
+		return orig(path, st)
+	}
+	t.Cleanup(func() { saveSourceStateFn = orig })
+
+	const total = 30
+	items := make([]SourceItem, 0, total)
+	for i := range total {
+		items = append(items, item(fmt.Sprintf("https://y%d.example", i), fmt.Sprintf("id-%d", i)))
+	}
+	n, err := pullSource(root, &fakeSource{name: "fake", cursor: "v1", items: items}, FetchOpts{}, 0, false)
+	if err != nil {
+		t.Fatalf("a failed checkpoint must not fail the run: %v", err)
+	}
+	if n != total {
+		t.Errorf("queued %d, want %d", n, total)
+	}
+	st, err := loadSourceState(sourceStatePath(root, "fake"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(st.Seen) != total {
+		t.Errorf("final state has %d seen ids, want %d", len(st.Seen), total)
+	}
+	var cur map[string]string
+	if err := json.Unmarshal(st.Cursor, &cur); err != nil || cur["c"] != "v1" {
+		t.Errorf("cursor = %s, want it advanced after the complete pass", st.Cursor)
+	}
+}

--- a/cmd/scribe/source_pinboard.go
+++ b/cmd/scribe/source_pinboard.go
@@ -1,0 +1,295 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// pinboardSource pulls bookmarks from the Pinboard v1 API
+// (https://api.pinboard.in/v1/). It is a URL producer only: it queues hrefs
+// (with title, tags, and the user's `extended` note) into output/inbox/ and
+// lets the existing ingest-drain path fetch the content. No page content is
+// fetched here, so the adapter stays deterministic and fast.
+//
+// Auth is an API token of the form `username:HEXTOKEN` (from
+// pinboard.in/settings/password), resolved via integrationToken("pinboard")
+// — env SCRIBE_PINBOARD_TOKEN or ~/.config/scribe/config.yaml, never the
+// committed scribe.yaml.
+//
+// Rate limits (Pinboard bans abusive clients): the cheap posts/update probe
+// gates every run, so an unchanged account costs one small request; posts/all
+// is capped server-side to once / 5 min and posts/recent to once / min, both
+// comfortably within an hourly cron cadence.
+type pinboardSource struct {
+	// baseURL overrides the API base in tests (httptest). Empty → production.
+	baseURL string
+}
+
+const pinboardAPIBase = "https://api.pinboard.in/v1/"
+
+func (p pinboardSource) Name() string { return "pinboard" }
+
+func (p pinboardSource) base() string {
+	if p.baseURL != "" {
+		return p.baseURL
+	}
+	return pinboardAPIBase
+}
+
+func (p pinboardSource) Configured(cfg *ScribeConfig) (bool, string) {
+	ic, ok := integrationConfig(cfg, "pinboard")
+	if !ok || !ic.Enabled {
+		return false, "not enabled (set integrations.pinboard.enabled: true in scribe.yaml)"
+	}
+	if integrationToken("pinboard") == "" {
+		return false, "no token (set SCRIBE_PINBOARD_TOKEN or integration_tokens.pinboard in ~/.config/scribe/config.yaml)"
+	}
+	if s := resolvePinboardScope(ic, FetchOpts{}); !validPinboardScope(s) {
+		return false, fmt.Sprintf("unknown scope %q (want recent+unread | unread | all)", s)
+	}
+	return true, ""
+}
+
+func validPinboardScope(s string) bool {
+	switch s {
+	case "recent+unread", "unread", "all":
+		return true
+	}
+	return false
+}
+
+// pinboardCursor is the opaque per-source cursor persisted between runs. It is
+// just the last-seen posts/update timestamp, which lets Fetch short-circuit
+// when nothing changed.
+type pinboardCursor struct {
+	UpdateTime string `json:"update_time"`
+}
+
+func (p pinboardSource) Fetch(ctx context.Context, cfg *ScribeConfig, prev json.RawMessage, opts FetchOpts) ([]SourceItem, json.RawMessage, error) {
+	token := integrationToken("pinboard")
+	if token == "" {
+		return nil, prev, errors.New("no token")
+	}
+	ic, _ := integrationConfig(cfg, "pinboard")
+	scope := resolvePinboardScope(ic, opts)
+	if !validPinboardScope(scope) {
+		return nil, prev, fmt.Errorf("unknown scope %q (want recent+unread | unread | all)", scope)
+	}
+
+	var cur pinboardCursor
+	if len(prev) > 0 {
+		_ = json.Unmarshal(prev, &cur)
+	}
+
+	// Cheap change-probe first. Short-circuit an unchanged account unless the
+	// caller forced a run or this is the first pull (no cursor yet).
+	upd, err := p.postsUpdate(ctx, token)
+	if err != nil {
+		return nil, prev, err
+	}
+	if !opts.Force && cur.UpdateTime != "" && upd != "" && upd == cur.UpdateTime {
+		return nil, prev, nil
+	}
+
+	posts, err := p.fetchPosts(ctx, token, scope)
+	if err != nil {
+		return nil, prev, err
+	}
+
+	items := make([]SourceItem, 0, len(posts))
+	for _, b := range posts {
+		if it, ok := b.toItem(); ok {
+			items = append(items, it)
+		}
+	}
+
+	next, err := json.Marshal(pinboardCursor{UpdateTime: upd})
+	if err != nil {
+		return nil, prev, fmt.Errorf("encode cursor: %w", err)
+	}
+	return items, next, nil
+}
+
+// resolvePinboardScope resolves the effective scope: a per-run override wins,
+// then the configured value, then the recent+unread default.
+func resolvePinboardScope(ic IntegrationConfig, opts FetchOpts) string {
+	return firstNonEmpty(opts.Scope, ic.Scope, "recent+unread")
+}
+
+// fetchPosts selects the endpoint(s) for a scope.
+//   - all:            posts/all (whole archive)
+//   - unread:         posts/all?toread=yes
+//   - recent+unread:  posts/recent (last 100) ∪ posts/all?toread=yes
+//
+// Tag filtering is NOT done here — Pinboard's server-side tag filter is AND
+// (and capped at 3 tags), while the user-facing filter is OR. The generic
+// driver applies the OR filter over SourceItem.Tags after the fetch, so the
+// behavior is identical for every adapter.
+//
+// The driver's seen-set dedups across runs, so re-returning already-queued
+// posts is harmless; only genuinely new hrefs get queued.
+func (p pinboardSource) fetchPosts(ctx context.Context, token, scope string) ([]pinboardPost, error) {
+	switch scope {
+	case "all":
+		return p.postsAll(ctx, token, url.Values{})
+	case "unread":
+		return p.postsAll(ctx, token, url.Values{"toread": {"yes"}})
+	case "recent+unread":
+		recent, err := p.postsRecent(ctx, token, 100)
+		if err != nil {
+			return nil, err
+		}
+		unread, err := p.postsAll(ctx, token, url.Values{"toread": {"yes"}})
+		if err != nil {
+			return nil, err
+		}
+		return mergePostsByHash(recent, unread), nil
+	default:
+		return nil, fmt.Errorf("unknown scope %q", scope)
+	}
+}
+
+// pinboardPost mirrors a bookmark object in the v1 JSON API.
+type pinboardPost struct {
+	Href        string `json:"href"`
+	Description string `json:"description"` // the title the user gave
+	Extended    string `json:"extended"`    // longer note / annotation
+	Tags        string `json:"tags"`        // space-separated
+	Time        string `json:"time"`        // ISO 8601
+	ToRead      string `json:"toread"`      // "yes" | "no"
+	Hash        string `json:"hash"`        // stable per-URL id
+}
+
+func (b pinboardPost) toItem() (SourceItem, bool) {
+	href := strings.TrimSpace(b.Href)
+	if href == "" {
+		return SourceItem{}, false
+	}
+	id := b.Hash
+	if id == "" {
+		id = href
+	}
+	ts, _ := time.Parse(time.RFC3339, b.Time) // zero on parse failure — fine
+	return SourceItem{
+		URL:       href,
+		Title:     strings.TrimSpace(b.Description),
+		Tags:      strings.Fields(b.Tags),
+		Note:      b.Extended,
+		CreatedAt: ts,
+		ID:        id,
+		Unread:    b.ToRead == "yes",
+	}, true
+}
+
+// mergePostsByHash unions bookmark lists, deduping on hash (href fallback),
+// preserving first-seen order.
+func mergePostsByHash(lists ...[]pinboardPost) []pinboardPost {
+	seen := map[string]bool{}
+	var out []pinboardPost
+	for _, list := range lists {
+		for _, b := range list {
+			key := b.Hash
+			if key == "" {
+				key = b.Href
+			}
+			if key == "" || seen[key] {
+				continue
+			}
+			seen[key] = true
+			out = append(out, b)
+		}
+	}
+	return out
+}
+
+// --- API calls ---
+
+func (p pinboardSource) postsUpdate(ctx context.Context, token string) (string, error) {
+	body, err := p.get(ctx, token, "posts/update", url.Values{})
+	if err != nil {
+		return "", err
+	}
+	var r struct {
+		UpdateTime string `json:"update_time"`
+	}
+	if err := json.Unmarshal(body, &r); err != nil {
+		return "", fmt.Errorf("posts/update decode: %w", err)
+	}
+	return r.UpdateTime, nil
+}
+
+func (p pinboardSource) postsAll(ctx context.Context, token string, q url.Values) ([]pinboardPost, error) {
+	body, err := p.get(ctx, token, "posts/all", q)
+	if err != nil {
+		return nil, err
+	}
+	var posts []pinboardPost
+	if err := json.Unmarshal(body, &posts); err != nil {
+		return nil, fmt.Errorf("posts/all decode: %w", err)
+	}
+	return posts, nil
+}
+
+func (p pinboardSource) postsRecent(ctx context.Context, token string, count int) ([]pinboardPost, error) {
+	body, err := p.get(ctx, token, "posts/recent", url.Values{"count": {strconv.Itoa(count)}})
+	if err != nil {
+		return nil, err
+	}
+	var r struct {
+		Posts []pinboardPost `json:"posts"`
+	}
+	if err := json.Unmarshal(body, &r); err != nil {
+		return nil, fmt.Errorf("posts/recent decode: %w", err)
+	}
+	return r.Posts, nil
+}
+
+// get issues one authenticated GET and returns the body. auth_token is kept
+// literal (its `username:HEX` colon is a legal query char per RFC 3986) so it
+// matches the documented form exactly; other params are URL-encoded.
+func (p pinboardSource) get(ctx context.Context, token, endpoint string, q url.Values) ([]byte, error) {
+	full := p.base() + endpoint + "?format=json&auth_token=" + token
+	if enc := q.Encode(); enc != "" {
+		full += "&" + enc
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, full, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "scribe-ingest/1.0")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("%s request: %w", endpoint, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return nil, fmt.Errorf("%s: rate limited (429) — try again later", endpoint)
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, fmt.Errorf("%s: unauthorized (401) — check the API token", endpoint)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%s: status %d", endpoint, resp.StatusCode)
+	}
+	// Guard against a runaway body; a full Pinboard archive is a few MB.
+	return io.ReadAll(io.LimitReader(resp.Body, 64<<20))
+}
+
+// firstNonEmpty returns the first non-empty string, or "".
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/cmd/scribe/source_pinboard.go
+++ b/cmd/scribe/source_pinboard.go
@@ -165,6 +165,7 @@ type pinboardPost struct {
 	Tags        string `json:"tags"`        // space-separated
 	Time        string `json:"time"`        // ISO 8601
 	ToRead      string `json:"toread"`      // "yes" | "no"
+	Shared      string `json:"shared"`      // "yes" (public) | "no" (private)
 	Hash        string `json:"hash"`        // stable per-URL id
 }
 
@@ -186,6 +187,9 @@ func (b pinboardPost) toItem() (SourceItem, bool) {
 		CreatedAt: ts,
 		ID:        id,
 		Unread:    b.ToRead == "yes",
+		// Pinboard omits `shared` in some payloads; treat only an explicit
+		// "no" as private so a missing field defaults to public (no over-skip).
+		Private: b.Shared == "no",
 	}, true
 }
 

--- a/cmd/scribe/source_pinboard.go
+++ b/cmd/scribe/source_pinboard.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -113,7 +114,7 @@ func (p pinboardSource) Fetch(ctx context.Context, cfg *ScribeConfig, prev json.
 
 	next, err := json.Marshal(pinboardCursor{UpdateTime: upd})
 	if err != nil {
-		return nil, prev, fmt.Errorf("encode cursor: %w", err)
+		return nil, prev, pinboardError(token, "encode cursor: %v", err)
 	}
 	return items, next, nil
 }
@@ -225,7 +226,7 @@ func (p pinboardSource) postsUpdate(ctx context.Context, token string) (string, 
 		UpdateTime string `json:"update_time"`
 	}
 	if err := json.Unmarshal(body, &r); err != nil {
-		return "", fmt.Errorf("posts/update decode: %w", err)
+		return "", pinboardError(token, "posts/update decode: %v", err)
 	}
 	return r.UpdateTime, nil
 }
@@ -237,7 +238,7 @@ func (p pinboardSource) postsAll(ctx context.Context, token string, q url.Values
 	}
 	var posts []pinboardPost
 	if err := json.Unmarshal(body, &posts); err != nil {
-		return nil, fmt.Errorf("posts/all decode: %w", err)
+		return nil, pinboardError(token, "posts/all decode: %v", err)
 	}
 	return posts, nil
 }
@@ -251,14 +252,81 @@ func (p pinboardSource) postsRecent(ctx context.Context, token string, count int
 		Posts []pinboardPost `json:"posts"`
 	}
 	if err := json.Unmarshal(body, &r); err != nil {
-		return nil, fmt.Errorf("posts/recent decode: %w", err)
+		return nil, pinboardError(token, "posts/recent decode: %v", err)
 	}
 	return r.Posts, nil
+}
+
+// pinboardHTTPClient refuses cross-host redirects. The auth token travels in
+// the query string (Pinboard's documented form), so following a redirect to
+// another host would hand the credential to that host verbatim. Same-host
+// redirects stay allowed. The ctx deadline set by pullSource bounds every
+// request, so no client-level Timeout is needed.
+var pinboardHTTPClient = &http.Client{
+	CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		if len(via) >= 10 {
+			return errors.New("stopped after 10 redirects")
+		}
+		if len(via) > 0 && req.URL.Host != via[0].URL.Host {
+			return fmt.Errorf("refusing cross-host redirect to %q (the auth token rides in the query string)", req.URL.Host)
+		}
+		return nil
+	},
+}
+
+// redactSecret removes an API token from any string that could reach a log
+// line, a run record, or a terminal.
+//
+// This is not belt-and-braces: Go's net/http builds transport failures as
+// *url.Error, and stripPassword only removes *userinfo* passwords — query
+// parameters are preserved verbatim. So a plain DNS or dial failure yields
+//
+//	Get "https://api.pinboard.in/v1/posts/update?format=json&auth_token=user:HEX": dial tcp ...
+//
+// which would otherwise land in output/runs/*.jsonl, /tmp/scribe-pull.log, and
+// `scribe doctor --section errors` output. A Pinboard token grants full
+// read+write on the account, so it must never survive into any of those.
+func redactSecret(s, token string) string {
+	for _, term := range secretRedactionTerms(token) {
+		s = strings.ReplaceAll(s, term, "REDACTED")
+	}
+	return s
+}
+
+// secretRedactionTerms lists every literal that must not survive redaction:
+// the whole `username:HEX` token, its URL-escaped form, and the HEX half on
+// its own (in case something splits the pair). Longest first, so the full
+// pair is replaced before either half can match inside it. The username half
+// is deliberately NOT redacted — it is not the secret, and blanking a short
+// username would mangle unrelated text.
+func secretRedactionTerms(token string) []string {
+	if strings.TrimSpace(token) == "" {
+		return nil
+	}
+	terms := []string{token, url.QueryEscape(token)}
+	if _, secret, ok := strings.Cut(token, ":"); ok && strings.TrimSpace(secret) != "" {
+		terms = append(terms, secret, url.QueryEscape(secret))
+	}
+	sort.Slice(terms, func(i, j int) bool { return len(terms[i]) > len(terms[j]) })
+	return terms
+}
+
+// pinboardError builds an error whose message is guaranteed free of the API
+// token. The chain is deliberately FLATTENED (errors.New, not %w): keeping the
+// original *url.Error reachable would keep the token reachable with it, since
+// any later caller doing errors.Unwrap(err).Error() would print the raw URL.
+// Nothing in the pull path does errors.Is/As on these, so no behavior is lost.
+func pinboardError(token, format string, args ...any) error {
+	return errors.New(redactSecret(fmt.Sprintf(format, args...), token))
 }
 
 // get issues one authenticated GET and returns the body. auth_token is kept
 // literal (its `username:HEX` colon is a legal query char per RFC 3986) so it
 // matches the documented form exactly; other params are URL-encoded.
+//
+// EVERY error path here runs through pinboardError — the request URL carries
+// the token, so an unsanitized error escaping this function is a credential
+// leak (see redactSecret).
 func (p pinboardSource) get(ctx context.Context, token, endpoint string, q url.Values) ([]byte, error) {
 	full := p.base() + endpoint + "?format=json&auth_token=" + token
 	if enc := q.Encode(); enc != "" {
@@ -266,26 +334,33 @@ func (p pinboardSource) get(ctx context.Context, token, endpoint string, q url.V
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, full, nil)
 	if err != nil {
-		return nil, err
+		// url.Parse failures embed the whole URL in the message.
+		return nil, pinboardError(token, "%s: build request: %v", endpoint, err)
 	}
 	req.Header.Set("User-Agent", "scribe-ingest/1.0")
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := pinboardHTTPClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("%s request: %w", endpoint, err)
+		// *url.Error — carries the token-bearing URL. Also the path a refused
+		// cross-host redirect takes.
+		return nil, pinboardError(token, "%s request: %v", endpoint, err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusTooManyRequests {
-		return nil, fmt.Errorf("%s: rate limited (429) — try again later", endpoint)
+		return nil, pinboardError(token, "%s: rate limited (429) — try again later", endpoint)
 	}
 	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, fmt.Errorf("%s: unauthorized (401) — check the API token", endpoint)
+		return nil, pinboardError(token, "%s: unauthorized (401) — check the API token", endpoint)
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("%s: status %d", endpoint, resp.StatusCode)
+		return nil, pinboardError(token, "%s: status %d", endpoint, resp.StatusCode)
 	}
 	// Guard against a runaway body; a full Pinboard archive is a few MB.
-	return io.ReadAll(io.LimitReader(resp.Body, 64<<20))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 64<<20))
+	if err != nil {
+		return nil, pinboardError(token, "%s: read body: %v", endpoint, err)
+	}
+	return body, nil
 }
 
 // firstNonEmpty returns the first non-empty string, or "".

--- a/cmd/scribe/source_pinboard_failure_test.go
+++ b/cmd/scribe/source_pinboard_failure_test.go
@@ -1,0 +1,327 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// readSingleRunRecord returns the one JSONL line writeRunRecord appended.
+func readSingleRunRecord(t *testing.T, root string) string {
+	t.Helper()
+	runsDir := filepath.Join(root, "output", "runs")
+	entries, err := os.ReadDir(runsDir)
+	if err != nil {
+		t.Fatalf("no run records written: %v", err)
+	}
+	var lines []string
+	for _, e := range entries {
+		if !strings.HasSuffix(e.Name(), ".jsonl") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(runsDir, e.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, ln := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+			if strings.TrimSpace(ln) != "" {
+				lines = append(lines, ln)
+			}
+		}
+	}
+	if len(lines) != 1 {
+		t.Fatalf("want exactly 1 run record, got %d: %v", len(lines), lines)
+	}
+	return lines[0]
+}
+
+// The failure-mode coverage for the Pinboard adapter. The happy-path tests
+// live in source_pinboard_test.go; everything here drives an ERROR path,
+// because that is where the token-leak bug (B1) hid: no test ever looked at
+// what an error message contained.
+//
+// Every test is offline — httptest servers or a closed listener. Nothing here
+// contacts api.pinboard.in.
+
+const (
+	testPinboardUser   = "oliver"
+	testPinboardSecret = "DEADBEEFCAFE1234"
+	testPinboardToken  = testPinboardUser + ":" + testPinboardSecret
+)
+
+// assertNoTokenLeak fails when a string that is about to reach a log line, a
+// run record, or a terminal still carries the credential in any form.
+func assertNoTokenLeak(t *testing.T, what, s string) {
+	t.Helper()
+	for _, bad := range []string{testPinboardToken, testPinboardSecret, "auth_token=" + testPinboardToken} {
+		if strings.Contains(s, bad) {
+			t.Errorf("%s leaks the credential (%q) — full text:\n%s", what, bad, s)
+		}
+	}
+}
+
+// pinboardErrorFrom drives one Fetch against a handler and returns the error.
+func pinboardErrorFrom(t *testing.T, h http.HandlerFunc) error {
+	t.Helper()
+	t.Setenv("SCRIBE_PINBOARD_TOKEN", testPinboardToken)
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+	p := pinboardSource{baseURL: srv.URL + "/"}
+	_, _, err := p.Fetch(context.Background(), pinboardTestCfg(), nil, FetchOpts{Scope: "all"})
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	return err
+}
+
+// TestPinboardTransportErrorRedactsToken is the B1 regression. A dial failure
+// produces a *url.Error whose message embeds the full request URL, and Go only
+// strips userinfo passwords — never query parameters. Before the fix this
+// error reached output/runs/*.jsonl, /tmp/scribe-pull.log, and `scribe doctor`
+// with `auth_token=oliver:DEADBEEFCAFE1234` intact.
+func TestPinboardTransportErrorRedactsToken(t *testing.T) {
+	t.Setenv("SCRIBE_PINBOARD_TOKEN", testPinboardToken)
+
+	// A server that is already closed → guaranteed connection-refused, no
+	// network egress and no dependency on DNS.
+	srv := httptest.NewServer(http.NotFoundHandler())
+	base := srv.URL + "/"
+	srv.Close()
+
+	p := pinboardSource{baseURL: base}
+	_, _, err := p.Fetch(context.Background(), pinboardTestCfg(), nil, FetchOpts{Scope: "all"})
+	if err == nil {
+		t.Fatal("expected a transport error against a closed server")
+	}
+	assertNoTokenLeak(t, "transport error", err.Error())
+
+	// The flattened chain must not smuggle the raw *url.Error back either.
+	for e := err; e != nil; {
+		assertNoTokenLeak(t, "wrapped error in chain", e.Error())
+		next, ok := e.(interface{ Unwrap() error })
+		if !ok {
+			break
+		}
+		e = next.Unwrap()
+	}
+	if !strings.Contains(err.Error(), "REDACTED") {
+		t.Errorf("expected a REDACTED marker in %q", err.Error())
+	}
+}
+
+// TestPinboardHTTPStatusErrorsRedactToken covers the documented failure
+// statuses. None of these embedded the token before the fix, but they share
+// the get() error path, so they must stay clean as it evolves.
+func TestPinboardHTTPStatusErrorsRedactToken(t *testing.T) {
+	cases := []struct {
+		name string
+		code int
+		want string
+	}{
+		{"rate limited", http.StatusTooManyRequests, "rate limited (429)"},
+		{"unauthorized", http.StatusUnauthorized, "unauthorized (401)"},
+		{"server error", http.StatusInternalServerError, "status 500"},
+		{"gateway", http.StatusBadGateway, "status 502"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := pinboardErrorFrom(t, func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.code)
+			})
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error = %q, want it to mention %q", err, tc.want)
+			}
+			assertNoTokenLeak(t, tc.name+" error", err.Error())
+		})
+	}
+}
+
+// TestPinboardMalformedResponseErrors covers a truncated / non-JSON body —
+// an upstream proxy serving an HTML error page, say. It must fail cleanly
+// rather than panic or silently yield zero items.
+func TestPinboardMalformedResponseErrors(t *testing.T) {
+	cases := map[string]string{
+		"html error page": "<html><body>502 Bad Gateway</body></html>",
+		"truncated json":  `[{"href":"https://a.com","desc`,
+		"empty body":      "",
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := pinboardErrorFrom(t, func(w http.ResponseWriter, _ *http.Request) {
+				io.WriteString(w, body)
+			})
+			if !strings.Contains(err.Error(), "decode") {
+				t.Errorf("error = %q, want a decode error", err)
+			}
+			assertNoTokenLeak(t, name+" decode error", err.Error())
+		})
+	}
+}
+
+// TestPinboardRefusesCrossHostRedirect is the B2 regression: the token rides
+// in the query string, so a redirect to another host would hand the
+// credential over. Same-host redirects stay allowed.
+func TestPinboardRefusesCrossHostRedirect(t *testing.T) {
+	t.Setenv("SCRIBE_PINBOARD_TOKEN", testPinboardToken)
+
+	var attackerSawToken string
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attackerSawToken = r.URL.Query().Get("auth_token")
+		io.WriteString(w, `{"update_time":"2026-07-01T10:00:00Z"}`)
+	}))
+	defer attacker.Close()
+
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, attacker.URL+r.URL.Path, http.StatusFound)
+	}))
+	defer redirector.Close()
+
+	p := pinboardSource{baseURL: redirector.URL + "/"}
+	_, _, err := p.Fetch(context.Background(), pinboardTestCfg(), nil, FetchOpts{Scope: "all"})
+	if err == nil {
+		t.Fatal("a cross-host redirect must be refused, got nil error")
+	}
+	if attackerSawToken != "" {
+		t.Errorf("token was forwarded to the redirect target: %q", attackerSawToken)
+	}
+	if !strings.Contains(err.Error(), "cross-host redirect") {
+		t.Errorf("error = %q, want it to name the refused redirect", err)
+	}
+	assertNoTokenLeak(t, "redirect refusal error", err.Error())
+}
+
+// TestPinboardAllowsSameHostRedirect guards against over-correcting: the
+// refusal must not break a legitimate same-host redirect.
+func TestPinboardAllowsSameHostRedirect(t *testing.T) {
+	t.Setenv("SCRIBE_PINBOARD_TOKEN", testPinboardToken)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/posts/update", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/real/update?"+r.URL.RawQuery, http.StatusFound)
+	})
+	mux.HandleFunc("/real/update", func(w http.ResponseWriter, _ *http.Request) {
+		io.WriteString(w, `{"update_time":"2026-07-01T10:00:00Z"}`)
+	})
+	mux.HandleFunc("/posts/all", func(w http.ResponseWriter, _ *http.Request) {
+		io.WriteString(w, `[{"href":"https://a.com","description":"A","hash":"h-a"}]`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	p := pinboardSource{baseURL: srv.URL + "/"}
+	items, _, err := p.Fetch(context.Background(), pinboardTestCfg(), nil, FetchOpts{Scope: "all"})
+	if err != nil {
+		t.Fatalf("same-host redirect should be followed: %v", err)
+	}
+	if len(items) != 1 {
+		t.Errorf("items = %d, want 1", len(items))
+	}
+}
+
+// TestRedactSecretCoversEveryForm pins the redaction helper itself.
+func TestRedactSecretCoversEveryForm(t *testing.T) {
+	cases := []struct {
+		name, in string
+	}{
+		{"raw pair", `Get "https://api.pinboard.in/v1/posts/all?auth_token=` + testPinboardToken + `": dial tcp`},
+		{"escaped pair", "https://x/?auth_token=oliver%3ADEADBEEFCAFE1234"},
+		{"bare secret", "token was " + testPinboardSecret + " somewhere"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assertNoTokenLeak(t, tc.name, redactSecret(tc.in, testPinboardToken))
+		})
+	}
+
+	// The username half is NOT a secret and must survive, or short usernames
+	// would mangle unrelated text.
+	if got := redactSecret("user oliver hit a wall", testPinboardToken); got != "user oliver hit a wall" {
+		t.Errorf("username should not be redacted, got %q", got)
+	}
+	// An empty token must be a no-op, not a replace-everything.
+	if got := redactSecret("nothing to hide", ""); got != "nothing to hide" {
+		t.Errorf("empty token should be a no-op, got %q", got)
+	}
+}
+
+// TestFetchErrorsPropagateThroughPullSource proves the sanitized message
+// survives the full path a cron run takes: Fetch → pullSource → the error the
+// CLI logs and hands to writeRunRecord.
+func TestFetchErrorsPropagateThroughPullSource(t *testing.T) {
+	t.Setenv("SCRIBE_PINBOARD_TOKEN", testPinboardToken)
+	root := testKB(t, "integrations:\n  pinboard:\n    enabled: true\n    scope: all\n")
+
+	srv := httptest.NewServer(http.NotFoundHandler())
+	base := srv.URL + "/"
+	srv.Close()
+
+	n, err := pullSource(root, pinboardSource{baseURL: base}, FetchOpts{}, 0, false)
+	if err == nil {
+		t.Fatal("expected the transport failure to surface")
+	}
+	if n != 0 {
+		t.Errorf("queued %d on a failed fetch, want 0", n)
+	}
+	assertNoTokenLeak(t, "pullSource error", err.Error())
+	// And the run-record redaction is the second line of defense.
+	assertNoTokenLeak(t, "run-record error", redactURLToken(err.Error()))
+}
+
+// TestRedactURLTokenMatchesPrefixedParams pins the main.go regex fix. Before
+// it, `auth_token=` matched nothing: `auth` needs `=` right after it and
+// `token` needs `?`/`&` right before it.
+func TestRedactURLTokenMatchesPrefixedParams(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"https://x/?auth_token=oliver:HEX", "https://x/?auth_token=REDACTED"},
+		{"https://x/?format=json&auth_token=oliver:HEX", "https://x/?format=json&auth_token=REDACTED"},
+		{"https://x/?access_token=abc", "https://x/?access_token=REDACTED"},
+		{"https://x/?api_key=abc", "https://x/?api_key=REDACTED"},
+		{"https://x/?private_token=abc", "https://x/?private_token=REDACTED"},
+		{"https://x/?token=abc", "https://x/?token=REDACTED"},
+		// The value stops at a quote so the rest of a url.Error stays readable.
+		{`Get "https://x/?auth_token=oliver:HEX": dial tcp`, `Get "https://x/?auth_token=REDACTED": dial tcp`},
+		// Non-secret params must be left alone.
+		{"https://x/?format=json&count=100", "https://x/?format=json&count=100"},
+	}
+	for _, tc := range cases {
+		if got := redactURLToken(tc.in); got != tc.want {
+			t.Errorf("redactURLToken(%q)\n  got  %q\n  want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestWriteRunRecordRedactsErrorToken drives the real writeRunRecord and reads
+// the JSONL back: this is the file `scribe doctor --section errors` prints.
+func TestWriteRunRecordRedactsErrorToken(t *testing.T) {
+	root := testKB(t, "")
+	t.Setenv("SCRIBE_KB", root)
+
+	leaky := errors.New(`pinboard fetch: Get "https://api.pinboard.in/v1/posts/all?format=json&auth_token=` +
+		testPinboardToken + `": dial tcp: no such host`)
+	writeRunRecord("pull", time.Now(), leaky)
+
+	data := readSingleRunRecord(t, root)
+	var rec struct {
+		Command string `json:"command"`
+		Status  string `json:"status"`
+		Error   string `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(data), &rec); err != nil {
+		t.Fatalf("run record is not valid JSON: %v\n%s", err, data)
+	}
+	if rec.Command != "pull" || rec.Status != "error" {
+		t.Errorf("unexpected record: %+v", rec)
+	}
+	assertNoTokenLeak(t, "run record error field", rec.Error)
+	assertNoTokenLeak(t, "run record raw line", data)
+}

--- a/cmd/scribe/source_pinboard_test.go
+++ b/cmd/scribe/source_pinboard_test.go
@@ -57,6 +57,7 @@ func TestPinboardToItem(t *testing.T) {
 		Tags:        "go  rust   elixir",
 		Time:        "2026-06-01T12:00:00Z",
 		ToRead:      "yes",
+		Shared:      "no",
 		Hash:        "abc123",
 	}
 	it, ok := post.toItem()
@@ -77,6 +78,9 @@ func TestPinboardToItem(t *testing.T) {
 	}
 	if !it.Unread {
 		t.Error("Unread = false, want true for toread=yes")
+	}
+	if !it.Private {
+		t.Error("Private = false, want true for shared=no")
 	}
 	if it.ID != "abc123" {
 		t.Errorf("ID = %q, want the hash", it.ID)

--- a/cmd/scribe/source_pinboard_test.go
+++ b/cmd/scribe/source_pinboard_test.go
@@ -1,0 +1,236 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// fakePinboard stands in for api.pinboard.in. It records how many times each
+// endpoint was hit so the short-circuit behavior is observable, and asserts
+// the auth token + format are passed on every call.
+func fakePinboard(t *testing.T, hits map[string]int) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	guard := func(next http.HandlerFunc) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("auth_token"); got != "user:TESTTOKEN" {
+				t.Errorf("auth_token = %q, want user:TESTTOKEN", got)
+			}
+			if got := r.URL.Query().Get("format"); got != "json" {
+				t.Errorf("format = %q, want json", got)
+			}
+			next(w, r)
+		}
+	}
+	mux.HandleFunc("/posts/update", guard(func(w http.ResponseWriter, _ *http.Request) {
+		hits["update"]++
+		io.WriteString(w, `{"update_time":"2026-07-01T10:00:00Z"}`)
+	}))
+	mux.HandleFunc("/posts/all", guard(func(w http.ResponseWriter, r *http.Request) {
+		hits["all"]++
+		if r.URL.Query().Get("toread") == "yes" {
+			io.WriteString(w, `[{"href":"https://u.com","description":"Unread","tags":"read-later","time":"2026-06-01T00:00:00Z","toread":"yes","hash":"h-unread"}]`)
+			return
+		}
+		io.WriteString(w, `[{"href":"https://a.com","description":"A","extended":"note a","tags":"go rust","time":"2026-06-01T00:00:00Z","toread":"no","hash":"h-a"}]`)
+	}))
+	mux.HandleFunc("/posts/recent", guard(func(w http.ResponseWriter, _ *http.Request) {
+		hits["recent"]++
+		io.WriteString(w, `{"posts":[{"href":"https://r.com","description":"R","tags":"","time":"2026-06-02T00:00:00Z","toread":"no","hash":"h-r"}]}`)
+	}))
+	return httptest.NewServer(mux)
+}
+
+func pinboardTestCfg() *ScribeConfig {
+	return &ScribeConfig{Integrations: IntegrationsConfig{"pinboard": {Enabled: true}}}
+}
+
+func TestPinboardToItem(t *testing.T) {
+	post := pinboardPost{
+		Href:        "https://example.com/x",
+		Description: "  Title  ",
+		Extended:    "my note",
+		Tags:        "go  rust   elixir",
+		Time:        "2026-06-01T12:00:00Z",
+		ToRead:      "yes",
+		Hash:        "abc123",
+	}
+	it, ok := post.toItem()
+	if !ok {
+		t.Fatal("toItem returned ok=false for a valid post")
+	}
+	if it.URL != "https://example.com/x" {
+		t.Errorf("URL = %q", it.URL)
+	}
+	if it.Title != "Title" {
+		t.Errorf("Title = %q, want trimmed", it.Title)
+	}
+	if it.Note != "my note" {
+		t.Errorf("Note = %q", it.Note)
+	}
+	if len(it.Tags) != 3 || it.Tags[0] != "go" || it.Tags[2] != "elixir" {
+		t.Errorf("Tags = %v, want [go rust elixir]", it.Tags)
+	}
+	if !it.Unread {
+		t.Error("Unread = false, want true for toread=yes")
+	}
+	if it.ID != "abc123" {
+		t.Errorf("ID = %q, want the hash", it.ID)
+	}
+	if it.CreatedAt.IsZero() {
+		t.Error("CreatedAt is zero, want parsed time")
+	}
+}
+
+func TestPinboardToItemEmptyHrefSkipped(t *testing.T) {
+	if _, ok := (pinboardPost{Href: "  "}).toItem(); ok {
+		t.Error("blank href should yield ok=false")
+	}
+}
+
+func TestPinboardToItemIDFallsBackToHref(t *testing.T) {
+	it, _ := pinboardPost{Href: "https://h.com"}.toItem()
+	if it.ID != "https://h.com" {
+		t.Errorf("ID = %q, want href fallback when hash empty", it.ID)
+	}
+}
+
+func TestMergePostsByHash(t *testing.T) {
+	a := []pinboardPost{{Href: "https://1", Hash: "h1"}, {Href: "https://2", Hash: "h2"}}
+	b := []pinboardPost{{Href: "https://2", Hash: "h2"}, {Href: "https://3", Hash: "h3"}}
+	got := mergePostsByHash(a, b)
+	if len(got) != 3 {
+		t.Fatalf("merged len = %d, want 3 (dedup h2)", len(got))
+	}
+	if got[0].Hash != "h1" || got[2].Hash != "h3" {
+		t.Errorf("order not preserved: %+v", got)
+	}
+}
+
+func TestPinboardFetchScopeAll(t *testing.T) {
+	t.Setenv("SCRIBE_PINBOARD_TOKEN", "user:TESTTOKEN")
+	hits := map[string]int{}
+	srv := fakePinboard(t, hits)
+	defer srv.Close()
+	p := pinboardSource{baseURL: srv.URL + "/"}
+
+	items, cur, err := p.Fetch(context.Background(), pinboardTestCfg(), nil, FetchOpts{Scope: "all"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(items) != 1 || items[0].ID != "h-a" {
+		t.Fatalf("items = %+v, want one h-a", items)
+	}
+	if hits["update"] != 1 || hits["all"] != 1 || hits["recent"] != 0 {
+		t.Errorf("hits = %v, want update=1 all=1 recent=0", hits)
+	}
+	var pc pinboardCursor
+	if err := json.Unmarshal(cur, &pc); err != nil || pc.UpdateTime != "2026-07-01T10:00:00Z" {
+		t.Errorf("cursor = %s (err %v), want update_time persisted", cur, err)
+	}
+}
+
+func TestPinboardUpdateShortCircuit(t *testing.T) {
+	t.Setenv("SCRIBE_PINBOARD_TOKEN", "user:TESTTOKEN")
+	hits := map[string]int{}
+	srv := fakePinboard(t, hits)
+	defer srv.Close()
+	p := pinboardSource{baseURL: srv.URL + "/"}
+
+	// Cursor already at the server's update_time → nothing changed.
+	prev, err := json.Marshal(pinboardCursor{UpdateTime: "2026-07-01T10:00:00Z"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	items, cur, err := p.Fetch(context.Background(), pinboardTestCfg(), prev, FetchOpts{Scope: "all"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(items) != 0 {
+		t.Errorf("items = %d, want 0 on unchanged account", len(items))
+	}
+	if hits["all"] != 0 {
+		t.Errorf("posts/all hit %d times, want 0 (short-circuit before the expensive call)", hits["all"])
+	}
+	if string(cur) != string(prev) {
+		t.Errorf("cursor changed on short-circuit: %s", cur)
+	}
+}
+
+func TestPinboardForceBypassesShortCircuit(t *testing.T) {
+	t.Setenv("SCRIBE_PINBOARD_TOKEN", "user:TESTTOKEN")
+	hits := map[string]int{}
+	srv := fakePinboard(t, hits)
+	defer srv.Close()
+	p := pinboardSource{baseURL: srv.URL + "/"}
+
+	prev, err := json.Marshal(pinboardCursor{UpdateTime: "2026-07-01T10:00:00Z"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	items, _, err := p.Fetch(context.Background(), pinboardTestCfg(), prev, FetchOpts{Scope: "all", Force: true})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(items) != 1 {
+		t.Errorf("items = %d, want 1 (force bypasses short-circuit)", len(items))
+	}
+	if hits["all"] != 1 {
+		t.Errorf("posts/all hit %d times, want 1", hits["all"])
+	}
+}
+
+func TestPinboardRecentUnreadUnions(t *testing.T) {
+	t.Setenv("SCRIBE_PINBOARD_TOKEN", "user:TESTTOKEN")
+	hits := map[string]int{}
+	srv := fakePinboard(t, hits)
+	defer srv.Close()
+	p := pinboardSource{baseURL: srv.URL + "/"}
+
+	items, _, err := p.Fetch(context.Background(), pinboardTestCfg(), nil, FetchOpts{Scope: "recent+unread"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("items = %d, want 2 (recent ∪ unread)", len(items))
+	}
+	if hits["recent"] != 1 || hits["all"] != 1 {
+		t.Errorf("hits = %v, want recent=1 all=1", hits)
+	}
+}
+
+func TestPinboardUnknownScopeErrors(t *testing.T) {
+	t.Setenv("SCRIBE_PINBOARD_TOKEN", "user:TESTTOKEN")
+	hits := map[string]int{}
+	srv := fakePinboard(t, hits)
+	defer srv.Close()
+	p := pinboardSource{baseURL: srv.URL + "/"}
+
+	if _, _, err := p.Fetch(context.Background(), pinboardTestCfg(), nil, FetchOpts{Scope: "bogus"}); err == nil {
+		t.Error("an unknown scope should error")
+	}
+}
+
+func TestPinboardConfiguredGates(t *testing.T) {
+	p := pinboardSource{}
+
+	// disabled
+	if ok, _ := p.Configured(&ScribeConfig{}); ok {
+		t.Error("Configured true with no integrations block")
+	}
+	// enabled but no token
+	t.Setenv("SCRIBE_PINBOARD_TOKEN", "")
+	cfg := &ScribeConfig{Integrations: IntegrationsConfig{"pinboard": {Enabled: true}}}
+	if ok, reason := p.Configured(cfg); ok || reason == "" {
+		t.Errorf("Configured should fail without a token, got ok=%v reason=%q", ok, reason)
+	}
+	// enabled + token
+	t.Setenv("SCRIBE_PINBOARD_TOKEN", "user:TESTTOKEN")
+	if ok, reason := p.Configured(cfg); !ok {
+		t.Errorf("Configured false with token present: %q", reason)
+	}
+}

--- a/cmd/scribe/source_test.go
+++ b/cmd/scribe/source_test.go
@@ -223,6 +223,49 @@ func TestPullSourceTagFilterOverride(t *testing.T) {
 	}
 }
 
+func TestPullSourcePublicOnly(t *testing.T) {
+	// public_only: true drops items marked Private; public items pass.
+	root := testKB(t, "integrations:\n  fake:\n    public_only: true\n")
+	src := &fakeSource{name: "fake", items: []SourceItem{
+		{URL: "https://pub.com", ID: "p", Title: "p"},
+		{URL: "https://priv.com", ID: "q", Title: "q", Private: true},
+	}}
+	n, err := pullSource(root, src, FetchOpts{}, 0, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("queued %d, want 1 (private dropped)", n)
+	}
+	files := inboxFiles(t, root)
+	if len(files) != 1 || !strings.Contains(files[0], "pub-com") {
+		t.Errorf("inbox = %v, want only the public entry", files)
+	}
+	// Private item is NOT marked seen (flipping public_only off re-includes it).
+	st, _ := loadSourceState(sourceStatePath(root, "fake"))
+	for _, id := range st.Seen {
+		if id == "q" {
+			t.Error("private item marked seen; should stay eligible")
+		}
+	}
+}
+
+func TestPullSourcePublicOnlyOverride(t *testing.T) {
+	// --public-only forces the filter on even when config leaves it false.
+	root := testKB(t, "")
+	src := &fakeSource{name: "fake", items: []SourceItem{
+		{URL: "https://pub.com", ID: "p", Title: "p"},
+		{URL: "https://priv.com", ID: "q", Title: "q", Private: true},
+	}}
+	n, err := pullSource(root, src, FetchOpts{PublicOnly: true}, 0, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("queued %d, want 1 (--public-only drops private)", n)
+	}
+}
+
 func TestPullSourceNoTagFilterKeepsAll(t *testing.T) {
 	root := testKB(t, "")
 	src := &fakeSource{name: "fake", items: []SourceItem{

--- a/cmd/scribe/source_test.go
+++ b/cmd/scribe/source_test.go
@@ -1,0 +1,348 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fakeSource is a deterministic Source for driver tests. It records how many
+// times Fetch ran so short-circuit/dedup behavior is observable.
+type fakeSource struct {
+	name       string
+	items      []SourceItem
+	cursor     string
+	fetchCount int
+}
+
+func (f *fakeSource) Name() string                            { return f.name }
+func (f *fakeSource) Configured(*ScribeConfig) (bool, string) { return true, "" }
+func (f *fakeSource) Fetch(_ context.Context, _ *ScribeConfig, _ json.RawMessage, _ FetchOpts) ([]SourceItem, json.RawMessage, error) {
+	f.fetchCount++
+	cur, err := json.Marshal(map[string]string{"c": f.cursor})
+	if err != nil {
+		return nil, nil, err
+	}
+	return f.items, cur, nil
+}
+
+// testKB writes a minimal scribe.yaml pointing lock_dir at an isolated temp
+// dir, so pullSource never touches the machine-wide /tmp lock the real cron
+// uses. Extra yaml lines let callers add an integrations block.
+func testKB(t *testing.T, extraYAML string) string {
+	t.Helper()
+	root := t.TempDir()
+	lockDir := t.TempDir()
+	yaml := "lock_dir: " + lockDir + "\n" + extraYAML
+	if err := os.WriteFile(filepath.Join(root, "scribe.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func inboxFiles(t *testing.T, root string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(filepath.Join(root, "output", "inbox"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		t.Fatal(err)
+	}
+	var out []string
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".url") {
+			out = append(out, e.Name())
+		}
+	}
+	return out
+}
+
+func item(url, id string) SourceItem { return SourceItem{URL: url, ID: id, Title: id} }
+
+func TestPullSourceQueuesAndDedups(t *testing.T) {
+	root := testKB(t, "")
+	src := &fakeSource{name: "fake", cursor: "v1", items: []SourceItem{
+		item("https://a.com", "a"),
+		item("https://b.com", "b"),
+		item("https://c.com", "c"),
+	}}
+
+	n, err := pullSource(root, src, FetchOpts{}, 0, false)
+	if err != nil {
+		t.Fatalf("pullSource: %v", err)
+	}
+	if n != 3 {
+		t.Fatalf("queued %d, want 3", n)
+	}
+	if got := inboxFiles(t, root); len(got) != 3 {
+		t.Fatalf("inbox has %d .url files, want 3: %v", len(got), got)
+	}
+
+	// State persisted: seen has all three, cursor advanced.
+	st, err := loadSourceState(sourceStatePath(root, "fake"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(st.Seen) != 3 {
+		t.Errorf("seen = %v, want 3 ids", st.Seen)
+	}
+	if len(st.Cursor) == 0 {
+		t.Error("cursor not persisted after a complete pass")
+	}
+	if st.LastPull == "" {
+		t.Error("last_pull not stamped")
+	}
+
+	// Second run with the same items → nothing new queued (dedup via seen).
+	n2, err := pullSource(root, src, FetchOpts{}, 0, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n2 != 0 {
+		t.Errorf("second run queued %d, want 0 (all seen)", n2)
+	}
+	if got := inboxFiles(t, root); len(got) != 3 {
+		t.Errorf("inbox grew to %d, want still 3", len(got))
+	}
+}
+
+func TestPullSourceMaxCapDoesNotAdvanceCursor(t *testing.T) {
+	root := testKB(t, "")
+	src := &fakeSource{name: "fake", cursor: "v1", items: []SourceItem{
+		item("https://1", "1"), item("https://2", "2"), item("https://3", "3"),
+		item("https://4", "4"), item("https://5", "5"),
+	}}
+
+	// Capped run: only 2 of 5 queued, cursor must NOT advance so a later
+	// backfill run resumes instead of being short-circuited away.
+	n, err := pullSource(root, src, FetchOpts{}, 2, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 2 {
+		t.Fatalf("queued %d, want 2 (capped)", n)
+	}
+	st, _ := loadSourceState(sourceStatePath(root, "fake"))
+	if len(st.Cursor) != 0 {
+		t.Errorf("cursor advanced on a capped run: %s", st.Cursor)
+	}
+	if len(st.Seen) != 2 {
+		t.Errorf("seen = %v, want the 2 queued ids", st.Seen)
+	}
+
+	// Uncapped follow-up queues the remaining 3 and advances the cursor.
+	n2, err := pullSource(root, src, FetchOpts{}, 0, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n2 != 3 {
+		t.Fatalf("follow-up queued %d, want 3", n2)
+	}
+	st2, _ := loadSourceState(sourceStatePath(root, "fake"))
+	if len(st2.Cursor) == 0 {
+		t.Error("cursor not advanced after a complete pass")
+	}
+	if len(st2.Seen) != 5 {
+		t.Errorf("seen = %v, want all 5", st2.Seen)
+	}
+}
+
+func TestPullSourceSkipDomains(t *testing.T) {
+	root := testKB(t, "integrations:\n  fake:\n    skip_domains: [\"skip.com\"]\n")
+	src := &fakeSource{name: "fake", items: []SourceItem{
+		item("https://keep.com/x", "k"),
+		item("https://skip.com/y", "s"),
+	}}
+	n, err := pullSource(root, src, FetchOpts{}, 0, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("queued %d, want 1 (skip.com filtered)", n)
+	}
+	files := inboxFiles(t, root)
+	if len(files) != 1 || !strings.Contains(files[0], "keep-com") {
+		t.Errorf("inbox = %v, want only the keep.com entry", files)
+	}
+	// Skipped item is NOT marked seen (a later config change may allow it).
+	st, _ := loadSourceState(sourceStatePath(root, "fake"))
+	for _, id := range st.Seen {
+		if id == "s" {
+			t.Error("skipped item marked seen; should stay eligible")
+		}
+	}
+}
+
+func taggedItem(url, id string, tags ...string) SourceItem {
+	return SourceItem{URL: url, ID: id, Title: id, Tags: tags}
+}
+
+func TestPullSourceTagFilterFromConfig(t *testing.T) {
+	// OR filter: keep bookmarks carrying at least one configured tag, case-
+	// insensitively; drop the rest; untagged config ingests all.
+	root := testKB(t, "integrations:\n  fake:\n    tags: [\"kb\", \"read\"]\n")
+	src := &fakeSource{name: "fake", items: []SourceItem{
+		taggedItem("https://a.com", "a", "go", "KB"),  // has kb (case-insensitive) → keep
+		taggedItem("https://b.com", "b", "rust"),      // no match → drop
+		taggedItem("https://c.com", "c", "read", "x"), // has read → keep
+		taggedItem("https://d.com", "d"),              // no tags → drop
+	}}
+	n, err := pullSource(root, src, FetchOpts{}, 0, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 2 {
+		t.Fatalf("queued %d, want 2 (a and c)", n)
+	}
+	st, _ := loadSourceState(sourceStatePath(root, "fake"))
+	// Filtered-out items are NOT marked seen (widening the filter re-includes).
+	for _, id := range st.Seen {
+		if id == "b" || id == "d" {
+			t.Errorf("filtered item %q marked seen; should stay eligible", id)
+		}
+	}
+}
+
+func TestPullSourceTagFilterOverride(t *testing.T) {
+	// A per-run --tag override (FetchOpts.Tags) wins over the configured tags.
+	root := testKB(t, "integrations:\n  fake:\n    tags: [\"kb\"]\n")
+	src := &fakeSource{name: "fake", items: []SourceItem{
+		taggedItem("https://a.com", "a", "kb"),
+		taggedItem("https://b.com", "b", "elixir"),
+	}}
+	n, err := pullSource(root, src, FetchOpts{Tags: []string{"elixir"}}, 0, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("queued %d, want 1 (override selects elixir, not kb)", n)
+	}
+}
+
+func TestPullSourceNoTagFilterKeepsAll(t *testing.T) {
+	root := testKB(t, "")
+	src := &fakeSource{name: "fake", items: []SourceItem{
+		taggedItem("https://a.com", "a", "go"),
+		taggedItem("https://b.com", "b"),
+	}}
+	n, err := pullSource(root, src, FetchOpts{}, 0, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 2 {
+		t.Fatalf("queued %d, want 2 (no filter = all)", n)
+	}
+}
+
+func TestPullSourceDryRunWritesNothing(t *testing.T) {
+	root := testKB(t, "")
+	src := &fakeSource{name: "fake", items: []SourceItem{item("https://a.com", "a")}}
+	n, err := pullSource(root, src, FetchOpts{}, 0, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Errorf("dry-run reported %d would-queue, want 1", n)
+	}
+	if got := inboxFiles(t, root); len(got) != 0 {
+		t.Errorf("dry-run wrote %d files, want 0", len(got))
+	}
+	if _, err := os.Stat(sourceStatePath(root, "fake")); !os.IsNotExist(err) {
+		t.Error("dry-run wrote a state file, want none")
+	}
+}
+
+func TestSourceItemToQueue(t *testing.T) {
+	it := SourceItem{
+		URL:    "https://x.com",
+		Title:  "X",
+		Tags:   []string{"go"},
+		Note:   "annotation",
+		Unread: true,
+	}
+	f := sourceItemToQueue("pinboard", it)
+	if f.Source != "pinboard" {
+		t.Errorf("Source = %q", f.Source)
+	}
+	if f.Note != "annotation" {
+		t.Errorf("Note = %q", f.Note)
+	}
+	if !containsFold(f.Tags, "to-read") {
+		t.Errorf("Tags = %v, want to-read added for unread", f.Tags)
+	}
+	if f.Domain != "general" {
+		t.Errorf("Domain = %q, want general", f.Domain)
+	}
+}
+
+func TestQueueNoteRoundTrip(t *testing.T) {
+	cases := []string{
+		"single line",
+		"line one\nline two",
+		"has a \\ backslash",
+		"windows\r\nnewline",
+		"",
+	}
+	for _, in := range cases {
+		got := decodeQueueNote(encodeQueueNote(in))
+		want := strings.ReplaceAll(in, "\r\n", "\n")
+		if got != want {
+			t.Errorf("roundtrip(%q) = %q, want %q", in, got, want)
+		}
+		if strings.Contains(encodeQueueNote(in), "\n") {
+			t.Errorf("encoded note still contains a raw newline: %q", encodeQueueNote(in))
+		}
+	}
+}
+
+func TestQueueNoteBlockquote(t *testing.T) {
+	got := queueNoteBlockquote("first\nsecond")
+	if got != "> first\n> second" {
+		t.Errorf("blockquote = %q", got)
+	}
+}
+
+func TestWriteQueueEntryRoundTripsNoteAndSource(t *testing.T) {
+	inbox := t.TempDir()
+	path, err := writeQueueEntry(inbox, queueFields{
+		URL:    "https://x.com",
+		Title:  "X",
+		Tags:   []string{"go", "pinboard"},
+		Note:   "line one\nline two",
+		Source: "pinboard",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry := parseQueueEntry(string(data))
+	if entry["url"] != "https://x.com" || entry["source"] != "pinboard" {
+		t.Errorf("parsed entry missing fields: %v", entry)
+	}
+	if decodeQueueNote(entry["note"]) != "line one\nline two" {
+		t.Errorf("note did not round-trip: %q", entry["note"])
+	}
+}
+
+func TestWriteQueueEntryUniquePaths(t *testing.T) {
+	inbox := t.TempDir()
+	// Same URL twice → the second must not overwrite the first.
+	p1, err := writeQueueEntry(inbox, queueFields{URL: "https://x.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	p2, err := writeQueueEntry(inbox, queueFields{URL: "https://x.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p1 == p2 {
+		t.Errorf("both entries wrote to %s; expected disambiguated paths", p1)
+	}
+}

--- a/cmd/scribe/source_test.go
+++ b/cmd/scribe/source_test.go
@@ -223,6 +223,37 @@ func TestPullSourceTagFilterOverride(t *testing.T) {
 	}
 }
 
+func TestPullSourceTagsModeAll(t *testing.T) {
+	// tags_mode: all flips the filter to AND — only bookmarks carrying EVERY
+	// configured tag pass (Pinboard's own /t:a/t:b/ semantics), still
+	// case-insensitively.
+	root := testKB(t, "integrations:\n  fake:\n    tags: [\"elixir\", \"concurrency\"]\n    tags_mode: all\n")
+	src := &fakeSource{name: "fake", items: []SourceItem{
+		taggedItem("https://a.com", "a", "Elixir", "concurrency"), // both → keep
+		taggedItem("https://b.com", "b", "elixir"),                // one of two → drop
+		taggedItem("https://c.com", "c", "concurrency", "otp"),    // one of two → drop
+		taggedItem("https://d.com", "d"),                          // none → drop
+	}}
+	n, err := pullSource(root, src, FetchOpts{}, 0, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("queued %d, want 1 (only a carries both tags)", n)
+	}
+}
+
+func TestPullSourceTagsModeInvalid(t *testing.T) {
+	// A typo in tags_mode must fail loudly, not silently widen the filter.
+	root := testKB(t, "integrations:\n  fake:\n    tags: [\"kb\"]\n    tags_mode: sometimes\n")
+	src := &fakeSource{name: "fake", items: []SourceItem{
+		taggedItem("https://a.com", "a", "kb"),
+	}}
+	if _, err := pullSource(root, src, FetchOpts{}, 0, false); err == nil || !strings.Contains(err.Error(), "tags_mode") {
+		t.Fatalf("err = %v, want a tags_mode config error", err)
+	}
+}
+
 func TestPullSourcePublicOnly(t *testing.T) {
 	// public_only: true drops items marked Private; public items pass.
 	root := testKB(t, "integrations:\n  fake:\n    public_only: true\n")

--- a/cmd/scribe/templates/scribe.yaml
+++ b/cmd/scribe/templates/scribe.yaml
@@ -343,10 +343,12 @@ capture:
 #   pinboard:
 #     enabled: true
 #     scope: recent+unread    # recent+unread | unread | all  (by read-state/recency)
-#     tags: []                # OR filter: only ingest bookmarks with >=1 of these
-#                             # tags (case-insensitive); empty = all. Orthogonal to
-#                             # scope, e.g. scope: all + tags: [kb] = everything
-#                             # you ever tagged "kb".
+#     tags: []                # tag filter (case-insensitive); empty = all.
+#                             # Orthogonal to scope, e.g. scope: all + tags: [kb]
+#                             # = everything you ever tagged "kb".
+#     tags_mode: any          # any = carries >=1 listed tag (default, ingest-gate
+#                             # shape); all = must carry EVERY listed tag (how
+#                             # pinboard.in/t:a/t:b/ narrows).
 #     public_only: false      # true = skip private bookmarks (an authenticated
 #                             # pull sees private ones too); default ingests all.
 #     skip_domains: []        # substring filter, same as capture.skip_domains

--- a/cmd/scribe/templates/scribe.yaml
+++ b/cmd/scribe/templates/scribe.yaml
@@ -347,6 +347,8 @@ capture:
 #                             # tags (case-insensitive); empty = all. Orthogonal to
 #                             # scope, e.g. scope: all + tags: [kb] = everything
 #                             # you ever tagged "kb".
+#     public_only: false      # true = skip private bookmarks (an authenticated
+#                             # pull sees private ones too); default ingests all.
 #     skip_domains: []        # substring filter, same as capture.skip_domains
 #
 # Token goes in ~/.config/scribe/config.yaml:

--- a/cmd/scribe/templates/scribe.yaml
+++ b/cmd/scribe/templates/scribe.yaml
@@ -332,6 +332,27 @@ capture:
   self_chat_handles:
     - "{{.SelfChatHandle}}"
 
+# Pull adapters — external accounts `scribe pull` fetches bookmarks from into
+# the ingest queue (output/inbox/), drained by the same path as `ingest url`.
+# API tokens NEVER live here: put them in ~/.config/scribe/config.yaml under
+# integration_tokens (gitignored, per-machine), or export SCRIBE_<NAME>_TOKEN.
+# Personal source like capture — disabled in team mode; re-enable per-person
+# in scribe.local.yaml.
+#
+# integrations:
+#   pinboard:
+#     enabled: true
+#     scope: recent+unread    # recent+unread | unread | all  (by read-state/recency)
+#     tags: []                # OR filter: only ingest bookmarks with >=1 of these
+#                             # tags (case-insensitive); empty = all. Orthogonal to
+#                             # scope, e.g. scope: all + tags: [kb] = everything
+#                             # you ever tagged "kb".
+#     skip_domains: []        # substring filter, same as capture.skip_domains
+#
+# Token goes in ~/.config/scribe/config.yaml:
+#   integration_tokens:
+#     pinboard: "username:HEXTOKEN"   # from pinboard.in/settings/password
+
 # Triage keyword categories for `scribe triage` (weighted FTS5 keyword scoring).
 # Edit any MATCH expression to tune to your stack. Weights multiply per hit.
 triage:


### PR DESCRIPTION
## What

Adds **`scribe pull`** — a generic pull-adapter framework for ingesting bookmarks from external accounts — and **Pinboard** (<https://pinboard.in>) as the first adapter.

Adapters are **URL producers only**: they queue bookmarks into `output/inbox/`, and the existing `ingest drain` path does the fetch → contextualize → absorb. So `pull` is deterministic and LLM-free (same budget class as `capture`/`triage`), and the next source (Raindrop, Instapaper, GitHub stars…) is a small file against the `Source` interface — not a re-architecture.

Zero new Go dependencies (Pinboard v1 is JSON over HTTPS, stdlib only).

## Configure it (3 steps)

**1. Get a token** from <https://pinboard.in/settings/password> (it's `username:HEXTOKEN`, and grants full read+write — treat it like a password). It's a **secret**, so it lives in the per-machine, gitignored user config — never the committed `scribe.yaml`:

```yaml
# ~/.config/scribe/config.yaml
integration_tokens:
  pinboard: "username:HEXTOKEN"
```

(or export `SCRIBE_PINBOARD_TOKEN` — env wins over the file, same rule as `llm_api_keys`.)

**2. Enable it** in `scribe.yaml`:

```yaml
integrations:
  pinboard:
    enabled: true
    scope: recent+unread    # recent+unread | unread | all  (by read-state/recency)
    tags: []                # OR filter: only ingest bookmarks with >=1 of these
                            # tags (case-insensitive); empty = all
    public_only: false      # true = skip private bookmarks; default ingests all
    skip_domains: []        # substring URL filter, same as capture.skip_domains
```

- **`scope`** selects the set by read-state/recency.
- **`tags`** is an independent **OR** filter. `tags: [kb, elixir]` ⇒ only bookmarks tagged `kb` **or** `elixir`. Empty ⇒ everything the scope returned. They compose: `scope: all` + `tags: [kb]` = "every bookmark I ever tagged `kb`".
- **`public_only`** — an authenticated pull sees your **private** bookmarks too, and by default ingests them. Set `public_only: true` (or pass `--public-only` for one run) to skip private (non-shared) bookmarks — worth it if the KB might ever be shared or `scribe promote`d, so private links don't ride along.

**3. Run it.**

## Test it

```sh
# 0. sanity-check the token (cheapest, side-effect-free call)
curl -s "https://api.pinboard.in/v1/posts/update?format=json&auth_token=$SCRIBE_PINBOARD_TOKEN"
#    → {"update_time":"..."}  means auth works

# 1. status of each integration (no network beyond config read)
scribe pull --list
#    pinboard   ready                       last pull: never

# 2. dry-run — see exactly what WOULD be queued, writes nothing
scribe pull pinboard -n

# 3. real pull → writes .url entries into output/inbox/
scribe pull pinboard

# 4. drain now instead of waiting for the 30-min cron
scribe ingest drain

# override the tag filter for one run:
scribe pull pinboard --tag kb --tag elixir -n

# skip private bookmarks for one run:
scribe pull pinboard --public-only -n

# one-shot full backfill, paced so it doesn't flood the inbox:
scribe pull pinboard --all-history --max 200   # re-run until it reports 0 new
```

`scribe pull` (bare, no source) pulls every configured integration — that's what the new hourly `pull-sources` cron job runs.

## Behavior details

- **Rate-limit friendly:** a cheap `posts/update` probe short-circuits a run when nothing changed *before* touching `posts/all`/`posts/recent`. Per-source state (cursor + seen-set) persists in `output/sources/<name>.json` (gitignored).
- **Metadata preserved:** the bookmark's `extended` note goes into the article body; Pinboard tags carry into frontmatter (plus a `pinboard` provenance tag, and `to-read` for unread items).
- **Privacy:** the API token is account-scoped, so a pull sees private bookmarks. `public_only` (config or `--public-only`) gates them out; default is unchanged (ingest all). Kept the v1 API over Pinboard's read-only RSS/feeds `secret` token because feeds can't do full-archive backfill and their tag filter is AND-only — noted as a possible future read-only mode.
- **Team KBs:** integrations are a personal source — hard-off from the repo `scribe.yaml` like capture (re-enable per-person in `scribe.local.yaml`), and trust-locked in the config-trust layer.

## Testing

- `make ci` green: `go test`, `go vet`, `go test -race`, `golangci-lint` (0 issues), `govulncheck` (no vulns).
- New offline table-driven tests (`httptest`, no network): Pinboard API client + mapping (incl. `shared`→`Private`) + scope routing + `posts/update` short-circuit; generic driver dedup/state/`--max`-cursor/skip-domains/**tag-filter** (config + `--tag` override + no-filter)/**public-only** (config + `--public-only`); queue note round-trip; team-mode hard-off.

## Files

New: `cmd/scribe/source.go` (framework + CLI), `source_pinboard.go` (adapter), `source_test.go` + `source_pinboard_test.go`. Edits: `ingest.go` (shared queue writer + `note:`/`source:`), `config.go`, `config_trust.go`, `cron.go`, `main.go`, `templates/scribe.yaml`, `README.md`, `CHANGELOG.md`, `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AtWXqSemj3X6YomHwo375
