### PR TITLE
docs: add guided personal and team onboarding

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -173,9 +173,13 @@ brews:
       Already installed by brew as dependencies: git, sqlite, ccrider.
 
       After installing:
-        scribe init --path ~/my-kb
+        scribe init --path ~/my-kb --bind
+        cd ~/my-kb && scribe skill install
         scribe cron install           # macOS: LaunchAgents
                                       # Linux: prints crontab lines
+        scribe doctor
+
+      Personal, Ollama, hosted, and team recipes: https://getscribe.dev/setup.md
 
       macOS — Full Disk Access for `scribe capture` (iMessage):
         scribe fda                    # opens the FDA pane and walks you through

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,23 @@ All notable changes to scribe are documented here. Format follows [Keep a Change
   the user crontab and current KB registry membership instead of reporting
   missing macOS LaunchAgents.
 
+### Changed — setup and team onboarding
+- Added a public, prompt-compatible setup runbook for humans and coding agents
+  covering personal Anthropic, local Ollama, hosted OpenAI-compatible providers,
+  team-owner, team-member, second-KB, Linux cron, and verification flows. It
+  explains why the embedded skills help after bootstrap but do not replace
+  install/init/source approval/cron/doctor.
+- Quick-start commands now use `init --bind` so the documented flow actually
+  installs the machine-global Claude/Codex/Amp handshake, and cost previews use
+  the CLI's real no-write form: `sync --dry-run --estimate`.
+- Team setup now separates the one owner who runs `init --team` from members who
+  clone and run `init --bind --yes`, quotes shared `--allow '~/work'` paths so
+  the owner's shell does not commit an absolute home path, and documents shared
+  versus per-machine state, config trust, skill drift, source approval, and the
+  current multi-KB scheduler.
+- Linux guidance distinguishes generated crontab output from an installed
+  schedule and verifies it directly with `crontab -l`.
+
 ## [0.4.4] — 2026-08-10
 
 A reliability and agent-integration release. It closes pass-2 content omission

--- a/Formula/scribe.rb
+++ b/Formula/scribe.rb
@@ -64,9 +64,13 @@ class Scribe < Formula
       Already installed by brew as dependencies: git, sqlite, ccrider.
 
       After installing:
-        scribe init --path ~/my-kb
+        scribe init --path ~/my-kb --bind
+        cd ~/my-kb && scribe skill install
         scribe cron install           # macOS: LaunchAgents
                                       # Linux: prints crontab lines to paste
+        scribe doctor
+
+      Personal, Ollama, hosted, and team recipes: https://getscribe.dev/setup.md
 
       macOS — Full Disk Access for `scribe capture` (iMessage):
         scribe fda                    # opens the FDA pane and walks you through

--- a/README.md
+++ b/README.md
@@ -163,14 +163,38 @@ make install    # builds with -tags sqlite_fts5 to ./bin/scribe, then deploys to
 
 ---
 
-## Quick start
+## Quick start — personal KB
+
+If you want Claude Code or Codex to do the setup, give it the public
+**[setup runbook](https://getscribe.dev/setup.md)**. It includes a copyable
+prompt, personal/Ollama/hosted/team recipes, safety rules, and an explicit
+verification checklist. `scribe skill install` is useful after bootstrap, but
+it is not a replacement for installing dependencies, choosing a setup profile,
+running `init --bind`, approving sources, and verifying cron/configuration
+(plus Ollama health when selected).
 
 ```sh
-scribe init --path ~/my-kb
+scribe init --path ~/my-kb --bind
 cd ~/my-kb
-git remote add origin git@github.com:you/my-kb.git   # optional
+scribe skill install
+scribe sync --discover
+scribe projects review
+scribe sync --dry-run --estimate
 scribe cron install
 scribe doctor
+```
+
+`--bind` makes this KB the machine default and writes the scribe handshake into
+`~/.claude/CLAUDE.md`, `~/.codex/AGENTS.md`, and `~/.config/amp/AGENTS.md`.
+Without it, init may
+deliberately leave those machine-global files untouched when another KB is
+already configured. The discover/review pair is the source-consent gate; the
+dry-run estimate does not write or call an LLM. Add a private git remote when
+you want backup/sync:
+
+```sh
+git remote add origin git@github.com:you/my-kb.git
+git push -u origin main
 ```
 
 `scribe init` will prompt for:
@@ -180,7 +204,7 @@ scribe doctor
 - **Domains** — comma-separated list for the `domain:` frontmatter field. `personal` and `general` are always added.
 - **iMessage self-chat handle** — phone number or email you iMessage yourself at (optional; leave empty to disable capture).
 
-Everything gets written into `scribe.yaml` at the KB root. Re-run `scribe init --check` any time to re-validate against dependencies and templates.
+Everything gets written into `scribe.yaml` at the KB root. Re-run `scribe init --check` any time to re-validate against dependencies and templates without prompts or writes.
 
 On macOS, if you gave a self-chat handle, `scribe init` finishes by offering to walk you through Full Disk Access for the scribe binary (needed by `scribe capture`). You can skip and run `scribe fda` later — see [Full Disk Access](#full-disk-access-for-scribe-capture) below.
 
@@ -191,6 +215,7 @@ All prompts take matching flags:
 ```sh
 scribe init \
   --path ~/my-kb \
+  --bind \
   --owner-name "Alice" \
   --owner-context "Platform engineer. Main projects: weblog, infra." \
   --domains weblog,infra \
@@ -245,7 +270,9 @@ Manual fallback if you ever need it: System Settings → Privacy & Security → 
 
 ### Linux — manual crontab
 
-On Linux, `scribe cron install` prints crontab(5) lines you paste into `crontab -e`. Example output:
+On Linux, `scribe cron install` prints crontab(5) lines you paste into
+`crontab -e`. Abbreviated example output (the command prints the complete block
+with the machine's real `PATH` and scribe binary):
 
 ```
 # ---- scribe ----
@@ -253,23 +280,36 @@ SHELL=/bin/bash
 PATH=/home/alice/.local/bin:/usr/bin:/bin:...
 
 # Hourly KB auto-commit
-7 */1 * * * cd "/home/alice/my-kb" && /home/alice/.local/bin/scribe commit
+7 */1 * * * /home/alice/.local/bin/scribe each -- commit
 
 # Project extraction every 2h
-23 */2 * * * cd "/home/alice/my-kb" && /home/alice/.local/bin/scribe sync --max 2
+23 */2 * * * /home/alice/.local/bin/scribe each -- sync --max 2
 
 # Session mining at 3:00, 12:00, 18:00
-0 12 * * * cd "/home/alice/my-kb" && /home/alice/.local/bin/scribe sync --sessions --sessions-max 3 --skip-large
-0 18 * * * cd "/home/alice/my-kb" && /home/alice/.local/bin/scribe sync --sessions --sessions-max 3 --skip-large
-0 3  * * * cd "/home/alice/my-kb" && /home/alice/.local/bin/scribe sync --sessions --sessions-max 3 --skip-large
+0 12 * * * /home/alice/.local/bin/scribe each -- sync --sessions --sessions-max 3 --skip-large
+0 18 * * * /home/alice/.local/bin/scribe each -- sync --sessions --sessions-max 3 --skip-large
+0 3 * * * /home/alice/.local/bin/scribe each -- sync --sessions --sessions-max 3 --skip-large
 
 # Drain queued URLs into raw/articles/ every 30min
-*/30 * * * * cd "/home/alice/my-kb" && /home/alice/.local/bin/scribe ingest drain
+*/30 * * * * /home/alice/.local/bin/scribe each -- ingest drain
 
 # Weekly Dream cycle (Sun 2am)
-0 2 * * 0 cd "/home/alice/my-kb" && /home/alice/.local/bin/scribe dream
+0 2 * * 0 /home/alice/.local/bin/scribe each -- dream
 # ---- end scribe ----
 ```
+
+The generated jobs use `scribe each` so one machine-level crontab serves every
+KB in `scribe kb list`. After saving the block, verify its presence and review
+the machine registry directly:
+
+```sh
+crontab -l
+scribe cron status
+scribe kb list
+```
+
+`scribe cron status` reads the user crontab on Linux, so it confirms the block
+actually landed rather than just that scribe printed it.
 
 The `scribe watch` job (fsnotify watcher for ccrider's SQLite DB) is not cron-friendly — run it under systemd-user, supervisord, or a persistent tmux/screen session. `scribe cron install` on Linux names the jobs that fall into this category so you know what still needs a supervisor.
 
@@ -643,9 +683,9 @@ This is for the Claude Desktop **app** only — Claude Code and Codex CLI alread
 ## Command reference
 
 ```sh
-scribe init         # bootstrap a KB or check an existing one
-scribe init --allow ~/work --disallow ~/personal   # scaffold with discovery filters baked in
-scribe init --team -p ~/team-kb --allow ~/work     # scaffold a shared team KB (per-machine manifest)
+scribe init --path ~/my-kb --bind  # bootstrap a default KB and wire the agent handshake
+scribe init --path ~/my-kb --bind --allow '~/work' --disallow '~/personal'  # portable discovery filters
+scribe init --bind --team -p ~/team-kb --allow '~/work'      # team owner: scaffold a shared KB
 scribe sync         # discover → extract → absorb → reindex
 scribe projects     # list discovered projects with status
 scribe projects review       # interactively approve/ignore pending projects
@@ -656,7 +696,7 @@ scribe config diff  # team KBs: show sensitive scribe.yaml keys changed since la
 scribe config trust # team KBs: approve the current sensitive keys
 scribe config update # append commented docs for options added since your scribe.yaml was scaffolded
 scribe sync --sessions       # mine all ccrider providers + direct Codex rollouts (when codex.mine is on)
-scribe sync --estimate       # token estimate for pending work (no LLM calls)
+scribe sync --dry-run --estimate  # token estimate for pending work (no writes or LLM calls)
 scribe sync --max-absorb N   # one-shot override of absorb.max_per_run from scribe.yaml
 scribe triage       # score unprocessed sessions by knowledge density
 scribe capture      # pull links you iMessaged to yourself as bookmarks (macOS only; needs Full Disk Access)
@@ -703,32 +743,80 @@ own sessions and repos; git is the merge layer.
 
 ### The recipe
 
+The complete prompt-compatible owner/member runbook is also available at
+**<https://getscribe.dev/setup.md>**. The important split is: one owner
+bootstraps with `--team`; every other member clones that exact repository and
+runs `init --bind --yes` inside it. Teammates do not each create a new team KB.
+
 1. **One member bootstraps the team KB** and pushes it to a private remote:
 
    ```sh
-   scribe init -p ~/team-kb --kb-name teamkb --team --allow ~/work
+   scribe init \
+     --path ~/team-kb \
+     --bind \
+     --kb-name teamkb \
+     --team \
+     --allow '~/work'
    cd ~/team-kb
+   scribe skill install
+   git add scribe.yaml .claude/skills .agents/skills
+   git commit -m "chore: add scribe agent skills"
    git remote add origin git@github.com:yourorg/team-kb.git
    git push -u origin main
    ```
 
    `--team` gitignores the per-machine manifest (see below) and prints these
-   setup steps. The `--allow` filter is committed in `scribe.yaml` and applies
-   to every member (`~` expands per-machine), so personal projects never leak
-   into the team repo.
+   setup steps. The quotes around `'~/work'` prevent the shell from replacing
+   `~` with the owner's absolute home path before it is committed. Scribe then
+   expands `~` separately on every member's machine. If checkout layouts differ,
+   add `sources.allowed_remotes: [github.com/yourorg]` to `scribe.yaml` before
+   the commit; origin identity is a stronger team boundary than a path alone.
 
-2. **Everyone else clones and points scribe at it** (per session or per cron job):
+2. **Everyone else clones and onboards their machine**:
+
+   If a member already has a personal KB and wants to keep it as the default
+   agent handshake, use the [second-KB profile](https://getscribe.dev/setup.md)
+   instead of `--bind`. Making the team KB the default is safe either way:
+   rebinding preserves the previous default as an explicit registry entry, so
+   the personal KB stays in the machine-level schedule (`scribe kb list`).
 
    ```sh
    git clone git@github.com:yourorg/team-kb.git ~/team-kb
-   SCRIBE_KB=~/team-kb scribe sync
+   cd ~/team-kb
+   git config user.name "Alice Example"
+   git config user.email "alice@example.com"
+
+   scribe init --bind --yes
+   scribe config diff
+   scribe config trust
+   scribe skill install --check
+   scribe sync --discover
+   scribe projects review
+   scribe sync --dry-run --estimate
+   scribe cron install
+   scribe doctor
    ```
 
-   The first sync rebuilds a fresh machine-local manifest, discovers that member's
-   projects (as `pending` — they approve with `scribe projects review`), and starts
-   extracting.
+   Do **not** pass `--path`, `--team`, `--kb-name`, `--allow`, or `--provider`
+   on member machines: those choices are already committed by the owner. The
+   member's `init --bind --yes` checks the existing clone and installs that
+   machine's default + Claude/Codex/Amp handshake. `config trust` explicitly accepts
+   the cloned sensitive config. Discovery rebuilds the gitignored machine-local
+   manifest, and nothing is extracted until that member approves projects.
 
-3. **That's the whole setup.** The pieces below make multi-writer work:
+3. **Shared versus per-member state**:
+
+   - **Same for everyone:** the private git remote and committed `scribe.yaml`
+     (`team`, KB name, domains, provider policy, shared source/remote filters,
+     secret gate). Change it once through git; each member reviews sensitive
+     drift with `scribe config diff` / `scribe config trust`.
+   - **Different on every machine:** `scripts/projects.json`, git identity,
+     credentials, capture handles, subscriptions, personal stop words, and extra
+     source exclusions. Put local KB overrides in gitignored
+     `scribe.local.yaml`; put hosted-provider keys and personal stop words in
+     `~/.config/scribe/config.yaml`.
+
+   The pieces below explain why multi-writer operation works:
 
    - `scripts/projects.json` is **gitignored** because it holds machine-local
      absolute paths, git SHAs, and approval decisions. Sharing it breaks when two
@@ -816,9 +904,15 @@ competing claims.
   others see the active claim after their pull and skip. Expired leases are
   stealable. Best-effort — with the remote unreachable, two machines may dream
   once concurrently, which only costs duplicate consolidation churn.
-- **`scribe cron install` manages one KB per machine** — the LaunchAgent labels
-  are fixed. Run your personal KB on cron and sync the team KB with a manual
-  cron line (`SCRIBE_KB=~/team-kb scribe sync`), or vice versa.
+- **One machine-level schedule serves every registered KB.** The macOS
+  LaunchAgents and generated Linux crontab lines run `scribe each` across
+  `scribe kb list`. Register secondary KBs explicitly with `scribe kb add`; on
+  macOS, `scribe cron install` also registers the current KB while installing
+  or refreshing the one KB-agnostic agent set. Use
+  `each.cadence` in an individual KB's `scribe.yaml` to pace it differently.
+  The global Claude/Codex/Amp handshake still points at one default KB at a time;
+  the [setup runbook](https://getscribe.dev/setup.md#a-second-kb-on-one-machine)
+  shows how to keep a personal default while registering a team KB.
 - **Concurrent edits to the same article can conflict** like any git repo. The
   append-heavy article layout keeps this rare; resolve by hand and re-run sync.
 - **Session transcripts never leave the machine.** Only the distilled wiki

--- a/cmd/scribe/skills/scribe-cli/SKILL.md
+++ b/cmd/scribe/skills/scribe-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scribe-cli
-description: Operate the scribe CLI to keep a knowledge-base pipeline healthy — diagnose with doctor/status, run sync/extraction, manage cron and Full Disk Access, and pick the right command for a maintenance goal. Use when the user wants to run scribe, asks which scribe command does X, says their KB is stale/empty or extraction/sync stopped, or is reading `scribe doctor`/`scribe status` output. For authoring KB content use scribe-kb; for the `scribe lint` content-quality queue use scribe-kb-tidy.
+description: Set up and operate the scribe CLI — install/init personal or team KBs, diagnose with doctor/status, run sync/extraction, manage cron and Full Disk Access, and pick the right command for a maintenance goal. Use when the user wants to install or run scribe, asks which scribe command or init/team flags to use, says their KB is stale/empty or extraction/sync stopped, or is reading `scribe doctor`/`scribe status` output. For authoring KB content use scribe-kb; for the `scribe lint` content-quality queue use scribe-kb-tidy.
 ---
 
 # scribe CLI — operations agent skill
@@ -15,6 +15,30 @@ Two sibling skills own the other halves and this skill routes to them:
 - **scribe-kb** — authoring/searching KB *content* (articles, drop files, qmd).
 - **scribe-kb-tidy** — working the `scribe lint` content-quality queue (split
   bloated, archive rolling, merge thin/self-named-dirs).
+
+## Installation or bootstrap requests
+
+For zero-to-running setup, read the public, prompt-compatible runbook first:
+<https://getscribe.dev/setup.md>. It has separate command sequences for a
+personal Anthropic KB, local Ollama, a hosted OpenAI-compatible provider, the
+team owner, each team member, a second KB on one machine, and Linux cron. Follow
+one profile rather than mixing flags.
+
+Key distinctions the short command map cannot express:
+
+- Fresh/default KBs use `scribe init --path <kb> --bind`; `--bind` is what
+  installs the machine-global Claude/Codex/Amp handshake.
+- Only the team owner uses `--team`, `--kb-name`, `--allow`, and `--provider`.
+  Members clone, `cd` into the checkout, then run `scribe init --bind --yes`.
+- Quote a shared tilde path (`--allow '~/work'`) so the shell does not commit the
+  owner's absolute home path.
+- Discover and approve sources before extraction: `scribe sync --discover`,
+  then `scribe projects review`.
+- The safe cost/scope preflight is `scribe sync --dry-run --estimate`. Ask before
+  the first real sync when it may spend tokens.
+- `scribe skill install` is post-bootstrap assistance. It does not install the
+  binary/dependencies, choose personal versus team mode, bind the handshake,
+  approve sources, install cron, or verify the provider.
 
 ## Golden rule: diagnose read-only before you act
 
@@ -51,7 +75,7 @@ blocks the real cron job. Everything else here is safe to run interactively.
 | See what's pending / backlog | `scribe status` |
 | Run the whole pipeline now | `scribe sync` (mind the lock rule) |
 | Just mine agent sessions | `scribe sync --sessions` |
-| Estimate token cost before syncing | `scribe sync --estimate` |
+| Estimate token cost before syncing | `scribe sync --dry-run --estimate` |
 | Score unprocessed sessions by value | `scribe triage` |
 | Enroll a repo for extraction | `scribe projects add <path>` |
 | Approve/ignore discovered repos | `scribe projects review` |
@@ -60,7 +84,7 @@ blocks the real cron job. Everything else here is safe to run interactively.
 | Work the lint content queue | → hand off to the **scribe-kb-tidy** skill |
 | Author/search KB content | → hand off to the **scribe-kb** skill |
 | Check LLM spend | `scribe cost` |
-| Install / check the background jobs | `scribe cron install` / `scribe cron status` |
+| Install / check the background jobs | `scribe cron install` / `scribe cron status` — on Linux, install prints a block to paste into `crontab -e` and status reports whether it landed |
 | Restore chat.db access (macOS) | `scribe fda` |
 
 The full command surface (every subcommand, grouped) is in
@@ -106,5 +130,7 @@ chat.db/FDA check), and verify the live binary first with `which scribe` and
 - `references/TROUBLESHOOT.md` — symptom → doctor section → fix, for the common
   failure modes (extraction stalled, cron off, FDA lost, ollama down, qmd not
   indexed, lint errors).
+- <https://getscribe.dev/setup.md> — zero-to-running personal/team setup and
+  verification, including the exact init flags.
 - The **scribe-kb** and **scribe-kb-tidy** skills (installed alongside) for
   content authoring and the lint content queue respectively.

--- a/cmd/scribe/skills/scribe-cli/references/COMMANDS.md
+++ b/cmd/scribe/skills/scribe-cli/references/COMMANDS.md
@@ -11,7 +11,7 @@ lock shared with cron — run one at a time, never backgrounded.
 |---|---|
 | `scribe sync` | **lock** — full pipeline: discover → extract → mine sessions → absorb → reindex → commit |
 | `scribe sync --sessions` | Mine all ccrider-indexed agent sessions, plus direct Codex rollouts when enabled |
-| `scribe sync --estimate` | Token estimate for pending work — no LLM calls |
+| `scribe sync --dry-run --estimate` | Token estimate for pending work — no writes or LLM calls |
 | `scribe sync --max-absorb N` | One-shot override of `absorb.max_per_run` |
 | `scribe status` | **read-only** — scoreboard: raw-by-density, absorb/contextualize progress, backlog, last sync, qmd/ollama health |
 | `scribe doctor` | **read-only** — health check: deps, config, localmode, convert, cron, state, freshness, errors, contradictions, stale, vault. Ends with the status scoreboard |
@@ -76,8 +76,11 @@ dir) that `scribe lint` flags but `--fix` can't repair → hand off to the
 
 | Command | What it does |
 |---|---|
-| `scribe init` | Scaffold a fresh KB (writes scribe.yaml, templates, agent handshake blocks) |
-| `scribe cron {install,status,uninstall}` | Manage the macOS LaunchAgents that run the pipeline |
+| `scribe init --path <kb> --bind` | Scaffold a fresh default KB and install the machine-global Claude/Codex/Amp handshake blocks |
+| `scribe init --team --path <kb> --bind` | Team owner only: scaffold a shared KB; members clone and run `scribe init --bind --yes` inside it |
+| `scribe cron install` | Install macOS LaunchAgents or print the Linux crontab block |
+| `scribe cron status` | Report macOS LaunchAgents or whether the Linux crontab block is installed |
+| `scribe cron uninstall` | Unload/remove macOS LaunchAgents; remove the block by hand with `crontab -e` on Linux |
 | `scribe fda` | macOS Full Disk Access probe + interactive grant (needed for chat.db capture) |
 | `scribe install-tools` | Bootstrap optional tools (uv + marker-pdf) for full PDF/DOCX/PPTX/XLSX/EPUB ingestion |
 | `scribe skill {install,list}` | Install/list the embedded agent skills (scribe-kb, scribe-kb-tidy, scribe-cli) |

--- a/cmd/scribe/skills/scribe-cli/references/TROUBLESHOOT.md
+++ b/cmd/scribe/skills/scribe-cli/references/TROUBLESHOOT.md
@@ -17,13 +17,15 @@ section with `scribe doctor --section <name>` when you're chasing one thing.
 ### "Nothing is being extracted / KB feels empty or stale"
 1. `scribe status` — look at `raw/articles` count, absorb/contextualize pending,
    and **last sync**. A stale/absent last-sync means the pipeline isn't running.
-2. `scribe doctor --section cron` — if the LaunchAgents aren't installed, the
-   daemon never runs. Fix: `scribe cron install`, then `scribe cron status`.
+2. Check scheduling — `scribe doctor --section cron`, then `scribe cron status`.
+   Both report macOS LaunchAgents or the Linux crontab block. Fix with
+   `scribe cron install` (on Linux it prints the block to paste into
+   `crontab -e`; confirm with `crontab -l`).
 3. `scribe doctor --section freshness` — flags when the last run is older than
    expected (reads `output/runs/*.jsonl`).
 4. If cron is healthy but backlog is high, run one pipeline pass by hand:
    `scribe sync` (respect the lock rule — one at a time, never backgrounded).
-   Preview first with `scribe sync --estimate`.
+   Preview first with `scribe sync --dry-run --estimate`.
 
 ### "Sessions aren't being mined"
 - `scribe triage` (read-only) shows unprocessed sessions scored by density. If

--- a/install.sh
+++ b/install.sh
@@ -164,8 +164,8 @@ main() {
     esac
 
     echo
-    echo "Next: scribe init --path ~/my-kb"
-    echo "See README for cron + Full Disk Access (macOS) details."
+    echo "Next: scribe init --path ~/my-kb --bind"
+    echo "Setup recipes (personal, Ollama, hosted, teams): https://getscribe.dev/setup.md"
 }
 
 main

--- a/site/public/_headers
+++ b/site/public/_headers
@@ -34,5 +34,8 @@
 /llms-full.txt
   Cache-Control: public, max-age=3600
 
+/setup.md
+  Cache-Control: public, max-age=3600
+
 /index.md
   Cache-Control: public, max-age=3600

--- a/site/public/index.html
+++ b/site/public/index.html
@@ -97,8 +97,14 @@
     {
       "@type": "HowToStep",
       "name": "Bootstrap a knowledge base",
-      "text": "Scaffold a KB and wire the agent handshake into ~/.claude/CLAUDE.md, ~/.codex/AGENTS.md, and ~/.config/amp/AGENTS.md: scribe init --path ~/my-kb",
+      "text": "Scaffold a KB and wire the agent handshake into ~/.claude/CLAUDE.md, ~/.codex/AGENTS.md, and ~/.config/amp/AGENTS.md: scribe init --path ~/my-kb --bind",
       "url": "https://getscribe.dev/#install"
+    },
+    {
+      "@type": "HowToStep",
+      "name": "Install skills and approve sources",
+      "text": "Install the agent skills, discover candidate repositories, and approve only the intended sources: cd ~/my-kb; scribe skill install; scribe sync --discover; scribe projects review",
+      "url": "https://getscribe.dev/setup.md"
     },
     {
       "@type": "HowToStep",
@@ -1474,6 +1480,11 @@
     color: var(--fg);
     overflow-x: auto;
     white-space: pre;
+  }
+  .code-panel pre.agent-prompt {
+    max-width: 82ch;
+    padding-right: 72px;
+    white-space: pre-wrap;
   }
   .code-panel .comment { color: var(--muted-2); }
   .code-panel .kw { color: var(--accent); font-weight: 500; }
@@ -3034,6 +3045,7 @@ advisory locks table-ambiguous under load.
       <div class="s__eyebrow">For teams</div>
       <h2 class="s__title">One KB. The whole team writes to it.</h2>
       <p class="s__sub">scribe is single-user by default and stays that way. But a small team on the same codebases can point every machine at one git-backed KB. The obvious fear with sharing agent sessions — a leaked secret, a private client repo, one teammate's config change reaching everyone — is exactly what the gates below are built to stop. Only knowledge you meant to keep crosses into the shared KB.</p>
+      <p class="s__sub"><a href="/setup.md">Run the exact team-owner and team-member setup commands →</a></p>
     </header>
 
     <figure class="video-embed video-embed--teams">
@@ -3331,7 +3343,7 @@ scribe cost — last 7 days — 2 KBs (personal-kb, team-kb)
       <summary>The full surface &mdash; everything scribe does</summary>
       <dl class="surface__grid">
         <dt>Capture</dt><dd>git repos &middot; coding-agent sessions (ccrider FTS5) &middot; direct Codex rollouts &middot; iMessage self-chat &middot; drop files &middot; URL ingest</dd>
-        <dt>Triage</dt><dd>FTS5 keyword-density gate &middot; zero-LLM reject &middot; <code>sync --estimate</code> token preview</dd>
+        <dt>Triage</dt><dd>FTS5 keyword-density gate &middot; zero-LLM reject &middot; <code>sync --dry-run --estimate</code> token preview</dd>
         <dt>Extract</dt><dd>two-pass absorb &middot; entity-first fan-out &middot; retrieval-context splicing &middot; <code>deep</code> / <code>assess</code> batch passes</dd>
         <dt>Graph</dt><dd>closed 10-kind typed-edge schema &middot; <code>_backlinks.json</code> &middot; orphan linking &middot; qmd BM25 + vector index</dd>
         <dt>Hygiene</dt><dd>frontmatter validate &middot; structural lint &middot; staleness ledger &middot; contradiction ledger &middot; Dream 4-phase consolidation</dd>
@@ -3349,12 +3361,13 @@ scribe cost — last 7 days — 2 KBs (personal-kb, team-kb)
     <header class="s__head">
       <div class="s__eyebrow">CLI</div>
       <h2 class="s__title">Set it up once. Forget it.</h2>
-      <p class="s__sub">Two commands to install. One <code>llm</code> block in <code>scribe.yaml</code> routes the whole pipeline local, hosted, or Anthropic. One query from any terminal.</p>
+      <p class="s__sub">One guided init, then explicit source approval and verification. The <a href="/setup.md">setup runbook</a> has copyable personal, Ollama, hosted-provider, team-owner, and team-member recipes. One <code>llm</code> block in <code>scribe.yaml</code> routes the whole pipeline local, hosted, or Anthropic.</p>
     </header>
 
     <div class="code-card">
       <div class="code-tabs" role="tablist" id="tabs">
         <button class="code-tab" role="tab" data-tab="install" aria-selected="true" aria-controls="panel-install" id="tab-install" tabindex="0">install</button>
+        <button class="code-tab" role="tab" data-tab="agent" aria-selected="false" aria-controls="panel-agent" id="tab-agent" tabindex="-1">install with agent</button>
         <button class="code-tab" role="tab" data-tab="local" aria-selected="false" aria-controls="panel-local" id="tab-local" tabindex="-1">scribe.yaml · local</button>
         <button class="code-tab" role="tab" data-tab="hosted" aria-selected="false" aria-controls="panel-hosted" id="tab-hosted" tabindex="-1">scribe.yaml · hosted</button>
         <button class="code-tab" role="tab" data-tab="anthropic" aria-selected="false" aria-controls="panel-anthropic" id="tab-anthropic" tabindex="-1">scribe.yaml · Anthropic</button>
@@ -3369,13 +3382,28 @@ brew tap oliver-kriska/scribe
 brew install oliver-kriska/scribe/scribe
 
 <span class="comment"># one-time setup</span>
-scribe init <span class="flag">--path</span> <span class="str">~/my-kb</span>
+scribe init <span class="flag">--path</span> <span class="str">~/my-kb</span> <span class="flag">--bind</span>
 <span class="kw">cd</span> ~/my-kb
+scribe skill install
+scribe sync <span class="flag">--discover</span>
+scribe projects review
+scribe sync <span class="flag">--dry-run --estimate</span>
 scribe cron install
 scribe doctor
 
 <span class="comment"># or via shell installer</span>
 curl <span class="flag">-fsSL</span> <span class="str">https://raw.githubusercontent.com/oliver-kriska/scribe/main/install.sh</span> | bash</pre>
+      </div>
+
+      <div class="code-panel" data-tab="agent" id="panel-agent" role="tabpanel" aria-labelledby="tab-agent" tabindex="0">
+        <button class="copy-btn" data-copy-target="code-agent" aria-label="Copy coding-agent setup prompt">copy prompt</button>
+<pre id="code-agent" class="agent-prompt">Read https://getscribe.dev/setup.md and set up scribe on this machine.
+Before changing anything, ask me for the setup profile, KB path, and LLM provider.
+For a team setup, also ask whether I am creating or joining the KB and ask for the private git remote.
+Inspect existing state before changing it. Execute the applicable steps; do not only explain them.
+Never use --force. Never print or commit secrets.
+Ask before the first real scribe sync because it may call an LLM and incur cost.
+Finish with the runbook's verification checklist and report what passed and what still needs human action.</pre>
       </div>
 
       <div class="code-panel" data-tab="local" id="panel-local" role="tabpanel" aria-labelledby="tab-local" tabindex="0">
@@ -3537,10 +3565,10 @@ scribe doctor <span class="flag">--section</span> localmode
           </div>
           <div class="terminal__title">~/kb — scribe</div>
         </div>
-        <pre class="commands__lines"><code><span class="cmd-prompt">$</span> <span class="cmd-name">scribe init</span>                        <span class="cmd-cmt"># bootstrap a KB, wire the agent handshake</span>
+        <pre class="commands__lines"><code><span class="cmd-prompt">$</span> <span class="cmd-name">scribe init --bind</span>                 <span class="cmd-cmt"># bootstrap a KB, wire the agent handshake</span>
 <span class="cmd-prompt">$</span> <span class="cmd-name">scribe sync</span>                        <span class="cmd-cmt"># discover → extract → absorb → reindex</span>
 <span class="cmd-prompt">$</span> <span class="cmd-name">scribe sync</span> <span class="cmd-arg">--sessions</span>             <span class="cmd-cmt"># mine coding-agent transcripts</span>
-<span class="cmd-prompt">$</span> <span class="cmd-name">scribe sync</span> <span class="cmd-arg">--estimate</span>             <span class="cmd-cmt"># token estimate, zero LLM calls</span>
+<span class="cmd-prompt">$</span> <span class="cmd-name">scribe sync</span> <span class="cmd-arg">--dry-run --estimate</span>   <span class="cmd-cmt"># token estimate, no writes or LLM calls</span>
 <span class="cmd-prompt">$</span> <span class="cmd-name">scribe doctor</span>                      <span class="cmd-cmt"># validate setup, cron, git remote, Ollama</span>
 <span class="cmd-prompt">$</span> <span class="cmd-name">scribe commit</span>                      <span class="cmd-cmt"># stage + push the KB to your private remote</span>
 <span class="cmd-prompt">$</span> <span class="cmd-name">scribe dream</span>                       <span class="cmd-cmt"># weekly consolidation (Ollama-driven)</span>
@@ -3684,14 +3712,11 @@ scribe doctor <span class="flag">--section</span> localmode
 <!-- ============================ CTA END ============================ -->
 <section class="s cta-end" id="install">
   <div class="wrap">
-    <h2>Install in 60 seconds.</h2>
-    <p>One <code>brew install</code>, one <code>scribe init</code>, and your tools start writing the notes for you.</p>
+    <h2>Install, approve sources, verify.</h2>
+    <p>Use the personal, local Ollama, hosted-provider, or team recipe. The same runbook can be pasted into Claude Code or Codex so it performs the setup and proves what works.</p>
     <div class="cta-end__buttons">
-      <a class="btn btn--accent" href="https://github.com/oliver-kriska/scribe">
-        <svg viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8a8 8 0 0 0 5.47 7.59c.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
-        Get scribe on GitHub
-      </a>
-      <a class="btn btn--ghost" href="#cli">Read the CLI →</a>
+      <a class="btn btn--accent" href="/setup.md">Open the setup runbook</a>
+      <a class="btn btn--ghost" href="https://github.com/oliver-kriska/scribe">View source on GitHub →</a>
     </div>
   </div>
 </section>
@@ -3718,7 +3743,7 @@ scribe doctor <span class="flag">--section</span> localmode
       <div class="footer__col">
         <h4>Resources</h4>
         <a href="https://github.com/oliver-kriska/scribe">GitHub repo</a>
-        <a href="https://github.com/oliver-kriska/scribe#install">Install guide</a>
+        <a href="/setup.md">Setup runbook</a>
         <a href="https://github.com/oliver-kriska/scribe/issues">Issues</a>
         <a href="#faq">FAQ</a>
       </div>
@@ -3981,7 +4006,7 @@ scribe doctor <span class="flag">--section</span> localmode
 
   const SCENES = [
     {
-      cmd: 'scribe init --path ~/my-kb',
+      cmd: 'scribe init --path ~/my-kb --bind',
       out: [
         '<span class="out-key">→</span> creating ~/my-kb/scribe.yaml',
         '<span class="out-key">→</span> writing handshake into ~/.claude/CLAUDE.md',

--- a/site/public/index.md
+++ b/site/public/index.md
@@ -88,6 +88,8 @@ Deeper differentiators against the broader memory-tool landscape:
 
 scribe is single-user by default and stays that way. But a small team on the same codebases can point every machine at one git-backed KB: clone the repo, and scribe rebuilds local state from what's committed. The obvious fear with sharing agent sessions — a leaked secret, a private client repo, one teammate's config change reaching everyone — is exactly what the gates below are built to stop. **Only knowledge you meant to keep crosses into the shared KB; every gate here is a mechanism in the code, not a policy in a doc.**
 
+**Exact commands:** the [setup runbook](https://getscribe.dev/setup.md) separates the one team owner who creates and publishes the KB from the commands every member runs after cloning it.
+
 The trust boundary, concretely — what tries to cross into the shared KB and what stops it:
 
 - An **AWS key in a session transcript** → the **secret-scan gate** → held back, never committed.
@@ -202,10 +204,10 @@ qmd query "how did I solve the oban idempotency bug last quarter"
 78 command paths, one binary. The ones you'll actually type:
 
 ```
-scribe init                 # bootstrap a KB, wire the agent handshake
+scribe init --bind          # bootstrap a KB, wire the agent handshake
 scribe sync                 # discover → extract → absorb → reindex
 scribe sync --sessions      # mine coding-agent transcripts
-scribe sync --estimate      # token estimate, zero LLM calls
+scribe sync --dry-run --estimate  # token estimate, no writes or LLM calls
 scribe doctor               # validate setup, cron, git remote, Ollama
 scribe commit               # stage + push the KB to your private remote
 scribe dream                # weekly consolidation (Ollama-driven)
@@ -241,14 +243,38 @@ The loop closes here: every absorb tick reindexes `qmd`; the next Claude Code, C
 
 ## Install
 
+For personal Anthropic, local Ollama, hosted-provider, team-owner, team-member,
+second-KB, and Linux recipes — plus a prompt that lets Claude Code or Codex
+perform and verify the setup — use <https://getscribe.dev/setup.md>.
+
 ```sh
 brew tap oliver-kriska/scribe
 brew install oliver-kriska/scribe/scribe
-scribe init --path ~/my-kb
+scribe init --path ~/my-kb --bind
 cd ~/my-kb
+scribe skill install
+scribe sync --discover
+scribe projects review
+scribe sync --dry-run --estimate
 scribe cron install
 scribe doctor
 ```
+
+### Install with Claude Code or Codex
+
+Paste this prompt into your coding agent:
+
+> Read https://getscribe.dev/setup.md and set up scribe on this machine.
+> Before changing anything, ask me for the setup profile, KB path, and LLM provider.
+> For a team setup, also ask whether I am creating or joining the KB and ask for the private git remote.
+> Inspect existing state before changing it. Execute the applicable steps; do not only explain them.
+> Never use --force. Never print or commit secrets.
+> Ask before the first real scribe sync because it may call an LLM and incur cost.
+> Finish with the runbook's verification checklist and report what passed and what still needs human action.
+
+The complete runbook tells the agent which actions still require a human, such
+as provider sign-in, private-repository creation, API-key entry, macOS Full Disk
+Access, and saving Linux crontab entries.
 
 Or via shell installer: `curl -fsSL https://raw.githubusercontent.com/oliver-kriska/scribe/main/install.sh | bash`
 

--- a/site/public/llms-full.txt
+++ b/site/public/llms-full.txt
@@ -88,6 +88,8 @@ Deeper differentiators against the broader memory-tool landscape:
 
 scribe is single-user by default and stays that way. But a small team on the same codebases can point every machine at one git-backed KB: clone the repo, and scribe rebuilds local state from what's committed. The obvious fear with sharing agent sessions — a leaked secret, a private client repo, one teammate's config change reaching everyone — is exactly what the gates below are built to stop. **Only knowledge you meant to keep crosses into the shared KB; every gate here is a mechanism in the code, not a policy in a doc.**
 
+**Exact commands:** the [setup runbook](https://getscribe.dev/setup.md) separates the one team owner who creates and publishes the KB from the commands every member runs after cloning it.
+
 The trust boundary, concretely — what tries to cross into the shared KB and what stops it:
 
 - An **AWS key in a session transcript** → the **secret-scan gate** → held back, never committed.
@@ -202,10 +204,10 @@ qmd query "how did I solve the oban idempotency bug last quarter"
 78 command paths, one binary. The ones you'll actually type:
 
 ```
-scribe init                 # bootstrap a KB, wire the agent handshake
+scribe init --bind          # bootstrap a KB, wire the agent handshake
 scribe sync                 # discover → extract → absorb → reindex
 scribe sync --sessions      # mine coding-agent transcripts
-scribe sync --estimate      # token estimate, zero LLM calls
+scribe sync --dry-run --estimate  # token estimate, no writes or LLM calls
 scribe doctor               # validate setup, cron, git remote, Ollama
 scribe commit               # stage + push the KB to your private remote
 scribe dream                # weekly consolidation (Ollama-driven)
@@ -241,14 +243,38 @@ The loop closes here: every absorb tick reindexes `qmd`; the next Claude Code, C
 
 ## Install
 
+For personal Anthropic, local Ollama, hosted-provider, team-owner, team-member,
+second-KB, and Linux recipes — plus a prompt that lets Claude Code or Codex
+perform and verify the setup — use <https://getscribe.dev/setup.md>.
+
 ```sh
 brew tap oliver-kriska/scribe
 brew install oliver-kriska/scribe/scribe
-scribe init --path ~/my-kb
+scribe init --path ~/my-kb --bind
 cd ~/my-kb
+scribe skill install
+scribe sync --discover
+scribe projects review
+scribe sync --dry-run --estimate
 scribe cron install
 scribe doctor
 ```
+
+### Install with Claude Code or Codex
+
+Paste this prompt into your coding agent:
+
+> Read https://getscribe.dev/setup.md and set up scribe on this machine.
+> Before changing anything, ask me for the setup profile, KB path, and LLM provider.
+> For a team setup, also ask whether I am creating or joining the KB and ask for the private git remote.
+> Inspect existing state before changing it. Execute the applicable steps; do not only explain them.
+> Never use --force. Never print or commit secrets.
+> Ask before the first real scribe sync because it may call an LLM and incur cost.
+> Finish with the runbook's verification checklist and report what passed and what still needs human action.
+
+The complete runbook tells the agent which actions still require a human, such
+as provider sign-in, private-repository creation, API-key entry, macOS Full Disk
+Access, and saving Linux crontab entries.
 
 Or via shell installer: `curl -fsSL https://raw.githubusercontent.com/oliver-kriska/scribe/main/install.sh | bash`
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -17,6 +17,7 @@ The product is the curated wiki, not raw chunks. Every dense source fans out int
 ## Resources
 
 - [Marketing site](https://getscribe.dev/): overview, features, install, comparison table
+- [Setup runbook](https://getscribe.dev/setup.md): prompt-compatible personal, Ollama, hosted-provider, team-owner, team-member, second-KB, Linux cron, and verification recipes
 - [Marketing site as markdown](https://getscribe.dev/index.md): same content, plain text
 - [Full content concatenated](https://getscribe.dev/llms-full.txt): everything in one file for large-context LLMs, including both explainer-video transcripts
 - [Explainer video, 60s](https://assets.getscribe.dev/scribe-explainer.mp4): the whole pitch — scribe reads your git history, Claude Code/Codex sessions, and saved links, and writes a plain-markdown KB your agents read before they act; local, cron-driven, not RAG (full transcript in llms-full.txt; also on YouTube: https://youtu.be/f2jV9PnzRzI)

--- a/site/public/setup.md
+++ b/site/public/setup.md
@@ -1,0 +1,492 @@
+# Set up scribe — human and coding-agent runbook
+
+This is the zero-to-running setup guide for scribe. It is deliberately
+procedural: choose one recipe, run the commands in order, and finish with the
+verification checklist. It covers personal Anthropic, local Ollama, hosted
+providers, team owners and members, multiple KBs, and Linux scheduling.
+
+Public URL: <https://getscribe.dev/setup.md>
+
+## Give this guide to Claude Code, Codex, or another coding agent
+
+Paste this prompt:
+
+> Read https://getscribe.dev/setup.md and set up scribe on this machine.
+> Before changing anything, ask me for the setup profile, KB path, and LLM provider.
+> For a team setup, also ask whether I am creating or joining the KB and ask for the private git remote.
+> Inspect existing state before changing it. Execute the applicable steps; do not only explain them.
+> Never use --force. Never print or commit secrets.
+> Ask before the first real scribe sync because it may call an LLM and incur cost.
+> Finish with the runbook's verification checklist and report what passed and what still needs human action.
+
+The agent should stop and ask the human for actions it cannot safely perform,
+such as signing into Claude, creating a private git repository, granting macOS
+Full Disk Access, adding a hosted-provider API key, or installing Linux crontab
+entries.
+
+## Choose one profile
+
+| Goal | Recipe |
+|---|---|
+| Your first personal KB, Anthropic-backed | [Personal KB](#personal-kb) with `--provider anthropic` |
+| Your first personal KB, no API spend | [Personal KB](#personal-kb) with `--provider ollama` |
+| Use Together, Groq, Fireworks, Hugging Face, or another `/v1` endpoint | [Hosted provider](#hosted-openai-compatible-provider) |
+| Create and publish a KB for a team | [Team owner](#team-owner-create-and-publish) |
+| Join an existing team KB | [Team member](#team-member-clone-and-onboard) |
+| Add a team KB while keeping a personal KB as default | [A second KB on one machine](#a-second-kb-on-one-machine) |
+| Linux scheduling | Use the same recipe, then follow [Linux cron](#linux-cron) |
+
+## Before changing anything
+
+An agent should inspect, not guess:
+
+```sh
+uname -s
+command -v scribe || true
+command -v git || true
+command -v sqlite3 || true
+command -v ccrider || true
+command -v qmd || true
+command -v claude || true
+command -v ollama || true
+scribe --version 2>/dev/null || true
+```
+
+If the intended KB directory already contains `scribe.yaml`, treat it as an
+existing KB. Do not run a fresh `scribe init --path …` over it and do not use
+`--force`. For an existing checkout, `cd` into it and run `scribe init --check --yes`
+or the team-member recipe below.
+
+Do not paste API keys into a prompt, command history, committed `scribe.yaml`,
+or a team repository. Hosted-provider keys belong in the per-machine
+`~/.config/scribe/config.yaml` (mode `0600`) or an environment variable.
+
+## Install the CLI and required tools
+
+### Homebrew (macOS or Linuxbrew)
+
+```sh
+brew tap oliver-kriska/scribe
+brew install oliver-kriska/scribe/scribe
+```
+
+The formula installs `git`, `sqlite`, and `ccrider`. Install the remaining
+required tools:
+
+```sh
+curl -fsSL https://claude.ai/install.sh | bash
+npm install -g @tobilu/qmd
+```
+
+Use `claude` once and complete its normal sign-in when the Anthropic provider
+will be used. The Ollama profile does not spend Anthropic tokens, but the
+current dependency check still expects the Claude CLI to be present.
+
+For fully local inference, also install and start Ollama:
+
+```sh
+brew install ollama
+ollama serve
+```
+
+On macOS the Ollama app/service may already be running; do not start a second
+server if `ollama list` works. When it is not running, start `ollama serve` in a
+dedicated terminal or OS service; a setup agent should not leave an
+uncontrolled foreground server attached to its command session.
+
+### Shell installer
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/oliver-kriska/scribe/main/install.sh | bash
+```
+
+The binary lands in `$HOME/.local/bin` by default. Ensure that directory is on
+`PATH`, then install `git`, `sqlite3`, `ccrider`, `qmd`, and the selected LLM
+provider using their upstream instructions. Check the result:
+
+```sh
+scribe --version
+```
+
+## Personal KB
+
+Set the target once so later commands are copy-safe:
+
+```sh
+KB="$HOME/my-kb"
+```
+
+### Anthropic
+
+```sh
+scribe init --path "$KB" --bind --provider anthropic
+```
+
+### Local Ollama
+
+```sh
+scribe init --path "$KB" --bind --provider ollama
+```
+
+`--bind` matters: it makes this KB the machine default and installs the scribe
+handshake into `~/.claude/CLAUDE.md`, `~/.codex/AGENTS.md`, and
+`~/.config/amp/AGENTS.md`. Without it,
+init may deliberately leave machine-global state untouched, especially when
+another KB is already configured.
+
+Continue with either provider:
+
+```sh
+cd "$KB"
+scribe skill install
+scribe sync --discover
+scribe projects review
+scribe sync --dry-run --estimate
+scribe cron install
+scribe doctor
+```
+
+What these steps do:
+
+1. `scribe skill install` adds the operational agent skills inside the KB. It
+   does not replace install/init; it is useful after the binary and KB exist.
+2. `sync --discover` records candidate repositories without extracting them.
+3. `projects review` is the consent gate. Approve only repositories this KB is
+   allowed to read.
+4. `sync --dry-run --estimate` previews pending work without writes or LLM
+   calls. A real `scribe sync` can spend tokens; run it only after reviewing the
+   estimate.
+5. `cron install` installs macOS LaunchAgents or prints Linux crontab entries.
+6. `doctor` checks dependencies, configuration, scheduling, qmd, and local
+   Ollama health when selected. A new empty KB can have freshness warnings;
+   hard failures must be fixed.
+
+Optional: add a private git remote so the markdown KB is backed up:
+
+```sh
+git -C "$KB" remote add origin git@github.com:you/my-kb.git
+git -C "$KB" push -u origin main
+```
+
+### Non-interactive personal init
+
+Supply every value that should not use a default:
+
+```sh
+scribe init \
+  --path "$KB" \
+  --bind \
+  --provider anthropic \
+  --owner-name "Alice" \
+  --owner-context "Platform engineer working on the API and infrastructure." \
+  --domains platform,infra \
+  --yes
+```
+
+Use `--provider ollama` for local mode. Omit `--handle` to leave optional
+iMessage capture disabled.
+
+## Hosted OpenAI-compatible provider
+
+The init flag accepts `anthropic` or `ollama`; hosted routing is configured
+after scaffolding. A personal user starts with the Anthropic personal recipe
+above. A team owner starts with the team-owner recipe below. In either case,
+replace the generated top-level `llm:` block with the chosen provider's real
+model and endpoint policy before publishing the configuration. Example:
+
+```yaml
+llm:
+  provider: together
+  model: MiniMaxAI/MiniMax-M3
+  api_key_env: TOGETHER_API_KEY
+  pricing:
+    "together/MiniMaxAI/MiniMax-M3":
+      input: 0.30
+      output: 1.20
+```
+
+Named providers (`together`, `groq`, `fireworks`, `huggingface`) have built-in
+base URLs. Use `provider: openai-compat` plus `base_url` for another compatible
+`/v1/chat/completions` endpoint. Confirm the exact serverless model ID and
+current pricing with the provider; catalog names and rates change.
+
+The key must stay outside the KB. Have the human place it in an environment
+variable or add `llm_api_key` / provider-specific `llm_api_keys` to
+`~/.config/scribe/config.yaml`, then restrict the file:
+
+```sh
+chmod 600 ~/.config/scribe/config.yaml
+scribe doctor
+scribe sync --dry-run --estimate
+```
+
+`doctor` validates the parsed routing and budget configuration but does not
+send a hosted-provider probe. The endpoint, key, and model are fully validated
+only by an approved real LLM call, which can incur cost. The final sync in this
+guide is that end-to-end check.
+
+For a team KB, the routing block is shared and trust-locked, but every member
+supplies their own key locally. Never commit a key to `scribe.yaml` or ask a
+member to paste one into an agent prompt.
+
+## Team owner: create and publish
+
+One person creates the KB. Everyone else clones it; teammates must **not** run
+`scribe init --team --path …` independently.
+
+Before init, choose a checkout convention shared by the team. The example uses
+`~/work`; the quotes are important because they preserve `~` in committed
+`scribe.yaml`, allowing scribe to expand it separately on every machine.
+
+```sh
+KB="$HOME/team-kb"
+
+scribe init \
+  --path "$KB" \
+  --bind \
+  --team \
+  --kb-name acme-kb \
+  --allow '~/work' \
+  --provider anthropic
+
+cd "$KB"
+scribe skill install
+```
+
+Use `--provider ollama` only if every participating machine will run the chosen
+Ollama model. If teammates keep repositories in different directory layouts,
+prefer a git-identity allowlist. Before pushing, edit the generated
+`scribe.yaml`:
+
+```yaml
+sources:
+  include:
+    - ~/work
+  allowed_remotes:
+    - github.com/acme
+```
+
+`allowed_remotes` rejects repositories without a matching `origin`, regardless
+of checkout location. Keep personal/client repositories out with shared
+`sources.exclude` rules or stricter per-person rules in the gitignored
+`scribe.local.yaml`.
+
+Init creates the scaffold commit before skills or later config edits, so commit
+those additions and publish the private repository:
+
+```sh
+git add scribe.yaml .claude/skills .agents/skills
+git commit -m "chore: configure team KB"
+git remote add origin git@github.com:acme/team-kb.git
+git push -u origin main
+```
+
+Then onboard the owner's machine like any other member:
+
+```sh
+scribe config trust
+scribe sync --discover
+scribe projects review
+scribe sync --dry-run --estimate
+scribe cron install
+scribe doctor
+```
+
+Do not place a personal iMessage handle, API key, personal source path, or NDA
+stop word in committed `scribe.yaml`. Put per-person values in
+`scribe.local.yaml` or `~/.config/scribe/config.yaml`.
+
+## Team member: clone and onboard
+
+Every member installs the CLI and dependencies first. Use the same scribe
+release and LLM provider policy as the rest of the team, then:
+
+If this machine already has a personal KB and it should remain the default
+agent handshake, follow [A second KB on one machine](#a-second-kb-on-one-machine)
+instead of running `--bind`. If the team KB should become the default, the bind
+below changes the global handshake, but the previous personal KB is preserved as
+an explicit registry entry so it stays in the machine-level schedule.
+
+```sh
+KB="$HOME/team-kb"
+
+git clone git@github.com:acme/team-kb.git "$KB"
+cd "$KB"
+
+git config user.name "Alice Example"
+git config user.email "alice@example.com"
+
+scribe init --bind --yes
+scribe config diff
+scribe config trust
+scribe skill install --check
+scribe sync --discover
+scribe projects review
+scribe sync --dry-run --estimate
+scribe cron install
+scribe doctor
+```
+
+The member command is `scribe init --bind --yes` **inside the clone**. Do not
+pass `--path`, `--team`, `--kb-name`, `--allow`, or `--provider`: those are
+team-owner choices already committed in `scribe.yaml`. This init invocation
+checks the checkout and installs that member's machine-local default and agent
+handshakes without recreating the KB.
+
+`scribe config diff` shows the trust boundary; `scribe config trust` explicitly
+accepts the cloned sensitive settings on that machine. `skill install --check`
+ensures the committed skills match the member's binary. If it reports drift,
+coordinate one skill update through the shared repository instead of having
+every member create competing updates.
+
+Each member has their own gitignored `scripts/projects.json`, so each must run
+discovery and approve repositories. Those approvals and absolute paths are not
+shared. The shared commands/flags live in committed `scribe.yaml`; the local
+manifest, credentials, subscriptions, capture handles, and additional source
+filters remain per-machine.
+
+## A second KB on one machine
+
+The scheduler supports multiple registered KBs, but the global Claude/Codex/Amp
+handshake and `kb_dir` default point to one KB at a time.
+
+To keep an existing personal KB as the default while adding a team KB:
+
+```sh
+KB="$HOME/team-kb"
+git clone git@github.com:acme/team-kb.git "$KB"
+cd "$KB"
+
+scribe init --check --yes
+scribe config trust
+scribe kb add "$KB"
+scribe cron install
+scribe doctor
+```
+
+Do not use `--bind` in this profile: it would repoint the one global handshake.
+Target the team KB by running inside it or explicitly:
+
+```sh
+scribe -C "$KB" status
+scribe -C "$KB" sync --dry-run --estimate
+```
+
+To intentionally make the team KB the new default, bind the team checkout.
+Rebinding preserves the previous default as an explicit registry entry, so the
+personal KB keeps its place in the machine-level schedule; `scribe kb list`
+confirms it:
+
+```sh
+cd "$KB"
+scribe init --bind --yes
+scribe kb list
+```
+
+One KB-agnostic LaunchAgent set runs `scribe each` across the registry; a
+second KB does not require a second set of plists. Configure per-KB pacing with
+`each.cadence` in that KB's `scribe.yaml` if needed.
+
+## Linux cron
+
+On Linux, `scribe cron install` prints crontab lines instead of installing
+them. Review the output, paste the block into `crontab -e`, then verify:
+
+```sh
+crontab -l
+scribe cron status
+scribe kb list
+```
+
+`scribe cron status` reports whether the scribe block is actually present in the
+user crontab. Do not claim scheduling is installed merely because scribe printed
+the block; the user must actually save it.
+
+## Optional macOS iMessage capture
+
+Personal KB: add the self-chat handle during interactive init or later in
+`scribe.yaml`. Team KB: place it only in the gitignored `scribe.local.yaml`.
+Then grant Full Disk Access to the exact scribe binary:
+
+```sh
+scribe fda
+scribe fda --verify
+```
+
+Official macOS release binaries are Developer ID signed and notarized, so a
+signed replacement at the same registered path keeps the grant. Homebrew moves
+the raw executable to a new versioned Cellar path, which TCC records separately,
+and an unsigned local `make install` changes the code identity. Re-run
+`scribe fda` after `brew upgrade` or an unsigned rebuild to verify and re-grant.
+
+## Verification checklist
+
+Use `-C` so every check names the intended KB explicitly:
+
+```sh
+scribe --version
+scribe -C "$KB" init --check --yes
+scribe -C "$KB" doctor
+scribe kb list
+scribe -C "$KB" projects list
+scribe -C "$KB" sync --dry-run --estimate
+scribe -C "$KB" skill install --check
+git -C "$KB" status --short
+```
+
+`init --check` is read-only and non-interactive on its own; `--yes` is harmless
+belt-and-braces on older releases. Verify scheduling — `cron status` covers both
+platforms (LaunchAgents on macOS, the crontab block on Linux):
+
+```sh
+scribe cron status
+
+# Linux, to see the block itself
+crontab -l
+```
+
+For a team KB, also run:
+
+```sh
+scribe -C "$KB" config diff
+git -C "$KB" remote -v
+```
+
+Setup is complete when:
+
+- `scribe` resolves to the expected binary and reports a version.
+- `init --check --yes` finds the intended KB without prompts or writes.
+- `doctor` has no unexplained hard failures; qmd is healthy, and Ollama is
+  reachable with the chosen local model when that provider is selected.
+- The KB appears in `scribe kb list`, and cron is installed (or its Linux block
+  has actually been added).
+- Only intended repositories are approved.
+- The dry-run estimate is plausible before any paid sync.
+- Agent skills match, and team config has no unreviewed drift.
+- The KB git remote is private and the worktree contains no accidental secret
+  or machine-local file.
+
+For a hosted provider, the checklist proves local configuration but deliberately
+does not spend tokens on a probe. A successful first real sync below is the
+endpoint/key/model verification.
+
+Only then, and with the user's approval when inference may cost money, run the
+first real pipeline pass:
+
+```sh
+scribe -C "$KB" sync
+```
+
+## What `init`, the handshake, and skills each do
+
+- `scribe init --bind` creates or checks the KB **and** wires the one
+  machine-global Claude Code/Codex/Amp handshake. That handshake makes agents in
+  other project directories query the KB and write reusable drop files.
+- `scribe skill install` writes `scribe-kb`, `scribe-kb-tidy`, and `scribe-cli`
+  into the KB's agent-skill directories. Those skills help an agent operate and
+  maintain an existing KB when a session is opened where the skills are
+  discoverable.
+- Therefore the skills command is useful, but it is not a bootstrap mechanism:
+  it requires an installed binary and a KB, does not install dependencies, does
+  not choose personal versus team mode, and does not replace `init --bind`,
+  source approval, cron setup, or `doctor` verification.

--- a/site/public/setup.md
+++ b/site/public/setup.md
@@ -54,7 +54,7 @@ scribe --version 2>/dev/null || true
 
 If the intended KB directory already contains `scribe.yaml`, treat it as an
 existing KB. Do not run a fresh `scribe init --path …` over it and do not use
-`--force`. For an existing checkout, `cd` into it and run `scribe init --check --yes`
+`--force`. For an existing checkout, `cd` into it and run `scribe init --check`
 or the team-member recipe below.
 
 Do not paste API keys into a prompt, command history, committed `scribe.yaml`,
@@ -357,7 +357,7 @@ KB="$HOME/team-kb"
 git clone git@github.com:acme/team-kb.git "$KB"
 cd "$KB"
 
-scribe init --check --yes
+scribe init --check
 scribe config trust
 scribe kb add "$KB"
 scribe cron install
@@ -425,7 +425,7 @@ Use `-C` so every check names the intended KB explicitly:
 
 ```sh
 scribe --version
-scribe -C "$KB" init --check --yes
+scribe -C "$KB" init --check
 scribe -C "$KB" doctor
 scribe kb list
 scribe -C "$KB" projects list
@@ -434,8 +434,11 @@ scribe -C "$KB" skill install --check
 git -C "$KB" status --short
 ```
 
-`init --check` is read-only and non-interactive on its own; `--yes` is harmless
-belt-and-braces on older releases. Verify scheduling — `cron status` covers both
+`init --check` is read-only and non-interactive on its own — don't reach for
+`--yes` here. Without `--check`, `--yes` repoints the KB binding in your global
+agent files, so pairing the two teaches a habit that is one dropped flag away
+from rewriting state you didn't mean to touch. Verify scheduling — `cron status`
+covers both
 platforms (LaunchAgents on macOS, the crontab block on Linux):
 
 ```sh
@@ -455,7 +458,7 @@ git -C "$KB" remote -v
 Setup is complete when:
 
 - `scribe` resolves to the expected binary and reports a version.
-- `init --check --yes` finds the intended KB without prompts or writes.
+- `init --check` finds the intended KB without prompts or writes.
 - `doctor` has no unexplained hard failures; qmd is healthy, and Ollama is
   reachable with the chosen local model when that provider is selected.
 - The KB appears in `scribe kb list`, and cron is installed (or its Linux block

--- a/site/public/sitemap.xml
+++ b/site/public/sitemap.xml
@@ -7,6 +7,12 @@
     <priority>1.0</priority>
   </url>
   <url>
+    <loc>https://getscribe.dev/setup.md</loc>
+    <lastmod>2026-08-10</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
     <loc>https://getscribe.dev/llms.txt</loc>
     <lastmod>2026-08-10</lastmod>
     <changefreq>weekly</changefreq>


### PR DESCRIPTION
## Summary

- add a standalone, prompt-compatible `setup.md` runbook for personal Anthropic, local Ollama, hosted OpenAI-compatible providers, team owners/members, multiple KBs, and Linux scheduling
- add a visible, copyable **install with agent** tab to getscribe.dev for Claude Code and Codex
- align the README, embedded CLI skill, package-manager caveats, installer output, `llms.txt`, sitemap, and site Markdown mirrors
- clarify that `scribe skill install` helps after bootstrap but does not replace dependency installation, `init --bind`, source approval, scheduling, or verification
- separate the team owner who scaffolds with `--team` from members who clone and onboard the existing checkout
- document current-CLI-safe workarounds explicitly: `init --check --yes`, registering an old default before rebinding, and direct Linux verification with `crontab -l`

## Scope

Documentation and user-facing install surfaces only—no Go runtime changes or Go tests.

The runtime issues discovered during the documentation audit are isolated in companion PR #71. This PR does not depend on #71 and remains accurate if merged independently.

## Verification

- `make test` (embedded skill bundle coverage)
- `git diff --check`
- `bash -n install.sh`
- getscribe.dev evergreen/version-pin audit
- HTML parser, unique IDs, tab ARIA references, copy targets, 9 JSON-LD blocks, sitemap XML, and Markdown fence checks
- exact `index.md` / `llms-full.txt` mirror
- exact coding-agent prompt across HTML, setup.md, index.md, and llms-full.txt
- local static server returned `200 text/markdown` for `/setup.md`

## Deployment

This PR updates the Cloudflare static-site source but does not deploy getscribe.dev. Deploy after review/merge using the repository's site-sync workflow.
