### PR TITLE
fix: make onboarding checks safe across platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to scribe are documented here. Format follows [Keep a Change
 
 ## [Unreleased]
 
+### Fixed
+- `scribe init --check` no longer prompts for scaffold values, preserving its
+  documented read-only, non-interactive contract.
+- Rebinding the default KB preserves the previous default as an explicit
+  registry entry, so machine-level `scribe each` schedules continue serving it.
+- On Linux, `scribe cron status` and `scribe doctor --section cron` now inspect
+  the user crontab and current KB registry membership instead of reporting
+  missing macOS LaunchAgents.
+
 ## [0.4.4] — 2026-08-10
 
 A reliability and agent-integration release. It closes pass-2 content omission

--- a/cmd/scribe/cron.go
+++ b/cmd/scribe/cron.go
@@ -15,7 +15,8 @@ import (
 	"time"
 )
 
-// CronCmd manages macOS LaunchAgents for scribe's scheduled KB jobs.
+// CronCmd manages scheduled scribe KB jobs: macOS LaunchAgents, or
+// ready-to-paste crontab guidance and status on Linux.
 //
 // Why LaunchAgents instead of crontab: macOS cron runs under launchd without
 // a user Aqua session, so it cannot read the login keychain. Claude Code's
@@ -24,8 +25,8 @@ import (
 // the gui/<uid> domain run inside the user's login session and have keychain
 // access. This command installs/removes/status those plists.
 type CronCmd struct {
-	Install   CronInstallCmd   `cmd:"" help:"Install LaunchAgent plists for scribe KB jobs."`
-	Status    CronStatusCmd    `cmd:"" help:"Show status of scribe LaunchAgents."`
+	Install   CronInstallCmd   `cmd:"" help:"Install macOS LaunchAgents or print Linux crontab entries."`
+	Status    CronStatusCmd    `cmd:"" help:"Show status of macOS LaunchAgents or the Linux crontab block."`
 	Uninstall CronUninstallCmd `cmd:"" help:"Unload and remove scribe LaunchAgents."`
 }
 
@@ -810,6 +811,14 @@ func (c *CronInstallCmd) Run() error {
 
 type CronStatusCmd struct{}
 
+// readUserCrontab is shared with doctor's Linux cron check and indirected for
+// deterministic tests. `crontab -l` exits non-zero when the user has no
+// crontab; callers turn that into an actionable missing-schedule result.
+var readUserCrontab = func() (string, error) {
+	out, err := exec.Command("crontab", "-l").CombinedOutput()
+	return string(out), err
+}
+
 func (c *CronStatusCmd) Run() error {
 	// KB-agnostic: agents serve the whole registry, so status no longer
 	// needs a KB context. Show the registry first, then per-agent state.
@@ -821,6 +830,21 @@ func (c *CronStatusCmd) Run() error {
 		fmt.Println()
 	} else {
 		fmt.Printf("No registered KBs — add one with `scribe kb add <path>` (or set kb_dir in %s)\n\n", userConfigPath())
+	}
+
+	if runtime.GOOS != "darwin" {
+		raw, err := readUserCrontab()
+		switch {
+		case err != nil:
+			fmt.Println("Linux crontab: missing or unreadable")
+			fmt.Println("Run `scribe cron install`, review the printed block, then add it with `crontab -e`.")
+		case hasScribeCrontabBlock(raw):
+			fmt.Println("Linux crontab: scribe block installed")
+		default:
+			fmt.Println("Linux crontab: no current scribe block found")
+			fmt.Println("Run `scribe cron install`, review the printed block, then add it with `crontab -e`.")
+		}
+		return nil
 	}
 
 	jobs := scribeJobs(resolveScribeBinary())
@@ -835,6 +859,12 @@ func (c *CronStatusCmd) Run() error {
 		fmt.Printf("%-28s %-10s %s\n", label, state, path)
 	}
 	return nil
+}
+
+func hasScribeCrontabBlock(raw string) bool {
+	return strings.Contains(raw, "# ---- scribe ----") &&
+		strings.Contains(raw, "# ---- end scribe ----") &&
+		strings.Contains(raw, "scribe each --")
 }
 
 // ---- uninstall ----

--- a/cmd/scribe/cron_test.go
+++ b/cmd/scribe/cron_test.go
@@ -1,12 +1,40 @@
 package main
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
 )
+
+func TestPrintedLinuxCronBlockMatchesStatusDetection(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	origStdout := os.Stdout
+	os.Stdout = w
+	printErr := printLinuxCronInstructions(scribeJobs("/home/alice/.local/bin/scribe"), false)
+	_ = w.Close()
+	os.Stdout = origStdout
+	t.Cleanup(func() {
+		os.Stdout = origStdout
+		_ = r.Close()
+	})
+
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if printErr != nil {
+		t.Fatalf("printLinuxCronInstructions: %v", printErr)
+	}
+	if !hasScribeCrontabBlock(string(out)) {
+		t.Fatalf("printed cron block is not recognized by status/doctor:\n%s", out)
+	}
+}
 
 // TestRenderCrontab confirms the collapsing rules and the one-line-per-slot
 // fallback match what we document in README. Each case is one representative

--- a/cmd/scribe/doctor.go
+++ b/cmd/scribe/doctor.go
@@ -696,6 +696,10 @@ func routeDocOrEpub(hasMarker bool) string {
 // ---- Cron ----
 
 func checkCron(root string) []check {
+	if runtimeGOOS != "darwin" {
+		return checkLinuxCron(root)
+	}
+
 	var out []check
 	binary := resolveScribeBinary()
 	jobs := scribeJobs(binary)
@@ -741,6 +745,44 @@ func checkCron(root string) []check {
 			Section: "cron", Name: "foreign-agents", Status: statusWarn,
 			Detail: fmt.Sprintf("%d LaunchAgent(s) outside scribe's job set also reference this binary or KB: %s — duplicated jobs run twice per slot", len(foreign), strings.Join(foreign, ", ")),
 			Fix:    "review each; if it is a stale duplicate: launchctl bootout gui/$(id -u)/<label> and move the plist out of ~/Library/LaunchAgents",
+		})
+	}
+	return out
+}
+
+func checkLinuxCron(root string) []check {
+	var out []check
+	if kbRegistered(loadUserConfig(), root) {
+		out = append(out, check{
+			Section: "cron", Name: "kb-scope", Status: statusOK,
+			Detail: fmt.Sprintf("this KB is registered — `scribe each` serves it (%d KB(s) on this machine)", len(registeredKBs())),
+		})
+	} else {
+		out = append(out, check{
+			Section: "cron", Name: "kb-scope", Status: statusFail,
+			Detail: "this KB is not in the machine registry — scheduled `scribe each` runs skip it",
+			Fix:    "scribe kb add " + root,
+		})
+	}
+
+	raw, err := readUserCrontab()
+	switch {
+	case err != nil:
+		out = append(out, check{
+			Section: "cron", Name: "linux-crontab", Status: statusFail,
+			Detail: "no readable user crontab with the scribe block",
+			Fix:    "run `scribe cron install`, review the output, then paste it into `crontab -e`",
+		})
+	case hasScribeCrontabBlock(raw):
+		out = append(out, check{
+			Section: "cron", Name: "linux-crontab", Status: statusOK,
+			Detail: "scribe marker block with KB-agnostic `scribe each` jobs is installed",
+		})
+	default:
+		out = append(out, check{
+			Section: "cron", Name: "linux-crontab", Status: statusFail,
+			Detail: "user crontab does not contain the current scribe block",
+			Fix:    "run `scribe cron install`, review the output, then paste it into `crontab -e`",
 		})
 	}
 	return out

--- a/cmd/scribe/doctor_cron_scope_test.go
+++ b/cmd/scribe/doctor_cron_scope_test.go
@@ -2,6 +2,13 @@ package main
 
 import "testing"
 
+func stubUserCrontab(t *testing.T, raw string, err error) {
+	t.Helper()
+	prev := readUserCrontab
+	readUserCrontab = func() (string, error) { return raw, err }
+	t.Cleanup(func() { readUserCrontab = prev })
+}
+
 // TestCronScopeCheck covers the KB-scope cron headline (issue #27 item 1):
 // "loaded" agents are a single KB-agnostic set, so doctor must say whether
 // they actually serve THIS KB — keyed on registry membership, not the
@@ -25,5 +32,33 @@ func TestCronScopeCheck(t *testing.T) {
 	}
 	if c.Name != "kb-scope" {
 		t.Errorf("name = %q, want kb-scope", c.Name)
+	}
+}
+
+func TestCheckLinuxCron(t *testing.T) {
+	isolateUserConfig(t)
+	root := makeKBRoot(t, "linux-kb")
+	writeUserCfg(t, "kbs:\n  - "+root+"\n")
+	stubUserCrontab(t, "# ---- scribe ----\n0 * * * * /usr/bin/scribe each -- commit\n# ---- end scribe ----\n", nil)
+
+	checks := checkLinuxCron(root)
+	if len(checks) != 2 {
+		t.Fatalf("checks = %d, want 2: %+v", len(checks), checks)
+	}
+	for _, c := range checks {
+		if c.Status != statusOK {
+			t.Errorf("%s status = %q, want ok: %+v", c.Name, c.Status, c)
+		}
+	}
+}
+
+func TestCheckLinuxCronReportsMissingBlock(t *testing.T) {
+	isolateUserConfig(t)
+	root := makeKBRoot(t, "linux-kb")
+	stubUserCrontab(t, "0 * * * * echo unrelated\n", nil)
+
+	checks := checkLinuxCron(root)
+	if len(checks) != 2 || checks[0].Status != statusFail || checks[1].Status != statusFail {
+		t.Fatalf("unregistered KB + missing block should fail both checks: %+v", checks)
 	}
 }

--- a/cmd/scribe/init.go
+++ b/cmd/scribe/init.go
@@ -386,26 +386,27 @@ func (c *InitCmd) runBootstrap() error {
 // --check mode any missing value falls back to a safe default so init can
 // run unattended (CI, shell scripts).
 func (c *InitCmd) collectVars(abs string) (templateVars, error) {
+	interactive := !c.Yes && !c.Check
 	kbName := c.KBName
 	if kbName == "" {
 		kbName = filepath.Base(abs)
 	}
 	owner := c.OwnerName
-	if owner == "" && !c.Yes {
+	if owner == "" && interactive {
 		owner = prompt("Owner name", os.Getenv("USER"))
 	}
 	if owner == "" {
 		owner = os.Getenv("USER")
 	}
 	ownerCtx := c.OwnerContext
-	if ownerCtx == "" && !c.Yes {
+	if ownerCtx == "" && interactive {
 		ownerCtx = prompt("Owner context (one sentence about your role/projects)", "Knowledge base owner.")
 	}
 	if ownerCtx == "" {
 		ownerCtx = "Knowledge base owner."
 	}
 	domains := c.Domains
-	if len(domains) == 0 && !c.Yes {
+	if len(domains) == 0 && interactive {
 		raw := prompt("Domains (comma-separated, e.g. work, oss, personal)", "")
 		for d := range strings.SplitSeq(raw, ",") {
 			d = strings.TrimSpace(d)
@@ -415,7 +416,7 @@ func (c *InitCmd) collectVars(abs string) (templateVars, error) {
 		}
 	}
 	handle := c.Handle
-	if handle == "" && !c.Yes {
+	if handle == "" && interactive {
 		handle = prompt("iMessage self-chat handle (leave empty to disable capture)", "")
 	}
 
@@ -423,7 +424,7 @@ func (c *InitCmd) collectVars(abs string) (templateVars, error) {
 	// --provider on the CLI, that wins. Otherwise prompt in
 	// interactive mode; default anthropic.
 	provider := strings.ToLower(strings.TrimSpace(c.Provider))
-	if provider == "" && !c.Yes {
+	if provider == "" && interactive {
 		provider = prompt("LLM provider (anthropic | ollama)", "anthropic")
 	}
 	if provider == "" {
@@ -1004,6 +1005,22 @@ func installUserConfig(root string, check, yes, bound bool) error {
 	// run inside a second KB silently wiped the machine's API key and KB
 	// list. Marshal the loaded config back instead; omitempty keeps the
 	// file minimal when those fields are unset.
+	//
+	// Preserve the previous default as an explicit registry member before
+	// repointing. Otherwise binding a cloned team KB would make a personal KB
+	// disappear from `scribe each` whenever it was represented only by kb_dir.
+	if uc.KBDir != "" && !samePath(uc.KBDir, root) {
+		alreadyListed := false
+		for _, kb := range uc.KBs {
+			if samePath(kb, uc.KBDir) {
+				alreadyListed = true
+				break
+			}
+		}
+		if !alreadyListed {
+			uc.KBs = append(uc.KBs, uc.KBDir)
+		}
+	}
 	uc.KBDir = root
 	body, err := yaml.Marshal(&uc)
 	if err != nil {

--- a/cmd/scribe/init_test.go
+++ b/cmd/scribe/init_test.go
@@ -2,12 +2,47 @@ package main
 
 import (
 	"bytes"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func TestCollectVarsCheckDoesNotPrompt(t *testing.T) {
+	stdinR, stdinW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = stdinW.Close() // immediate EOF if code incorrectly tries to read
+	stdoutR, stdoutW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	origStdin, origStdout := os.Stdin, os.Stdout
+	os.Stdin, os.Stdout = stdinR, stdoutW
+	_, collectErr := (&InitCmd{Check: true}).collectVars("/home/alice/my-kb")
+	_ = stdoutW.Close()
+	os.Stdin, os.Stdout = origStdin, origStdout
+	t.Cleanup(func() {
+		os.Stdin, os.Stdout = origStdin, origStdout
+		_ = stdinR.Close()
+		_ = stdoutR.Close()
+	})
+
+	out, err := io.ReadAll(stdoutR)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if collectErr != nil {
+		t.Fatalf("collectVars: %v", collectErr)
+	}
+	if len(out) != 0 {
+		t.Fatalf("--check prompted or printed during variable collection: %q", out)
+	}
+}
 
 // TestIsThrowawayPath guards the heuristic that gates global state
 // rewrites in `scribe init -p ...`. The 2026-05-13 incident burned
@@ -668,5 +703,31 @@ func TestInstallUserConfigPreservesSecretsAndRegistry(t *testing.T) {
 	}
 	if perm := info.Mode().Perm(); perm != 0o600 {
 		t.Errorf("config perms = %o, want 0600 (file carries an api key)", perm)
+	}
+}
+
+func TestInstallUserConfigPreservesPreviousDefaultInRegistry(t *testing.T) {
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	oldRoot := filepath.Join(fakeHome, "personal-kb")
+	newRoot := filepath.Join(fakeHome, "team-kb")
+	if err := os.MkdirAll(filepath.Dir(userConfigPath()), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(userConfigPath(), []byte("kb_dir: "+oldRoot+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := installUserConfig(newRoot, false, true, true); err != nil {
+		t.Fatalf("installUserConfig: %v", err)
+	}
+	got := loadUserConfig()
+	if got.KBDir != newRoot {
+		t.Errorf("KBDir = %q, want %q", got.KBDir, newRoot)
+	}
+	if len(got.KBs) != 1 || got.KBs[0] != oldRoot {
+		t.Errorf("KBs = %v, want previous default %q preserved", got.KBs, oldRoot)
 	}
 }


### PR DESCRIPTION
## Summary

- make `scribe init --check` genuinely non-interactive, matching its read-only CLI contract
- preserve the previous default KB as an explicit registry entry when rebinding, so `scribe each` keeps scheduling both KBs
- make Linux `scribe cron status` and `scribe doctor --section cron` inspect the user crontab and current KB registry membership instead of probing macOS LaunchAgents
- add regression coverage for non-interactive checks, registry preservation, Linux cron state, and generated-crontab round-tripping

## Scope

Runtime behavior and tests only. The setup runbook, README, embedded skills, package caveats, and website changes are intentionally split into a separate documentation PR.

## Verification

- `make check`
- focused regression tests for all three fixes
- isolated personal → team rebind smoke test confirmed both KBs remain in `scribe kb list`
