### PR TITLE
docs: add guided personal and team onboarding

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -152,9 +152,13 @@ brews:
       Already installed by brew as dependencies: git, sqlite, ccrider.
 
       After installing:
-        scribe init --path ~/my-kb
+        scribe init --path ~/my-kb --bind
+        cd ~/my-kb && scribe skill install
         scribe cron install           # macOS: LaunchAgents
                                       # Linux: prints crontab lines
+        scribe doctor
+
+      Personal, Ollama, hosted, and team recipes: https://getscribe.dev/setup.md
 
       macOS — Full Disk Access for `scribe capture` (iMessage):
         scribe fda                    # opens the FDA pane and walks you through

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to scribe are documented here. Format follows [Keep a Change
 
 ## [Unreleased]
 
+### Changed — setup and team onboarding
+- Added a public, prompt-compatible setup runbook for humans and coding agents
+  covering personal Anthropic, local Ollama, hosted OpenAI-compatible providers,
+  team-owner, team-member, second-KB, Linux cron, and verification flows. It
+  explains why the embedded skills help after bootstrap but do not replace
+  install/init/source approval/cron/doctor.
+- Quick-start commands now use `init --bind` so the documented flow actually
+  installs the machine-global Claude/Codex handshake, and cost previews use the
+  CLI's real no-write form: `sync --dry-run --estimate`.
+- Team setup now separates the one owner who runs `init --team` from members who
+  clone and run `init --bind --yes`, quotes shared `--allow '~/work'` paths so
+  the owner's shell does not commit an absolute home path, and documents shared
+  versus per-machine state, config trust, skill drift, source approval, and the
+  current multi-KB scheduler.
+- `scribe init` prints the same discover/review/estimate/skills flow and no
+  longer describes the retired one-KB-per-machine scheduler behavior.
+- `scribe init --check` is now genuinely non-interactive, and rebinding a
+  machine to another default KB preserves the previous default in the explicit
+  registry so `scribe each` continues scheduling both.
+- Linux `scribe cron status` and `scribe doctor --section cron` now inspect the
+  user's installed crontab block instead of falsely reporting missing macOS
+  LaunchAgent plists; doctor also verifies that the current KB is registered.
+
 ## [0.4.3] — 2026-07-22
 
 A session-ingestion compatibility release. Scribe now treats ccrider as the

--- a/Formula/scribe.rb
+++ b/Formula/scribe.rb
@@ -64,9 +64,13 @@ class Scribe < Formula
       Already installed by brew as dependencies: git, sqlite, ccrider.
 
       After installing:
-        scribe init --path ~/my-kb
+        scribe init --path ~/my-kb --bind
+        cd ~/my-kb && scribe skill install
         scribe cron install           # macOS: LaunchAgents
                                       # Linux: prints crontab lines to paste
+        scribe doctor
+
+      Personal, Ollama, hosted, and team recipes: https://getscribe.dev/setup.md
 
       macOS — Full Disk Access for `scribe capture` (iMessage):
         scribe fda                    # opens the FDA pane and walks you through

--- a/README.md
+++ b/README.md
@@ -161,14 +161,37 @@ make install    # builds with -tags sqlite_fts5 to ./bin/scribe, then deploys to
 
 ---
 
-## Quick start
+## Quick start — personal KB
+
+If you want Claude Code or Codex to do the setup, give it the public
+**[setup runbook](https://getscribe.dev/setup.md)**. It includes a copyable
+prompt, personal/Ollama/hosted/team recipes, safety rules, and an explicit
+verification checklist. `scribe skill install` is useful after bootstrap, but
+it is not a replacement for installing dependencies, choosing a setup profile,
+running `init --bind`, approving sources, and verifying cron/configuration
+(plus Ollama health when selected).
 
 ```sh
-scribe init --path ~/my-kb
+scribe init --path ~/my-kb --bind
 cd ~/my-kb
-git remote add origin git@github.com:you/my-kb.git   # optional
+scribe skill install
+scribe sync --discover
+scribe projects review
+scribe sync --dry-run --estimate
 scribe cron install
 scribe doctor
+```
+
+`--bind` makes this KB the machine default and writes the scribe handshake into
+`~/.claude/CLAUDE.md` and `~/.codex/AGENTS.md`. Without it, init may
+deliberately leave those machine-global files untouched when another KB is
+already configured. The discover/review pair is the source-consent gate; the
+dry-run estimate does not write or call an LLM. Add a private git remote when
+you want backup/sync:
+
+```sh
+git remote add origin git@github.com:you/my-kb.git
+git push -u origin main
 ```
 
 `scribe init` will prompt for:
@@ -189,6 +212,7 @@ All prompts take matching flags:
 ```sh
 scribe init \
   --path ~/my-kb \
+  --bind \
   --owner-name "Alice" \
   --owner-context "Platform engineer. Main projects: weblog, infra." \
   --domains weblog,infra \
@@ -234,7 +258,9 @@ Manual fallback if you ever need it: System Settings → Privacy & Security → 
 
 ### Linux — manual crontab
 
-On Linux, `scribe cron install` prints crontab(5) lines you paste into `crontab -e`. Example output:
+On Linux, `scribe cron install` prints crontab(5) lines you paste into
+`crontab -e`. Abbreviated example output (the command prints the complete block
+with the machine's real `PATH` and scribe binary):
 
 ```
 # ---- scribe ----
@@ -242,22 +268,31 @@ SHELL=/bin/bash
 PATH=/home/alice/.local/bin:/usr/bin:/bin:...
 
 # Hourly KB auto-commit
-7 */1 * * * cd "/home/alice/my-kb" && /home/alice/.local/bin/scribe commit
+7 */1 * * * /home/alice/.local/bin/scribe each -- commit
 
 # Project extraction every 2h
-23 */2 * * * cd "/home/alice/my-kb" && /home/alice/.local/bin/scribe sync --max 2
+23 */2 * * * /home/alice/.local/bin/scribe each -- sync --max 2
 
 # Session mining at 3:00, 12:00, 18:00
-0 12 * * * cd "/home/alice/my-kb" && /home/alice/.local/bin/scribe sync --sessions --sessions-max 3 --skip-large
-0 18 * * * cd "/home/alice/my-kb" && /home/alice/.local/bin/scribe sync --sessions --sessions-max 3 --skip-large
-0 3  * * * cd "/home/alice/my-kb" && /home/alice/.local/bin/scribe sync --sessions --sessions-max 3 --skip-large
+0 12 * * * /home/alice/.local/bin/scribe each -- sync --sessions --sessions-max 3 --skip-large
+0 18 * * * /home/alice/.local/bin/scribe each -- sync --sessions --sessions-max 3 --skip-large
+0 3 * * * /home/alice/.local/bin/scribe each -- sync --sessions --sessions-max 3 --skip-large
 
 # Drain queued URLs into raw/articles/ every 30min
-*/30 * * * * cd "/home/alice/my-kb" && /home/alice/.local/bin/scribe ingest drain
+*/30 * * * * /home/alice/.local/bin/scribe each -- ingest drain
 
 # Weekly Dream cycle (Sun 2am)
-0 2 * * 0 cd "/home/alice/my-kb" && /home/alice/.local/bin/scribe dream
+0 2 * * 0 /home/alice/.local/bin/scribe each -- dream
 # ---- end scribe ----
+```
+
+The generated jobs use `scribe each` so one machine-level crontab serves every
+KB in `scribe kb list`. After saving the block, verify both its presence and the
+current KB's registry membership:
+
+```sh
+scribe cron status
+scribe doctor --section cron
 ```
 
 The `scribe watch` job (fsnotify watcher for ccrider's SQLite DB) is not cron-friendly — run it under systemd-user, supervisord, or a persistent tmux/screen session. `scribe cron install` on Linux names the jobs that fall into this category so you know what still needs a supervisor.
@@ -630,9 +665,9 @@ This is for the Claude Desktop **app** only — Claude Code and Codex CLI alread
 ## Command reference
 
 ```sh
-scribe init         # bootstrap a KB or check an existing one
-scribe init --allow ~/work --disallow ~/personal   # scaffold with discovery filters baked in
-scribe init --team -p ~/team-kb --allow ~/work     # scaffold a shared team KB (per-machine manifest)
+scribe init --path ~/my-kb --bind  # bootstrap a default KB and wire the agent handshake
+scribe init --path ~/my-kb --bind --allow '~/work' --disallow '~/personal'  # portable discovery filters
+scribe init --bind --team -p ~/team-kb --allow '~/work'      # team owner: scaffold a shared KB
 scribe sync         # discover → extract → absorb → reindex
 scribe projects     # list discovered projects with status
 scribe projects review       # interactively approve/ignore pending projects
@@ -643,7 +678,7 @@ scribe config diff  # team KBs: show sensitive scribe.yaml keys changed since la
 scribe config trust # team KBs: approve the current sensitive keys
 scribe config update # append commented docs for options added since your scribe.yaml was scaffolded
 scribe sync --sessions       # mine all ccrider providers + direct Codex rollouts (when codex.mine is on)
-scribe sync --estimate       # token estimate for pending work (no LLM calls)
+scribe sync --dry-run --estimate  # token estimate for pending work (no writes or LLM calls)
 scribe sync --max-absorb N   # one-shot override of absorb.max_per_run from scribe.yaml
 scribe triage       # score unprocessed sessions by knowledge density
 scribe capture      # pull links you iMessaged to yourself as bookmarks (macOS only; needs Full Disk Access)
@@ -690,32 +725,80 @@ own sessions and repos; git is the merge layer.
 
 ### The recipe
 
+The complete prompt-compatible owner/member runbook is also available at
+**<https://getscribe.dev/setup.md>**. The important split is: one owner
+bootstraps with `--team`; every other member clones that exact repository and
+runs `init --bind --yes` inside it. Teammates do not each create a new team KB.
+
 1. **One member bootstraps the team KB** and pushes it to a private remote:
 
    ```sh
-   scribe init -p ~/team-kb --kb-name teamkb --team --allow ~/work
+   scribe init \
+     --path ~/team-kb \
+     --bind \
+     --kb-name teamkb \
+     --team \
+     --allow '~/work'
    cd ~/team-kb
+   scribe skill install
+   git add scribe.yaml .claude/skills .agents/skills
+   git commit -m "chore: add scribe agent skills"
    git remote add origin git@github.com:yourorg/team-kb.git
    git push -u origin main
    ```
 
    `--team` gitignores the per-machine manifest (see below) and prints these
-   setup steps. The `--allow` filter is committed in `scribe.yaml` and applies
-   to every member (`~` expands per-machine), so personal projects never leak
-   into the team repo.
+   setup steps. The quotes around `'~/work'` prevent the shell from replacing
+   `~` with the owner's absolute home path before it is committed. Scribe then
+   expands `~` separately on every member's machine. If checkout layouts differ,
+   add `sources.allowed_remotes: [github.com/yourorg]` to `scribe.yaml` before
+   the commit; origin identity is a stronger team boundary than a path alone.
 
-2. **Everyone else clones and points scribe at it** (per session or per cron job):
+2. **Everyone else clones and onboards their machine**:
+
+   If a member already has a personal KB and wants to keep it as the default
+   Claude/Codex handshake, use the [second-KB profile](https://getscribe.dev/setup.md)
+   instead of `--bind`. Binding the team KB changes the default, but preserves
+   the previous default in `scribe kb list` so scheduled `scribe each` jobs keep
+   serving both.
 
    ```sh
    git clone git@github.com:yourorg/team-kb.git ~/team-kb
-   SCRIBE_KB=~/team-kb scribe sync
+   cd ~/team-kb
+   git config user.name "Alice Example"
+   git config user.email "alice@example.com"
+
+   scribe init --bind --yes
+   scribe config diff
+   scribe config trust
+   scribe skill install --check
+   scribe sync --discover
+   scribe projects review
+   scribe sync --dry-run --estimate
+   scribe cron install
+   scribe doctor
    ```
 
-   The first sync rebuilds a fresh machine-local manifest, discovers that member's
-   projects (as `pending` — they approve with `scribe projects review`), and starts
-   extracting.
+   Do **not** pass `--path`, `--team`, `--kb-name`, `--allow`, or `--provider`
+   on member machines: those choices are already committed by the owner. The
+   member's `init --bind --yes` checks the existing clone and installs that
+   machine's default + Claude/Codex handshake. `config trust` explicitly accepts
+   the cloned sensitive config. Discovery rebuilds the gitignored machine-local
+   manifest, and nothing is extracted until that member approves projects.
 
-3. **That's the whole setup.** The pieces below make multi-writer work:
+3. **Shared versus per-member state**:
+
+   - **Same for everyone:** the private git remote and committed `scribe.yaml`
+     (`team`, KB name, domains, provider policy, shared source/remote filters,
+     secret gate). Change it once through git; each member reviews sensitive
+     drift with `scribe config diff` / `scribe config trust`.
+   - **Different on every machine:** `scripts/projects.json`, git identity,
+     credentials, capture handles, subscriptions, personal stop words, and extra
+     source exclusions. Put local KB overrides in gitignored
+     `scribe.local.yaml`; put hosted-provider keys and personal stop words in
+     `~/.config/scribe/config.yaml`.
+
+   The pieces below explain why multi-writer operation works:
 
    - `scripts/projects.json` is **gitignored** because it holds machine-local
      absolute paths, git SHAs, and approval decisions. Sharing it breaks when two
@@ -803,9 +886,13 @@ competing claims.
   others see the active claim after their pull and skip. Expired leases are
   stealable. Best-effort — with the remote unreachable, two machines may dream
   once concurrently, which only costs duplicate consolidation churn.
-- **`scribe cron install` manages one KB per machine** — the LaunchAgent labels
-  are fixed. Run your personal KB on cron and sync the team KB with a manual
-  cron line (`SCRIBE_KB=~/team-kb scribe sync`), or vice versa.
+- **One machine-level cron set serves every registered KB.** The LaunchAgents
+  run `scribe each` across `scribe kb list`; `scribe cron install` registers the
+  current KB and installs or refreshes that one KB-agnostic set. Use
+  `each.cadence` in an individual KB's `scribe.yaml` to pace it differently.
+  The global Claude/Codex handshake still points at one default KB at a time;
+  the [setup runbook](https://getscribe.dev/setup.md#a-second-kb-on-one-machine)
+  shows how to keep a personal default while registering a team KB.
 - **Concurrent edits to the same article can conflict** like any git repo. The
   append-heavy article layout keeps this rare; resolve by hand and re-run sync.
 - **Session transcripts never leave the machine.** Only the distilled wiki

--- a/cmd/scribe/cron.go
+++ b/cmd/scribe/cron.go
@@ -15,7 +15,8 @@ import (
 	"time"
 )
 
-// CronCmd manages macOS LaunchAgents for scribe's scheduled KB jobs.
+// CronCmd manages scheduled scribe KB jobs: macOS LaunchAgents, or
+// ready-to-paste crontab guidance and status on Linux.
 //
 // Why LaunchAgents instead of crontab: macOS cron runs under launchd without
 // a user Aqua session, so it cannot read the login keychain. Claude Code's
@@ -24,8 +25,8 @@ import (
 // the gui/<uid> domain run inside the user's login session and have keychain
 // access. This command installs/removes/status those plists.
 type CronCmd struct {
-	Install   CronInstallCmd   `cmd:"" help:"Install LaunchAgent plists for scribe KB jobs."`
-	Status    CronStatusCmd    `cmd:"" help:"Show status of scribe LaunchAgents."`
+	Install   CronInstallCmd   `cmd:"" help:"Install macOS LaunchAgents or print Linux crontab entries."`
+	Status    CronStatusCmd    `cmd:"" help:"Show status of macOS LaunchAgents or the Linux crontab block."`
 	Uninstall CronUninstallCmd `cmd:"" help:"Unload and remove scribe LaunchAgents."`
 }
 
@@ -810,6 +811,14 @@ func (c *CronInstallCmd) Run() error {
 
 type CronStatusCmd struct{}
 
+// readUserCrontab is shared with doctor's Linux cron check and indirected for
+// deterministic tests. `crontab -l` exits non-zero when the user has no
+// crontab; callers turn that into an actionable missing-schedule result.
+var readUserCrontab = func() (string, error) {
+	out, err := exec.Command("crontab", "-l").CombinedOutput() //nolint:noctx // one-shot local probe
+	return string(out), err
+}
+
 func (c *CronStatusCmd) Run() error {
 	// KB-agnostic: agents serve the whole registry, so status no longer
 	// needs a KB context. Show the registry first, then per-agent state.
@@ -821,6 +830,21 @@ func (c *CronStatusCmd) Run() error {
 		fmt.Println()
 	} else {
 		fmt.Printf("No registered KBs — add one with `scribe kb add <path>` (or set kb_dir in %s)\n\n", userConfigPath())
+	}
+
+	if runtime.GOOS != "darwin" {
+		raw, err := readUserCrontab()
+		switch {
+		case err != nil:
+			fmt.Println("Linux crontab: missing or unreadable")
+			fmt.Println("Run `scribe cron install`, review the printed block, then add it with `crontab -e`.")
+		case hasScribeCrontabBlock(raw):
+			fmt.Println("Linux crontab: scribe block installed")
+		default:
+			fmt.Println("Linux crontab: no current scribe block found")
+			fmt.Println("Run `scribe cron install`, review the printed block, then add it with `crontab -e`.")
+		}
+		return nil
 	}
 
 	jobs := scribeJobs(resolveScribeBinary())
@@ -835,6 +859,12 @@ func (c *CronStatusCmd) Run() error {
 		fmt.Printf("%-28s %-10s %s\n", label, state, path)
 	}
 	return nil
+}
+
+func hasScribeCrontabBlock(raw string) bool {
+	return strings.Contains(raw, "# ---- scribe ----") &&
+		strings.Contains(raw, "# ---- end scribe ----") &&
+		strings.Contains(raw, "scribe each --")
 }
 
 // ---- uninstall ----

--- a/cmd/scribe/cron.go
+++ b/cmd/scribe/cron.go
@@ -815,7 +815,7 @@ type CronStatusCmd struct{}
 // deterministic tests. `crontab -l` exits non-zero when the user has no
 // crontab; callers turn that into an actionable missing-schedule result.
 var readUserCrontab = func() (string, error) {
-	out, err := exec.Command("crontab", "-l").CombinedOutput() //nolint:noctx // one-shot local probe
+	out, err := exec.Command("crontab", "-l").CombinedOutput()
 	return string(out), err
 }
 

--- a/cmd/scribe/cron_test.go
+++ b/cmd/scribe/cron_test.go
@@ -1,12 +1,40 @@
 package main
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
 )
+
+func TestPrintedLinuxCronBlockMatchesStatusDetection(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	origStdout := os.Stdout
+	os.Stdout = w
+	printErr := printLinuxCronInstructions(scribeJobs("/home/alice/.local/bin/scribe"), false)
+	_ = w.Close()
+	os.Stdout = origStdout
+	t.Cleanup(func() {
+		os.Stdout = origStdout
+		_ = r.Close()
+	})
+
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if printErr != nil {
+		t.Fatalf("printLinuxCronInstructions: %v", printErr)
+	}
+	if !hasScribeCrontabBlock(string(out)) {
+		t.Fatalf("printed cron block is not recognized by status/doctor:\n%s", out)
+	}
+}
 
 // TestRenderCrontab confirms the collapsing rules and the one-line-per-slot
 // fallback match what we document in README. Each case is one representative

--- a/cmd/scribe/doctor.go
+++ b/cmd/scribe/doctor.go
@@ -694,6 +694,10 @@ func routeDocOrEpub(hasMarker bool) string {
 // ---- Cron ----
 
 func checkCron(root string) []check {
+	if runtimeGOOS != "darwin" {
+		return checkLinuxCron(root)
+	}
+
 	var out []check
 	binary := resolveScribeBinary()
 	jobs := scribeJobs(binary)
@@ -739,6 +743,44 @@ func checkCron(root string) []check {
 			Section: "cron", Name: "foreign-agents", Status: statusWarn,
 			Detail: fmt.Sprintf("%d LaunchAgent(s) outside scribe's job set also reference this binary or KB: %s — duplicated jobs run twice per slot", len(foreign), strings.Join(foreign, ", ")),
 			Fix:    "review each; if it is a stale duplicate: launchctl bootout gui/$(id -u)/<label> and move the plist out of ~/Library/LaunchAgents",
+		})
+	}
+	return out
+}
+
+func checkLinuxCron(root string) []check {
+	var out []check
+	if kbRegistered(loadUserConfig(), root) {
+		out = append(out, check{
+			Section: "cron", Name: "kb-scope", Status: statusOK,
+			Detail: fmt.Sprintf("this KB is registered — `scribe each` serves it (%d KB(s) on this machine)", len(registeredKBs())),
+		})
+	} else {
+		out = append(out, check{
+			Section: "cron", Name: "kb-scope", Status: statusFail,
+			Detail: "this KB is not in the machine registry — scheduled `scribe each` runs skip it",
+			Fix:    "scribe kb add " + root,
+		})
+	}
+
+	raw, err := readUserCrontab()
+	switch {
+	case err != nil:
+		out = append(out, check{
+			Section: "cron", Name: "linux-crontab", Status: statusFail,
+			Detail: "no readable user crontab with the scribe block",
+			Fix:    "run `scribe cron install`, review the output, then paste it into `crontab -e`",
+		})
+	case hasScribeCrontabBlock(raw):
+		out = append(out, check{
+			Section: "cron", Name: "linux-crontab", Status: statusOK,
+			Detail: "scribe marker block with KB-agnostic `scribe each` jobs is installed",
+		})
+	default:
+		out = append(out, check{
+			Section: "cron", Name: "linux-crontab", Status: statusFail,
+			Detail: "user crontab does not contain the current scribe block",
+			Fix:    "run `scribe cron install`, review the output, then paste it into `crontab -e`",
 		})
 	}
 	return out

--- a/cmd/scribe/doctor_cron_scope_test.go
+++ b/cmd/scribe/doctor_cron_scope_test.go
@@ -2,6 +2,13 @@ package main
 
 import "testing"
 
+func stubUserCrontab(t *testing.T, raw string, err error) {
+	t.Helper()
+	prev := readUserCrontab
+	readUserCrontab = func() (string, error) { return raw, err }
+	t.Cleanup(func() { readUserCrontab = prev })
+}
+
 // TestCronScopeCheck covers the KB-scope cron headline (issue #27 item 1):
 // "loaded" agents are a single KB-agnostic set, so doctor must say whether
 // they actually serve THIS KB — keyed on registry membership, not the
@@ -25,5 +32,33 @@ func TestCronScopeCheck(t *testing.T) {
 	}
 	if c.Name != "kb-scope" {
 		t.Errorf("name = %q, want kb-scope", c.Name)
+	}
+}
+
+func TestCheckLinuxCron(t *testing.T) {
+	isolateUserConfig(t)
+	root := makeKBRoot(t, "linux-kb")
+	writeUserCfg(t, "kbs:\n  - "+root+"\n")
+	stubUserCrontab(t, "# ---- scribe ----\n0 * * * * /usr/bin/scribe each -- commit\n# ---- end scribe ----\n", nil)
+
+	checks := checkLinuxCron(root)
+	if len(checks) != 2 {
+		t.Fatalf("checks = %d, want 2: %+v", len(checks), checks)
+	}
+	for _, c := range checks {
+		if c.Status != statusOK {
+			t.Errorf("%s status = %q, want ok: %+v", c.Name, c.Status, c)
+		}
+	}
+}
+
+func TestCheckLinuxCronReportsMissingBlock(t *testing.T) {
+	isolateUserConfig(t)
+	root := makeKBRoot(t, "linux-kb")
+	stubUserCrontab(t, "0 * * * * echo unrelated\n", nil)
+
+	checks := checkLinuxCron(root)
+	if len(checks) != 2 || checks[0].Status != statusFail || checks[1].Status != statusFail {
+		t.Fatalf("unregistered KB + missing block should fail both checks: %+v", checks)
 	}
 }

--- a/cmd/scribe/init.go
+++ b/cmd/scribe/init.go
@@ -322,24 +322,30 @@ func (c *InitCmd) runBootstrap() error {
 	fmt.Println()
 	fmt.Println("Next steps:")
 	fmt.Println("  1. Review the generated scribe.yaml and tweak domains/triage keywords.")
+	fmt.Println("  2. Install agent skills: cd " + abs + " && scribe skill install")
+	fmt.Println("  3. Discover + approve sources: scribe sync --discover && scribe projects review")
+	fmt.Println("  4. Preview cost/scope: scribe sync --dry-run --estimate")
 	if other := otherKBServedByAgents(abs); other != "" {
-		fmt.Printf("  2. Cron: this machine's scribe LaunchAgents already serve %s —\n", other)
-		fmt.Println("     one agent set per machine for now (issue #26). Run this KB manually,")
-		fmt.Printf("     e.g. SCRIBE_KB=%s scribe sync\n", abs)
+		fmt.Printf("  5. Migrate legacy cron (currently tied to %s): scribe cron install\n", other)
+		fmt.Println("     This registers both KBs and replaces the old single-KB agents with")
+		fmt.Println("     the current KB-agnostic `scribe each` scheduler.")
 	} else {
-		fmt.Println("  2. Install cron: scribe cron install")
+		fmt.Println("  5. Install cron: scribe cron install")
 		fmt.Println("     (On Linux, `scribe cron install` prints crontab entries you paste manually.)")
 	}
-	fmt.Println("  3. Run `scribe doctor` to verify dependencies + freshness checks.")
+	fmt.Println("  6. Run `scribe doctor` to verify dependencies + freshness checks.")
 	if strings.EqualFold(vars.LLMProvider, "ollama") {
-		fmt.Println("  4. Ollama mode: `ollama serve` must be running when sync fires; `scribe doctor` probes it.")
+		fmt.Println("  7. Ollama mode: `ollama serve` must be running when sync fires; `scribe doctor` probes it.")
 	}
 	if c.Team {
 		fmt.Println()
 		fmt.Println("Team KB setup (this KB is in shared mode — scripts/projects.json is gitignored):")
-		fmt.Println("  push it:        git remote add origin git@github.com:yourorg/team-kb.git && git push -u origin main")
-		fmt.Println("  members clone:  git clone <remote> ~/team-kb && SCRIBE_KB=~/team-kb scribe sync")
-		fmt.Println("  approvals:      each member runs `scribe projects review` after their first sync")
+		fmt.Println("  owner publish:  install + commit the skills, then add a private origin and push")
+		fmt.Println("  members clone:  git clone <remote> ~/team-kb && cd ~/team-kb")
+		fmt.Println("  member bind:    scribe init --bind --yes")
+		fmt.Println("  member trust:   scribe config diff && scribe config trust")
+		fmt.Println("  member sources: scribe sync --discover && scribe projects review")
+		fmt.Println("  member verify:  scribe sync --dry-run --estimate && scribe cron install && scribe doctor")
 		fmt.Println("  config trust:   sensitive scribe.yaml keys are locked per-machine; review pushed")
 		fmt.Println("                  changes with `scribe config diff`, accept with `scribe config trust`")
 		fmt.Println("  personal bits:  per-user settings (capture handles, extra filters) go in the")
@@ -350,6 +356,7 @@ func (c *InitCmd) runBootstrap() error {
 		fmt.Println("                  unprefixed `password = ...` leaks, at the cost of noise)")
 		fmt.Println("  consolidation:  `scribe dream` coordinates itself via a committed lease — the")
 		fmt.Println("                  first machine claims the weekly cycle, the rest skip")
+		fmt.Println("  full runbook:   https://getscribe.dev/setup.md")
 	}
 
 	// Offer to walk the user through Full Disk Access right now. Only on
@@ -375,26 +382,27 @@ func (c *InitCmd) runBootstrap() error {
 // --check mode any missing value falls back to a safe default so init can
 // run unattended (CI, shell scripts).
 func (c *InitCmd) collectVars(abs string) (templateVars, error) {
+	interactive := !c.Yes && !c.Check
 	kbName := c.KBName
 	if kbName == "" {
 		kbName = filepath.Base(abs)
 	}
 	owner := c.OwnerName
-	if owner == "" && !c.Yes {
+	if owner == "" && interactive {
 		owner = prompt("Owner name", os.Getenv("USER"))
 	}
 	if owner == "" {
 		owner = os.Getenv("USER")
 	}
 	ownerCtx := c.OwnerContext
-	if ownerCtx == "" && !c.Yes {
+	if ownerCtx == "" && interactive {
 		ownerCtx = prompt("Owner context (one sentence about your role/projects)", "Knowledge base owner.")
 	}
 	if ownerCtx == "" {
 		ownerCtx = "Knowledge base owner."
 	}
 	domains := c.Domains
-	if len(domains) == 0 && !c.Yes {
+	if len(domains) == 0 && interactive {
 		raw := prompt("Domains (comma-separated, e.g. work, oss, personal)", "")
 		for d := range strings.SplitSeq(raw, ",") {
 			d = strings.TrimSpace(d)
@@ -404,7 +412,7 @@ func (c *InitCmd) collectVars(abs string) (templateVars, error) {
 		}
 	}
 	handle := c.Handle
-	if handle == "" && !c.Yes {
+	if handle == "" && interactive {
 		handle = prompt("iMessage self-chat handle (leave empty to disable capture)", "")
 	}
 
@@ -412,7 +420,7 @@ func (c *InitCmd) collectVars(abs string) (templateVars, error) {
 	// --provider on the CLI, that wins. Otherwise prompt in
 	// interactive mode; default anthropic.
 	provider := strings.ToLower(strings.TrimSpace(c.Provider))
-	if provider == "" && !c.Yes {
+	if provider == "" && interactive {
 		provider = prompt("LLM provider (anthropic | ollama)", "anthropic")
 	}
 	if provider == "" {
@@ -963,6 +971,22 @@ func installUserConfig(root string, check, yes, bound bool) error {
 	// run inside a second KB silently wiped the machine's API key and KB
 	// list. Marshal the loaded config back instead; omitempty keeps the
 	// file minimal when those fields are unset.
+	//
+	// Preserve the previous default as an explicit registry member before
+	// repointing. Otherwise binding a cloned team KB would make a personal KB
+	// disappear from `scribe each` whenever it was represented only by kb_dir.
+	if uc.KBDir != "" && !samePath(uc.KBDir, root) {
+		alreadyListed := false
+		for _, kb := range uc.KBs {
+			if samePath(kb, uc.KBDir) {
+				alreadyListed = true
+				break
+			}
+		}
+		if !alreadyListed {
+			uc.KBs = append(uc.KBs, uc.KBDir)
+		}
+	}
 	uc.KBDir = root
 	body, err := yaml.Marshal(&uc)
 	if err != nil {

--- a/cmd/scribe/init_test.go
+++ b/cmd/scribe/init_test.go
@@ -2,12 +2,47 @@ package main
 
 import (
 	"bytes"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func TestCollectVarsCheckDoesNotPrompt(t *testing.T) {
+	stdinR, stdinW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = stdinW.Close() // immediate EOF if code incorrectly tries to read
+	stdoutR, stdoutW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	origStdin, origStdout := os.Stdin, os.Stdout
+	os.Stdin, os.Stdout = stdinR, stdoutW
+	_, collectErr := (&InitCmd{Check: true}).collectVars("/home/alice/my-kb")
+	_ = stdoutW.Close()
+	os.Stdin, os.Stdout = origStdin, origStdout
+	t.Cleanup(func() {
+		os.Stdin, os.Stdout = origStdin, origStdout
+		_ = stdinR.Close()
+		_ = stdoutR.Close()
+	})
+
+	out, err := io.ReadAll(stdoutR)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if collectErr != nil {
+		t.Fatalf("collectVars: %v", collectErr)
+	}
+	if len(out) != 0 {
+		t.Fatalf("--check prompted or printed during variable collection: %q", out)
+	}
+}
 
 // TestIsThrowawayPath guards the heuristic that gates global state
 // rewrites in `scribe init -p ...`. The 2026-05-13 incident burned
@@ -572,5 +607,31 @@ func TestInstallUserConfigPreservesSecretsAndRegistry(t *testing.T) {
 	}
 	if perm := info.Mode().Perm(); perm != 0o600 {
 		t.Errorf("config perms = %o, want 0600 (file carries an api key)", perm)
+	}
+}
+
+func TestInstallUserConfigPreservesPreviousDefaultInRegistry(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	oldRoot := filepath.Join(fakeHome, "personal-kb")
+	newRoot := filepath.Join(fakeHome, "team-kb")
+	if err := os.MkdirAll(filepath.Dir(userConfigPath()), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(userConfigPath(), []byte("kb_dir: "+oldRoot+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := installUserConfig(newRoot, false, true, true); err != nil {
+		t.Fatalf("installUserConfig: %v", err)
+	}
+	got := loadUserConfig()
+	if got.KBDir != newRoot {
+		t.Errorf("KBDir = %q, want %q", got.KBDir, newRoot)
+	}
+	if len(got.KBs) != 1 || got.KBs[0] != oldRoot {
+		t.Errorf("KBs = %v, want previous default %q preserved", got.KBs, oldRoot)
 	}
 }

--- a/cmd/scribe/skills/scribe-cli/SKILL.md
+++ b/cmd/scribe/skills/scribe-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scribe-cli
-description: Operate the scribe CLI to keep a knowledge-base pipeline healthy — diagnose with doctor/status, run sync/extraction, manage cron and Full Disk Access, and pick the right command for a maintenance goal. Use when the user wants to run scribe, asks which scribe command does X, says their KB is stale/empty or extraction/sync stopped, or is reading `scribe doctor`/`scribe status` output. For authoring KB content use scribe-kb; for the `scribe lint` content-quality queue use scribe-kb-tidy.
+description: Set up and operate the scribe CLI — install/init personal or team KBs, diagnose with doctor/status, run sync/extraction, manage cron and Full Disk Access, and pick the right command for a maintenance goal. Use when the user wants to install or run scribe, asks which scribe command or init/team flags to use, says their KB is stale/empty or extraction/sync stopped, or is reading `scribe doctor`/`scribe status` output. For authoring KB content use scribe-kb; for the `scribe lint` content-quality queue use scribe-kb-tidy.
 ---
 
 # scribe CLI — operations agent skill
@@ -15,6 +15,30 @@ Two sibling skills own the other halves and this skill routes to them:
 - **scribe-kb** — authoring/searching KB *content* (articles, drop files, qmd).
 - **scribe-kb-tidy** — working the `scribe lint` content-quality queue (split
   bloated, archive rolling, merge thin/self-named-dirs).
+
+## Installation or bootstrap requests
+
+For zero-to-running setup, read the public, prompt-compatible runbook first:
+<https://getscribe.dev/setup.md>. It has separate command sequences for a
+personal Anthropic KB, local Ollama, a hosted OpenAI-compatible provider, the
+team owner, each team member, a second KB on one machine, and Linux cron. Follow
+one profile rather than mixing flags.
+
+Key distinctions the short command map cannot express:
+
+- Fresh/default KBs use `scribe init --path <kb> --bind`; `--bind` is what
+  installs the machine-global Claude/Codex handshake.
+- Only the team owner uses `--team`, `--kb-name`, `--allow`, and `--provider`.
+  Members clone, `cd` into the checkout, then run `scribe init --bind --yes`.
+- Quote a shared tilde path (`--allow '~/work'`) so the shell does not commit the
+  owner's absolute home path.
+- Discover and approve sources before extraction: `scribe sync --discover`,
+  then `scribe projects review`.
+- The safe cost/scope preflight is `scribe sync --dry-run --estimate`. Ask before
+  the first real sync when it may spend tokens.
+- `scribe skill install` is post-bootstrap assistance. It does not install the
+  binary/dependencies, choose personal versus team mode, bind the handshake,
+  approve sources, install cron, or verify the provider.
 
 ## Golden rule: diagnose read-only before you act
 
@@ -51,7 +75,7 @@ blocks the real cron job. Everything else here is safe to run interactively.
 | See what's pending / backlog | `scribe status` |
 | Run the whole pipeline now | `scribe sync` (mind the lock rule) |
 | Just mine agent sessions | `scribe sync --sessions` |
-| Estimate token cost before syncing | `scribe sync --estimate` |
+| Estimate token cost before syncing | `scribe sync --dry-run --estimate` |
 | Score unprocessed sessions by value | `scribe triage` |
 | Enroll a repo for extraction | `scribe projects add <path>` |
 | Approve/ignore discovered repos | `scribe projects review` |
@@ -103,5 +127,7 @@ the chat.db/FDA check). Verify the live binary first: `which scribe` and
 - `references/TROUBLESHOOT.md` — symptom → doctor section → fix, for the common
   failure modes (extraction stalled, cron off, FDA lost, ollama down, qmd not
   indexed, lint errors).
+- <https://getscribe.dev/setup.md> — zero-to-running personal/team setup and
+  verification, including the exact init flags.
 - The **scribe-kb** and **scribe-kb-tidy** skills (installed alongside) for
   content authoring and the lint content queue respectively.

--- a/cmd/scribe/skills/scribe-cli/references/COMMANDS.md
+++ b/cmd/scribe/skills/scribe-cli/references/COMMANDS.md
@@ -11,7 +11,7 @@ lock shared with cron — run one at a time, never backgrounded.
 |---|---|
 | `scribe sync` | **lock** — full pipeline: discover → extract → mine sessions → absorb → reindex → commit |
 | `scribe sync --sessions` | Mine all ccrider-indexed agent sessions, plus direct Codex rollouts when enabled |
-| `scribe sync --estimate` | Token estimate for pending work — no LLM calls |
+| `scribe sync --dry-run --estimate` | Token estimate for pending work — no writes or LLM calls |
 | `scribe sync --max-absorb N` | One-shot override of `absorb.max_per_run` |
 | `scribe status` | **read-only** — scoreboard: raw-by-density, absorb/contextualize progress, backlog, last sync, qmd/ollama health |
 | `scribe doctor` | **read-only** — health check: deps, config, localmode, convert, cron, state, freshness, errors, contradictions, stale, vault. Ends with the status scoreboard |
@@ -76,8 +76,10 @@ dir) that `scribe lint` flags but `--fix` can't repair → hand off to the
 
 | Command | What it does |
 |---|---|
-| `scribe init` | Scaffold a fresh KB (writes scribe.yaml, templates, agent handshake blocks) |
-| `scribe cron {install,status,uninstall}` | Manage the macOS LaunchAgents that run the pipeline |
+| `scribe init --path <kb> --bind` | Scaffold a fresh default KB and install the machine-global Claude/Codex handshake blocks |
+| `scribe init --team --path <kb> --bind` | Team owner only: scaffold a shared KB; members clone and run `scribe init --bind --yes` inside it |
+| `scribe cron {install,status}` | Manage macOS LaunchAgents or print/check the Linux crontab block |
+| `scribe cron uninstall` | Unload and remove macOS LaunchAgents; edit Linux crontab entries manually |
 | `scribe fda` | macOS Full Disk Access probe + interactive grant (needed for chat.db capture) |
 | `scribe install-tools` | Bootstrap optional tools (uv + marker-pdf) for full PDF/DOCX/PPTX/XLSX/EPUB ingestion |
 | `scribe skill {install,list}` | Install/list the embedded agent skills (scribe-kb, scribe-kb-tidy, scribe-cli) |

--- a/cmd/scribe/skills/scribe-cli/references/TROUBLESHOOT.md
+++ b/cmd/scribe/skills/scribe-cli/references/TROUBLESHOOT.md
@@ -23,7 +23,7 @@ section with `scribe doctor --section <name>` when you're chasing one thing.
    expected (reads `output/runs/*.jsonl`).
 4. If cron is healthy but backlog is high, run one pipeline pass by hand:
    `scribe sync` (respect the lock rule — one at a time, never backgrounded).
-   Preview first with `scribe sync --estimate`.
+   Preview first with `scribe sync --dry-run --estimate`.
 
 ### "Sessions aren't being mined"
 - `scribe triage` (read-only) shows unprocessed sessions scored by density. If

--- a/install.sh
+++ b/install.sh
@@ -164,8 +164,8 @@ main() {
     esac
 
     echo
-    echo "Next: scribe init --path ~/my-kb"
-    echo "See README for cron + Full Disk Access (macOS) details."
+    echo "Next: scribe init --path ~/my-kb --bind"
+    echo "Setup recipes (personal, Ollama, hosted, teams): https://getscribe.dev/setup.md"
 }
 
 main

--- a/site/public/_headers
+++ b/site/public/_headers
@@ -34,5 +34,8 @@
 /llms-full.txt
   Cache-Control: public, max-age=3600
 
+/setup.md
+  Cache-Control: public, max-age=3600
+
 /index.md
   Cache-Control: public, max-age=3600

--- a/site/public/index.html
+++ b/site/public/index.html
@@ -97,8 +97,14 @@
     {
       "@type": "HowToStep",
       "name": "Bootstrap a knowledge base",
-      "text": "Scaffold a KB and wire the agent handshake into ~/.claude/CLAUDE.md and ~/.codex/AGENTS.md: scribe init --path ~/my-kb",
+      "text": "Scaffold a KB and wire the agent handshake into ~/.claude/CLAUDE.md and ~/.codex/AGENTS.md: scribe init --path ~/my-kb --bind",
       "url": "https://getscribe.dev/#install"
+    },
+    {
+      "@type": "HowToStep",
+      "name": "Install skills and approve sources",
+      "text": "Install the agent skills, discover candidate repositories, and approve only the intended sources: cd ~/my-kb; scribe skill install; scribe sync --discover; scribe projects review",
+      "url": "https://getscribe.dev/setup.md"
     },
     {
       "@type": "HowToStep",
@@ -252,7 +258,7 @@
   "url": "https://getscribe.dev/",
   "image": "https://getscribe.dev/og.png",
   "datePublished": "2026-05-14T00:00:00+02:00",
-  "dateModified": "2026-07-23T00:00:00+02:00",
+  "dateModified": "2026-07-30T00:00:00+02:00",
   "inLanguage": "en",
   "author": {
     "@type": "Person",
@@ -1406,6 +1412,11 @@
     color: var(--fg);
     overflow-x: auto;
     white-space: pre;
+  }
+  .code-panel pre.agent-prompt {
+    max-width: 82ch;
+    padding-right: 72px;
+    white-space: pre-wrap;
   }
   .code-panel .comment { color: var(--muted-2); }
   .code-panel .kw { color: var(--accent); font-weight: 500; }
@@ -2964,6 +2975,7 @@ advisory locks table-ambiguous under load.
       <div class="s__eyebrow">For teams</div>
       <h2 class="s__title">One KB. The whole team writes to it.</h2>
       <p class="s__sub">scribe is single-user by default and stays that way. But a small team on the same codebases can point every machine at one git-backed KB. The obvious fear with sharing agent sessions — a leaked secret, a private client repo, one teammate's config change reaching everyone — is exactly what the gates below are built to stop. Only knowledge you meant to keep crosses into the shared KB.</p>
+      <p class="s__sub"><a href="/setup.md">Run the exact team-owner and team-member setup commands →</a></p>
     </header>
 
     <figure class="video-embed video-embed--teams">
@@ -3228,7 +3240,7 @@ scribe cost — last 7 days — 2 KBs (personal-kb, team-kb)
       <summary>The full surface &mdash; everything scribe does</summary>
       <dl class="surface__grid">
         <dt>Capture</dt><dd>git repos &middot; coding-agent sessions (ccrider FTS5) &middot; direct Codex rollouts &middot; iMessage self-chat &middot; drop files &middot; URL ingest</dd>
-        <dt>Triage</dt><dd>FTS5 keyword-density gate &middot; zero-LLM reject &middot; <code>sync --estimate</code> token preview</dd>
+        <dt>Triage</dt><dd>FTS5 keyword-density gate &middot; zero-LLM reject &middot; <code>sync --dry-run --estimate</code> token preview</dd>
         <dt>Extract</dt><dd>two-pass absorb &middot; entity-first fan-out &middot; retrieval-context splicing &middot; <code>deep</code> / <code>assess</code> batch passes</dd>
         <dt>Graph</dt><dd>closed 10-kind typed-edge schema &middot; <code>_backlinks.json</code> &middot; orphan linking &middot; qmd BM25 + vector index</dd>
         <dt>Hygiene</dt><dd>frontmatter validate &middot; structural lint &middot; staleness ledger &middot; contradiction ledger &middot; Dream 4-phase consolidation</dd>
@@ -3246,12 +3258,13 @@ scribe cost — last 7 days — 2 KBs (personal-kb, team-kb)
     <header class="s__head">
       <div class="s__eyebrow">CLI</div>
       <h2 class="s__title">Set it up once. Forget it.</h2>
-      <p class="s__sub">Two commands to install. One <code>llm</code> block in <code>scribe.yaml</code> routes the whole pipeline local, hosted, or Anthropic. One query from any terminal.</p>
+      <p class="s__sub">One guided init, then explicit source approval and verification. The <a href="/setup.md">setup runbook</a> has copyable personal, Ollama, hosted-provider, team-owner, and team-member recipes. One <code>llm</code> block in <code>scribe.yaml</code> routes the whole pipeline local, hosted, or Anthropic.</p>
     </header>
 
     <div class="code-card">
       <div class="code-tabs" role="tablist" id="tabs">
         <button class="code-tab" role="tab" data-tab="install" aria-selected="true" aria-controls="panel-install" id="tab-install" tabindex="0">install</button>
+        <button class="code-tab" role="tab" data-tab="agent" aria-selected="false" aria-controls="panel-agent" id="tab-agent" tabindex="-1">install with agent</button>
         <button class="code-tab" role="tab" data-tab="local" aria-selected="false" aria-controls="panel-local" id="tab-local" tabindex="-1">scribe.yaml · local</button>
         <button class="code-tab" role="tab" data-tab="hosted" aria-selected="false" aria-controls="panel-hosted" id="tab-hosted" tabindex="-1">scribe.yaml · hosted</button>
         <button class="code-tab" role="tab" data-tab="anthropic" aria-selected="false" aria-controls="panel-anthropic" id="tab-anthropic" tabindex="-1">scribe.yaml · Anthropic</button>
@@ -3266,13 +3279,28 @@ brew tap oliver-kriska/scribe
 brew install oliver-kriska/scribe/scribe
 
 <span class="comment"># one-time setup</span>
-scribe init <span class="flag">--path</span> <span class="str">~/my-kb</span>
+scribe init <span class="flag">--path</span> <span class="str">~/my-kb</span> <span class="flag">--bind</span>
 <span class="kw">cd</span> ~/my-kb
+scribe skill install
+scribe sync <span class="flag">--discover</span>
+scribe projects review
+scribe sync <span class="flag">--dry-run --estimate</span>
 scribe cron install
 scribe doctor
 
 <span class="comment"># or via shell installer</span>
 curl <span class="flag">-fsSL</span> <span class="str">https://raw.githubusercontent.com/oliver-kriska/scribe/main/install.sh</span> | bash</pre>
+      </div>
+
+      <div class="code-panel" data-tab="agent" id="panel-agent" role="tabpanel" aria-labelledby="tab-agent" tabindex="0">
+        <button class="copy-btn" data-copy-target="code-agent" aria-label="Copy coding-agent setup prompt">copy prompt</button>
+<pre id="code-agent" class="agent-prompt">Read https://getscribe.dev/setup.md and set up scribe on this machine.
+Before changing anything, ask me for the setup profile, KB path, and LLM provider.
+For a team setup, also ask whether I am creating or joining the KB and ask for the private git remote.
+Inspect existing state before changing it. Execute the applicable steps; do not only explain them.
+Never use --force. Never print or commit secrets.
+Ask before the first real scribe sync because it may call an LLM and incur cost.
+Finish with the runbook's verification checklist and report what passed and what still needs human action.</pre>
       </div>
 
       <div class="code-panel" data-tab="local" id="panel-local" role="tabpanel" aria-labelledby="tab-local" tabindex="0">
@@ -3434,10 +3462,10 @@ scribe doctor <span class="flag">--section</span> localmode
           </div>
           <div class="terminal__title">~/kb — scribe</div>
         </div>
-        <pre class="commands__lines"><code><span class="cmd-prompt">$</span> <span class="cmd-name">scribe init</span>                        <span class="cmd-cmt"># bootstrap a KB, wire the agent handshake</span>
+        <pre class="commands__lines"><code><span class="cmd-prompt">$</span> <span class="cmd-name">scribe init --bind</span>                 <span class="cmd-cmt"># bootstrap a KB, wire the agent handshake</span>
 <span class="cmd-prompt">$</span> <span class="cmd-name">scribe sync</span>                        <span class="cmd-cmt"># discover → extract → absorb → reindex</span>
 <span class="cmd-prompt">$</span> <span class="cmd-name">scribe sync</span> <span class="cmd-arg">--sessions</span>             <span class="cmd-cmt"># mine coding-agent transcripts</span>
-<span class="cmd-prompt">$</span> <span class="cmd-name">scribe sync</span> <span class="cmd-arg">--estimate</span>             <span class="cmd-cmt"># token estimate, zero LLM calls</span>
+<span class="cmd-prompt">$</span> <span class="cmd-name">scribe sync</span> <span class="cmd-arg">--dry-run --estimate</span>   <span class="cmd-cmt"># token estimate, no writes or LLM calls</span>
 <span class="cmd-prompt">$</span> <span class="cmd-name">scribe doctor</span>                      <span class="cmd-cmt"># validate setup, cron, git remote, Ollama</span>
 <span class="cmd-prompt">$</span> <span class="cmd-name">scribe commit</span>                      <span class="cmd-cmt"># stage + push the KB to your private remote</span>
 <span class="cmd-prompt">$</span> <span class="cmd-name">scribe dream</span>                       <span class="cmd-cmt"># weekly consolidation (Ollama-driven)</span>
@@ -3581,14 +3609,11 @@ scribe doctor <span class="flag">--section</span> localmode
 <!-- ============================ CTA END ============================ -->
 <section class="s cta-end" id="install">
   <div class="wrap">
-    <h2>Install in 60 seconds.</h2>
-    <p>One <code>brew install</code>, one <code>scribe init</code>, and your tools start writing the notes for you.</p>
+    <h2>Install, approve sources, verify.</h2>
+    <p>Use the personal, local Ollama, hosted-provider, or team recipe. The same runbook can be pasted into Claude Code or Codex so it performs the setup and proves what works.</p>
     <div class="cta-end__buttons">
-      <a class="btn btn--accent" href="https://github.com/oliver-kriska/scribe">
-        <svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8a8 8 0 0 0 5.47 7.59c.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
-        Get scribe on GitHub
-      </a>
-      <a class="btn btn--ghost" href="#cli">Read the CLI →</a>
+      <a class="btn btn--accent" href="/setup.md">Open the setup runbook</a>
+      <a class="btn btn--ghost" href="https://github.com/oliver-kriska/scribe">View source on GitHub →</a>
     </div>
   </div>
 </section>
@@ -3615,7 +3640,7 @@ scribe doctor <span class="flag">--section</span> localmode
       <div class="footer__col">
         <h4>Resources</h4>
         <a href="https://github.com/oliver-kriska/scribe">GitHub repo</a>
-        <a href="https://github.com/oliver-kriska/scribe#install">Install guide</a>
+        <a href="/setup.md">Setup runbook</a>
         <a href="https://github.com/oliver-kriska/scribe/issues">Issues</a>
         <a href="#faq">FAQ</a>
       </div>
@@ -3628,7 +3653,7 @@ scribe doctor <span class="flag">--section</span> localmode
       </div>
     </div>
     <div class="footer__bottom">
-      <span>MIT · last updated 2026-07-23</span>
+      <span>MIT · last updated 2026-07-30</span>
       <span>github.com/oliver-kriska/scribe</span>
     </div>
   </div>
@@ -3857,7 +3882,7 @@ scribe doctor <span class="flag">--section</span> localmode
 
   const SCENES = [
     {
-      cmd: 'scribe init --path ~/my-kb',
+      cmd: 'scribe init --path ~/my-kb --bind',
       out: [
         '<span class="out-key">→</span> creating ~/my-kb/scribe.yaml',
         '<span class="out-key">→</span> writing handshake into ~/.claude/CLAUDE.md',

--- a/site/public/index.md
+++ b/site/public/index.md
@@ -88,6 +88,8 @@ Deeper differentiators against the broader memory-tool landscape:
 
 scribe is single-user by default and stays that way. But a small team on the same codebases can point every machine at one git-backed KB: clone the repo, and scribe rebuilds local state from what's committed. The obvious fear with sharing agent sessions — a leaked secret, a private client repo, one teammate's config change reaching everyone — is exactly what the gates below are built to stop. **Only knowledge you meant to keep crosses into the shared KB; every gate here is a mechanism in the code, not a policy in a doc.**
 
+**Exact commands:** the [setup runbook](https://getscribe.dev/setup.md) separates the one team owner who creates and publishes the KB from the commands every member runs after cloning it.
+
 The trust boundary, concretely — what tries to cross into the shared KB and what stops it:
 
 - An **AWS key in a session transcript** → the **secret-scan gate** → held back, never committed.
@@ -198,10 +200,10 @@ qmd query "how did I solve the oban idempotency bug last quarter"
 78 command paths, one binary. The ones you'll actually type:
 
 ```
-scribe init                 # bootstrap a KB, wire the agent handshake
+scribe init --bind          # bootstrap a KB, wire the agent handshake
 scribe sync                 # discover → extract → absorb → reindex
 scribe sync --sessions      # mine coding-agent transcripts
-scribe sync --estimate      # token estimate, zero LLM calls
+scribe sync --dry-run --estimate  # token estimate, no writes or LLM calls
 scribe doctor               # validate setup, cron, git remote, Ollama
 scribe commit               # stage + push the KB to your private remote
 scribe dream                # weekly consolidation (Ollama-driven)
@@ -237,14 +239,38 @@ The loop closes here: every absorb tick reindexes `qmd`; the next time you open 
 
 ## Install
 
+For personal Anthropic, local Ollama, hosted-provider, team-owner, team-member,
+second-KB, and Linux recipes — plus a prompt that lets Claude Code or Codex
+perform and verify the setup — use <https://getscribe.dev/setup.md>.
+
 ```sh
 brew tap oliver-kriska/scribe
 brew install oliver-kriska/scribe/scribe
-scribe init --path ~/my-kb
+scribe init --path ~/my-kb --bind
 cd ~/my-kb
+scribe skill install
+scribe sync --discover
+scribe projects review
+scribe sync --dry-run --estimate
 scribe cron install
 scribe doctor
 ```
+
+### Install with Claude Code or Codex
+
+Paste this prompt into your coding agent:
+
+> Read https://getscribe.dev/setup.md and set up scribe on this machine.
+> Before changing anything, ask me for the setup profile, KB path, and LLM provider.
+> For a team setup, also ask whether I am creating or joining the KB and ask for the private git remote.
+> Inspect existing state before changing it. Execute the applicable steps; do not only explain them.
+> Never use --force. Never print or commit secrets.
+> Ask before the first real scribe sync because it may call an LLM and incur cost.
+> Finish with the runbook's verification checklist and report what passed and what still needs human action.
+
+The complete runbook tells the agent which actions still require a human, such
+as provider sign-in, private-repository creation, API-key entry, macOS Full Disk
+Access, and saving Linux crontab entries.
 
 Or via shell installer: `curl -fsSL https://raw.githubusercontent.com/oliver-kriska/scribe/main/install.sh | bash`
 
@@ -299,4 +325,4 @@ Yes to both. The knowledge base is indexed by `qmd` for BM25 keyword search and 
 
 **License:** MIT
 **Source:** <https://github.com/oliver-kriska/scribe>
-**Last updated:** 2026-07-22
+**Last updated:** 2026-07-30

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -88,6 +88,8 @@ Deeper differentiators against the broader memory-tool landscape:
 
 scribe is single-user by default and stays that way. But a small team on the same codebases can point every machine at one git-backed KB: clone the repo, and scribe rebuilds local state from what's committed. The obvious fear with sharing agent sessions — a leaked secret, a private client repo, one teammate's config change reaching everyone — is exactly what the gates below are built to stop. **Only knowledge you meant to keep crosses into the shared KB; every gate here is a mechanism in the code, not a policy in a doc.**
 
+**Exact commands:** the [setup runbook](https://getscribe.dev/setup.md) separates the one team owner who creates and publishes the KB from the commands every member runs after cloning it.
+
 The trust boundary, concretely — what tries to cross into the shared KB and what stops it:
 
 - An **AWS key in a session transcript** → the **secret-scan gate** → held back, never committed.
@@ -198,10 +200,10 @@ qmd query "how did I solve the oban idempotency bug last quarter"
 78 command paths, one binary. The ones you'll actually type:
 
 ```
-scribe init                 # bootstrap a KB, wire the agent handshake
+scribe init --bind          # bootstrap a KB, wire the agent handshake
 scribe sync                 # discover → extract → absorb → reindex
 scribe sync --sessions      # mine coding-agent transcripts
-scribe sync --estimate      # token estimate, zero LLM calls
+scribe sync --dry-run --estimate  # token estimate, no writes or LLM calls
 scribe doctor               # validate setup, cron, git remote, Ollama
 scribe commit               # stage + push the KB to your private remote
 scribe dream                # weekly consolidation (Ollama-driven)
@@ -237,14 +239,38 @@ The loop closes here: every absorb tick reindexes `qmd`; the next time you open 
 
 ## Install
 
+For personal Anthropic, local Ollama, hosted-provider, team-owner, team-member,
+second-KB, and Linux recipes — plus a prompt that lets Claude Code or Codex
+perform and verify the setup — use <https://getscribe.dev/setup.md>.
+
 ```sh
 brew tap oliver-kriska/scribe
 brew install oliver-kriska/scribe/scribe
-scribe init --path ~/my-kb
+scribe init --path ~/my-kb --bind
 cd ~/my-kb
+scribe skill install
+scribe sync --discover
+scribe projects review
+scribe sync --dry-run --estimate
 scribe cron install
 scribe doctor
 ```
+
+### Install with Claude Code or Codex
+
+Paste this prompt into your coding agent:
+
+> Read https://getscribe.dev/setup.md and set up scribe on this machine.
+> Before changing anything, ask me for the setup profile, KB path, and LLM provider.
+> For a team setup, also ask whether I am creating or joining the KB and ask for the private git remote.
+> Inspect existing state before changing it. Execute the applicable steps; do not only explain them.
+> Never use --force. Never print or commit secrets.
+> Ask before the first real scribe sync because it may call an LLM and incur cost.
+> Finish with the runbook's verification checklist and report what passed and what still needs human action.
+
+The complete runbook tells the agent which actions still require a human, such
+as provider sign-in, private-repository creation, API-key entry, macOS Full Disk
+Access, and saving Linux crontab entries.
 
 Or via shell installer: `curl -fsSL https://raw.githubusercontent.com/oliver-kriska/scribe/main/install.sh | bash`
 
@@ -299,4 +325,4 @@ Yes to both. The knowledge base is indexed by `qmd` for BM25 keyword search and 
 
 **License:** MIT
 **Source:** <https://github.com/oliver-kriska/scribe>
-**Last updated:** 2026-07-22
+**Last updated:** 2026-07-30

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -17,6 +17,7 @@ The product is the curated wiki, not raw chunks. Every dense source fans out int
 ## Resources
 
 - [Marketing site](https://getscribe.dev/): overview, features, install, comparison table
+- [Setup runbook](https://getscribe.dev/setup.md): prompt-compatible personal, Ollama, hosted-provider, team-owner, team-member, second-KB, Linux cron, and verification recipes
 - [Marketing site as markdown](https://getscribe.dev/index.md): same content, plain text
 - [Full content concatenated](https://getscribe.dev/llms-full.txt): everything in one file for large-context LLMs, including both explainer-video transcripts
 - [Explainer video, 60s](https://assets.getscribe.dev/scribe-explainer.mp4): the whole pitch — scribe reads your git history, Claude Code/Codex sessions, and saved links, and writes a plain-markdown KB your agents read before they act; local, cron-driven, not RAG (full transcript in llms-full.txt; also on YouTube: https://youtu.be/f2jV9PnzRzI)

--- a/site/public/setup.md
+++ b/site/public/setup.md
@@ -1,0 +1,475 @@
+# Set up scribe — human and coding-agent runbook
+
+This is the zero-to-running setup guide for scribe. It is deliberately
+procedural: choose one recipe, run the commands in order, and finish with the
+verification checklist. It covers personal Anthropic, local Ollama, hosted
+providers, team owners and members, multiple KBs, and Linux scheduling.
+
+Public URL: <https://getscribe.dev/setup.md>
+
+## Give this guide to Claude Code, Codex, or another coding agent
+
+Paste this prompt:
+
+> Read https://getscribe.dev/setup.md and set up scribe on this machine.
+> Before changing anything, ask me for the setup profile, KB path, and LLM provider.
+> For a team setup, also ask whether I am creating or joining the KB and ask for the private git remote.
+> Inspect existing state before changing it. Execute the applicable steps; do not only explain them.
+> Never use --force. Never print or commit secrets.
+> Ask before the first real scribe sync because it may call an LLM and incur cost.
+> Finish with the runbook's verification checklist and report what passed and what still needs human action.
+
+The agent should stop and ask the human for actions it cannot safely perform,
+such as signing into Claude, creating a private git repository, granting macOS
+Full Disk Access, adding a hosted-provider API key, or installing Linux crontab
+entries.
+
+## Choose one profile
+
+| Goal | Recipe |
+|---|---|
+| Your first personal KB, Anthropic-backed | [Personal KB](#personal-kb) with `--provider anthropic` |
+| Your first personal KB, no API spend | [Personal KB](#personal-kb) with `--provider ollama` |
+| Use Together, Groq, Fireworks, Hugging Face, or another `/v1` endpoint | [Hosted provider](#hosted-openai-compatible-provider) |
+| Create and publish a KB for a team | [Team owner](#team-owner-create-and-publish) |
+| Join an existing team KB | [Team member](#team-member-clone-and-onboard) |
+| Add a team KB while keeping a personal KB as default | [A second KB on one machine](#a-second-kb-on-one-machine) |
+| Linux scheduling | Use the same recipe, then follow [Linux cron](#linux-cron) |
+
+## Before changing anything
+
+An agent should inspect, not guess:
+
+```sh
+uname -s
+command -v scribe || true
+command -v git || true
+command -v sqlite3 || true
+command -v ccrider || true
+command -v qmd || true
+command -v claude || true
+command -v ollama || true
+scribe --version 2>/dev/null || true
+```
+
+If the intended KB directory already contains `scribe.yaml`, treat it as an
+existing KB. Do not run a fresh `scribe init --path …` over it and do not use
+`--force`. For an existing checkout, `cd` into it and run `scribe init --check`
+or the team-member recipe below.
+
+Do not paste API keys into a prompt, command history, committed `scribe.yaml`,
+or a team repository. Hosted-provider keys belong in the per-machine
+`~/.config/scribe/config.yaml` (mode `0600`) or an environment variable.
+
+## Install the CLI and required tools
+
+### Homebrew (macOS or Linuxbrew)
+
+```sh
+brew tap oliver-kriska/scribe
+brew install oliver-kriska/scribe/scribe
+```
+
+The formula installs `git`, `sqlite`, and `ccrider`. Install the remaining
+required tools:
+
+```sh
+curl -fsSL https://claude.ai/install.sh | bash
+npm install -g @tobilu/qmd
+```
+
+Use `claude` once and complete its normal sign-in when the Anthropic provider
+will be used. The Ollama profile does not spend Anthropic tokens, but the
+current dependency check still expects the Claude CLI to be present.
+
+For fully local inference, also install and start Ollama:
+
+```sh
+brew install ollama
+ollama serve
+```
+
+On macOS the Ollama app/service may already be running; do not start a second
+server if `ollama list` works. When it is not running, start `ollama serve` in a
+dedicated terminal or OS service; a setup agent should not leave an
+uncontrolled foreground server attached to its command session.
+
+### Shell installer
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/oliver-kriska/scribe/main/install.sh | bash
+```
+
+The binary lands in `$HOME/.local/bin` by default. Ensure that directory is on
+`PATH`, then install `git`, `sqlite3`, `ccrider`, `qmd`, and the selected LLM
+provider using their upstream instructions. Check the result:
+
+```sh
+scribe --version
+```
+
+## Personal KB
+
+Set the target once so later commands are copy-safe:
+
+```sh
+KB="$HOME/my-kb"
+```
+
+### Anthropic
+
+```sh
+scribe init --path "$KB" --bind --provider anthropic
+```
+
+### Local Ollama
+
+```sh
+scribe init --path "$KB" --bind --provider ollama
+```
+
+`--bind` matters: it makes this KB the machine default and installs the scribe
+handshake into both `~/.claude/CLAUDE.md` and `~/.codex/AGENTS.md`. Without it,
+init may deliberately leave machine-global state untouched, especially when
+another KB is already configured.
+
+Continue with either provider:
+
+```sh
+cd "$KB"
+scribe skill install
+scribe sync --discover
+scribe projects review
+scribe sync --dry-run --estimate
+scribe cron install
+scribe doctor
+```
+
+What these steps do:
+
+1. `scribe skill install` adds the operational agent skills inside the KB. It
+   does not replace install/init; it is useful after the binary and KB exist.
+2. `sync --discover` records candidate repositories without extracting them.
+3. `projects review` is the consent gate. Approve only repositories this KB is
+   allowed to read.
+4. `sync --dry-run --estimate` previews pending work without writes or LLM
+   calls. A real `scribe sync` can spend tokens; run it only after reviewing the
+   estimate.
+5. `cron install` installs macOS LaunchAgents or prints Linux crontab entries.
+6. `doctor` checks dependencies, configuration, scheduling, qmd, and local
+   Ollama health when selected. A new empty KB can have freshness warnings;
+   hard failures must be fixed.
+
+Optional: add a private git remote so the markdown KB is backed up:
+
+```sh
+git -C "$KB" remote add origin git@github.com:you/my-kb.git
+git -C "$KB" push -u origin main
+```
+
+### Non-interactive personal init
+
+Supply every value that should not use a default:
+
+```sh
+scribe init \
+  --path "$KB" \
+  --bind \
+  --provider anthropic \
+  --owner-name "Alice" \
+  --owner-context "Platform engineer working on the API and infrastructure." \
+  --domains platform,infra \
+  --yes
+```
+
+Use `--provider ollama` for local mode. Omit `--handle` to leave optional
+iMessage capture disabled.
+
+## Hosted OpenAI-compatible provider
+
+The init flag accepts `anthropic` or `ollama`; hosted routing is configured
+after scaffolding. A personal user starts with the Anthropic personal recipe
+above. A team owner starts with the team-owner recipe below. In either case,
+replace the generated top-level `llm:` block with the chosen provider's real
+model and endpoint policy before publishing the configuration. Example:
+
+```yaml
+llm:
+  provider: together
+  model: MiniMaxAI/MiniMax-M3
+  api_key_env: TOGETHER_API_KEY
+  pricing:
+    "together/MiniMaxAI/MiniMax-M3":
+      input: 0.30
+      output: 1.20
+```
+
+Named providers (`together`, `groq`, `fireworks`, `huggingface`) have built-in
+base URLs. Use `provider: openai-compat` plus `base_url` for another compatible
+`/v1/chat/completions` endpoint. Confirm the exact serverless model ID and
+current pricing with the provider; catalog names and rates change.
+
+The key must stay outside the KB. Have the human place it in an environment
+variable or add `llm_api_key` / provider-specific `llm_api_keys` to
+`~/.config/scribe/config.yaml`, then restrict the file:
+
+```sh
+chmod 600 ~/.config/scribe/config.yaml
+scribe doctor
+scribe sync --dry-run --estimate
+```
+
+`doctor` validates the parsed routing and budget configuration but does not
+send a hosted-provider probe. The endpoint, key, and model are fully validated
+only by an approved real LLM call, which can incur cost. The final sync in this
+guide is that end-to-end check.
+
+For a team KB, the routing block is shared and trust-locked, but every member
+supplies their own key locally. Never commit a key to `scribe.yaml` or ask a
+member to paste one into an agent prompt.
+
+## Team owner: create and publish
+
+One person creates the KB. Everyone else clones it; teammates must **not** run
+`scribe init --team --path …` independently.
+
+Before init, choose a checkout convention shared by the team. The example uses
+`~/work`; the quotes are important because they preserve `~` in committed
+`scribe.yaml`, allowing scribe to expand it separately on every machine.
+
+```sh
+KB="$HOME/team-kb"
+
+scribe init \
+  --path "$KB" \
+  --bind \
+  --team \
+  --kb-name acme-kb \
+  --allow '~/work' \
+  --provider anthropic
+
+cd "$KB"
+scribe skill install
+```
+
+Use `--provider ollama` only if every participating machine will run the chosen
+Ollama model. If teammates keep repositories in different directory layouts,
+prefer a git-identity allowlist. Before pushing, edit the generated
+`scribe.yaml`:
+
+```yaml
+sources:
+  include:
+    - ~/work
+  allowed_remotes:
+    - github.com/acme
+```
+
+`allowed_remotes` rejects repositories without a matching `origin`, regardless
+of checkout location. Keep personal/client repositories out with shared
+`sources.exclude` rules or stricter per-person rules in the gitignored
+`scribe.local.yaml`.
+
+Init creates the scaffold commit before skills or later config edits, so commit
+those additions and publish the private repository:
+
+```sh
+git add scribe.yaml .claude/skills .agents/skills
+git commit -m "chore: configure team KB"
+git remote add origin git@github.com:acme/team-kb.git
+git push -u origin main
+```
+
+Then onboard the owner's machine like any other member:
+
+```sh
+scribe config trust
+scribe sync --discover
+scribe projects review
+scribe sync --dry-run --estimate
+scribe cron install
+scribe doctor
+```
+
+Do not place a personal iMessage handle, API key, personal source path, or NDA
+stop word in committed `scribe.yaml`. Put per-person values in
+`scribe.local.yaml` or `~/.config/scribe/config.yaml`.
+
+## Team member: clone and onboard
+
+Every member installs the CLI and dependencies first. Use the same scribe
+release and LLM provider policy as the rest of the team, then:
+
+If this machine already has a personal KB and it should remain the default
+Claude/Codex handshake, follow [A second KB on one machine](#a-second-kb-on-one-machine)
+instead of running `--bind`. If the team KB should become the default, the bind
+below preserves the old default in `scribe kb list`, so scheduling continues
+to serve both KBs.
+
+```sh
+KB="$HOME/team-kb"
+
+git clone git@github.com:acme/team-kb.git "$KB"
+cd "$KB"
+
+git config user.name "Alice Example"
+git config user.email "alice@example.com"
+
+scribe init --bind --yes
+scribe config diff
+scribe config trust
+scribe skill install --check
+scribe sync --discover
+scribe projects review
+scribe sync --dry-run --estimate
+scribe cron install
+scribe doctor
+```
+
+The member command is `scribe init --bind --yes` **inside the clone**. Do not
+pass `--path`, `--team`, `--kb-name`, `--allow`, or `--provider`: those are
+team-owner choices already committed in `scribe.yaml`. This init invocation
+checks the checkout and installs that member's machine-local default and agent
+handshakes without recreating the KB.
+
+`scribe config diff` shows the trust boundary; `scribe config trust` explicitly
+accepts the cloned sensitive settings on that machine. `skill install --check`
+ensures the committed skills match the member's binary. If it reports drift,
+coordinate one skill update through the shared repository instead of having
+every member create competing updates.
+
+Each member has their own gitignored `scripts/projects.json`, so each must run
+discovery and approve repositories. Those approvals and absolute paths are not
+shared. The shared commands/flags live in committed `scribe.yaml`; the local
+manifest, credentials, subscriptions, capture handles, and additional source
+filters remain per-machine.
+
+## A second KB on one machine
+
+The scheduler supports multiple registered KBs, but the global Claude/Codex
+handshake and `kb_dir` default point to one KB at a time.
+
+To keep an existing personal KB as the default while adding a team KB:
+
+```sh
+KB="$HOME/team-kb"
+git clone git@github.com:acme/team-kb.git "$KB"
+cd "$KB"
+
+scribe init --check
+scribe config trust
+scribe kb add "$KB"
+scribe cron install
+scribe doctor
+```
+
+Do not use `--bind` in this profile: it would repoint the one global handshake.
+Target the team KB by running inside it or explicitly:
+
+```sh
+scribe -C "$KB" status
+scribe -C "$KB" sync --dry-run --estimate
+```
+
+To intentionally make the team KB the new default, first ensure the old
+personal KB is explicitly registered, then bind the team checkout:
+
+```sh
+scribe kb add "$HOME/my-kb"
+cd "$KB"
+scribe init --bind --yes
+scribe kb list
+```
+
+One KB-agnostic LaunchAgent set runs `scribe each` across the registry; a
+second KB does not require a second set of plists. Configure per-KB pacing with
+`each.cadence` in that KB's `scribe.yaml` if needed.
+
+## Linux cron
+
+On Linux, `scribe cron install` prints crontab lines instead of installing
+them. Review the output, paste the block into `crontab -e`, then verify:
+
+```sh
+crontab -l
+scribe doctor --section cron
+```
+
+Do not claim scheduling is installed merely because scribe printed the block;
+the user must actually save it in their crontab.
+
+## Optional macOS iMessage capture
+
+Personal KB: add the self-chat handle during interactive init or later in
+`scribe.yaml`. Team KB: place it only in the gitignored `scribe.local.yaml`.
+Then grant Full Disk Access to the exact scribe binary:
+
+```sh
+scribe fda
+scribe fda --verify
+```
+
+The macOS permission can be invalidated when the binary is replaced. Re-run
+`scribe fda` after `brew upgrade` or `make install` when capture stops working.
+
+## Verification checklist
+
+Use `-C` so every check names the intended KB explicitly:
+
+```sh
+scribe --version
+scribe -C "$KB" init --check
+scribe -C "$KB" doctor
+scribe -C "$KB" cron status
+scribe kb list
+scribe -C "$KB" projects list
+scribe -C "$KB" sync --dry-run --estimate
+scribe -C "$KB" skill install --check
+git -C "$KB" status --short
+```
+
+For a team KB, also run:
+
+```sh
+scribe -C "$KB" config diff
+git -C "$KB" remote -v
+```
+
+Setup is complete when:
+
+- `scribe` resolves to the expected binary and reports a version.
+- `init --check` finds the intended KB and performs no writes.
+- `doctor` has no unexplained hard failures; qmd is healthy, and Ollama is
+  reachable with the chosen local model when that provider is selected.
+- The KB appears in `scribe kb list`, and cron is installed (or its Linux block
+  has actually been added).
+- Only intended repositories are approved.
+- The dry-run estimate is plausible before any paid sync.
+- Agent skills match, and team config has no unreviewed drift.
+- The KB git remote is private and the worktree contains no accidental secret
+  or machine-local file.
+
+For a hosted provider, the checklist proves local configuration but deliberately
+does not spend tokens on a probe. A successful first real sync below is the
+endpoint/key/model verification.
+
+Only then, and with the user's approval when inference may cost money, run the
+first real pipeline pass:
+
+```sh
+scribe -C "$KB" sync
+```
+
+## What `init`, the handshake, and skills each do
+
+- `scribe init --bind` creates or checks the KB **and** wires the one
+  machine-global Claude Code/Codex handshake. That handshake makes agents in
+  other project directories query the KB and write reusable drop files.
+- `scribe skill install` writes `scribe-kb`, `scribe-kb-tidy`, and `scribe-cli`
+  into the KB's agent-skill directories. Those skills help an agent operate and
+  maintain an existing KB when a session is opened where the skills are
+  discoverable.
+- Therefore the skills command is useful, but it is not a bootstrap mechanism:
+  it requires an installed binary and a KB, does not install dependencies, does
+  not choose personal versus team mode, and does not replace `init --bind`,
+  source approval, cron setup, or `doctor` verification.

--- a/site/public/sitemap.xml
+++ b/site/public/sitemap.xml
@@ -2,25 +2,31 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://getscribe.dev/</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
+    <loc>https://getscribe.dev/setup.md</loc>
+    <lastmod>2026-07-30</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
     <loc>https://getscribe.dev/llms.txt</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://getscribe.dev/llms-full.txt</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://getscribe.dev/index.md</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>


### PR DESCRIPTION
## Summary

- add a standalone, prompt-compatible `setup.md` runbook for personal Anthropic, local Ollama, hosted OpenAI-compatible providers, team owners/members, multiple KBs, and Linux scheduling
- add a visible, copyable **install with agent** path to getscribe.dev and keep the README, embedded CLI skill, package-manager caveats, `llms.txt`, and site Markdown mirrors aligned
- clarify that `scribe skill install` helps after bootstrap but does not replace binary/dependency installation, `init --bind`, source approval, scheduling, or verification
- separate the one team owner who scaffolds with `--team` from members who clone and run `init --bind --yes`; document shared versus per-machine state, config trust, source approval, skill drift, and safe hosted-key placement
- make `scribe init --check` genuinely non-interactive and preserve the previous default KB in the registry when rebinding, so scheduled `scribe each` jobs continue serving both KBs
- make Linux `cron status` and `doctor --section cron` inspect the installed crontab block and current KB registry membership instead of probing macOS LaunchAgents

## Why

The previous quick start omitted `--bind`, which can leave the Claude/Codex handshake unwired when a path is supplied. Team guidance also mixed owner and member responsibilities, the old Linux example still used retired single-KB cron commands, and `sync --estimate` was shown without the required `--dry-run` safety flag.

The new runbook gives humans one profile to follow and gives Claude Code/Codex a constrained prompt that requires inspecting existing state, avoiding `--force` and secrets, asking before paid inference, and finishing with explicit verification.

## Verification

- `make check` (`go test -tags sqlite_fts5 ./...` + `go vet`)
- focused regression tests for non-interactive `init --check`, rebind registry preservation, Linux cron detection, and generated-block round-tripping
- isolated personal → team rebind CLI smoke test; both KBs remained in `scribe kb list`
- `git diff --check`
- `bash -n install.sh`
- getscribe.dev evergreen/version-pin audit
- HTML parser, unique IDs, tab ARIA references, copy targets, 9 JSON-LD blocks, sitemap XML, Markdown fence checks
- exact `index.md` / `llms-full.txt` mirror and exact coding-agent prompt across HTML + Markdown surfaces
- local static server returned `200 text/markdown` for `/setup.md`

## Deployment

This PR updates the Cloudflare static-site source but does not deploy getscribe.dev. Deploy after review/merge using the repository's site-sync workflow.
