### PR TITLE
wip: X (Twitter) bookmarks pull-adapter via xurl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,13 @@ stars…) is a small file against the same `Source` interface.
 - **Config** in `scribe.yaml` under `integrations.pinboard`:
   - `scope: recent+unread | unread | all` — selects bookmarks by
     read-state/recency (`recent+unread` is the default).
-  - `tags: []` — an **OR filter**: only ingest bookmarks carrying at least one
-    of these tags (case-insensitive); empty ingests everything the scope
-    returns. Composes with `scope` (e.g. `scope: all` + `tags: [kb]`).
+  - `tags: []` — tag filter (case-insensitive); empty ingests everything the
+    scope returns. Composes with `scope` (e.g. `scope: all` + `tags: [kb]`).
+  - `tags_mode: any | all` — how multiple tags combine: `any` (default) keeps
+    bookmarks carrying at least one listed tag (the ingest-gate shape), `all`
+    requires every listed tag — the narrowing semantics of Pinboard's own
+    `/t:a/t:b/` URL filtering. Unknown values fail loudly instead of silently
+    widening the filter.
   - `public_only: false` — an authenticated pull sees private bookmarks too;
     set `true` (or pass `--public-only`) to skip them, so private links don't
     reach a KB that might be shared or promoted.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,30 @@ stars…) is a small file against the same `Source` interface.
 - Bookmark `extended` notes are preserved into the article body, and Pinboard
   tags (plus a `pinboard` provenance tag, and `to-read` for unread) carry into
   frontmatter. Zero new Go dependencies (Pinboard v1 is JSON over HTTPS).
+- **X (Twitter) bookmarks** — a second adapter, pulling your X bookmarks through
+  X's official API by shelling out to
+  [`xurl`](https://github.com/xdevplatform/xurl) (X's own API CLI), so scribe
+  implements no OAuth and stores no X token: auth lives entirely in `xurl`'s
+  `~/.xurl`, and no credential goes in scribe's config at all (unlike Pinboard).
+  Queued entries are author URLs (`https://x.com/<user>/status/<id>`) that the
+  existing FxTwitter ingest tier renders — no new fetch path.
+  - **Incremental by cheap probe:** bookmarks are LIFO, so a run stops once it
+    reaches already-seen ids; a run that finds nothing new costs a fraction of a
+    cent (one small probe page), keeping the hourly `pull-sources` job cheap.
+  - **Costs/depth:** reads bill $0.001 each against prepaid pay-per-use credits
+    (no subscription, no minimum spend); a first full pull of ~800 bookmarks is
+    ≈ $0.80. The API serves only the **~800 most recent** bookmarks — a rolling
+    window, not an archive (and a reported pagination bug may cap real depth
+    lower still); deeper backfill needs a browser-side exporter into
+    `output/inbox/`.
+  - **Folders skipped in v1** — X's bookmark-folder API is currently broken
+    (20-item cap, rejects pagination).
+  - **`xurl` is an optional tool** (the `fzf` pattern): when it's missing or
+    unauthenticated the `x` adapter soft-skips with a one-line install/auth hint
+    instead of failing the run. No `scope`/`public_only` (those are Pinboard
+    read-state concepts); `tags` matches against each tweet's #hashtags (the
+    only tag-like signal a bookmark carries) and `skip_domains` behaves as it
+    does for Pinboard. Zero new Go dependencies (`exec.Command` into `xurl`).
 
 ## [0.4.0] — 2026-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,11 @@ stars…) is a small file against the same `Source` interface.
     `output/inbox/`.
   - **Folders skipped in v1** — X's bookmark-folder API is currently broken
     (20-item cap, rejects pagination).
+  - **`scribe pull x --setup`** — guided one-time setup checklist: verifies
+    each prerequisite in order (config → xurl on PATH → `~/.xurl` auth) with
+    the exact fix printed at the first failure, then proves auth end-to-end
+    with a single ~$0.001 live call. X's developer-account + prepaid-billing
+    onboarding can't be automated away, so scribe walks you through it instead.
   - **`xurl` is an optional tool** (the `fzf` pattern): when it's missing or
     unauthenticated the `x` adapter soft-skips with a one-line install/auth hint
     instead of failing the run. No `scope`/`public_only` (those are Pinboard

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ stars…) is a small file against the same `Source` interface.
   - `tags: []` — an **OR filter**: only ingest bookmarks carrying at least one
     of these tags (case-insensitive); empty ingests everything the scope
     returns. Composes with `scope` (e.g. `scope: all` + `tags: [kb]`).
+  - `public_only: false` — an authenticated pull sees private bookmarks too;
+    set `true` (or pass `--public-only`) to skip them, so private links don't
+    reach a KB that might be shared or promoted.
   - `skip_domains: []` — substring URL filter, same as `capture.skip_domains`.
 - **Token** is a secret: `integration_tokens.pinboard` in
   `~/.config/scribe/config.yaml` or `SCRIBE_PINBOARD_TOKEN` — never the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to scribe are documented here. Format follows [Keep a Change
 
 ## [Unreleased]
 
+### Added — pull adapters (`scribe pull`), starting with Pinboard
+
+A generic **pull-adapter framework** for ingesting bookmarks from external
+accounts into the KB, and **Pinboard** (<https://pinboard.in>) as its first
+adapter. Adapters are URL producers only: they queue bookmarks into
+`output/inbox/`, and the existing `ingest drain` path fetches →
+contextualizes → absorbs them. Deterministic and fast — no LLM, no page
+fetching in `pull` itself — so the next source (Raindrop, Instapaper, GitHub
+stars…) is a small file against the same `Source` interface.
+
+- **`scribe pull [source]`** — pull one integration or, bare, every configured
+  one (what the new hourly `pull-sources` cron job runs). Flags: `--list`
+  (status of each integration), `--scope`, `--tag` (repeatable), `--all-history`
+  (one-shot full backfill), `--max` (pace a big backfill), `--force`, `-n`
+  (dry-run).
+- **Config** in `scribe.yaml` under `integrations.pinboard`:
+  - `scope: recent+unread | unread | all` — selects bookmarks by
+    read-state/recency (`recent+unread` is the default).
+  - `tags: []` — an **OR filter**: only ingest bookmarks carrying at least one
+    of these tags (case-insensitive); empty ingests everything the scope
+    returns. Composes with `scope` (e.g. `scope: all` + `tags: [kb]`).
+  - `skip_domains: []` — substring URL filter, same as `capture.skip_domains`.
+- **Token** is a secret: `integration_tokens.pinboard` in
+  `~/.config/scribe/config.yaml` or `SCRIBE_PINBOARD_TOKEN` — never the
+  committed `scribe.yaml`. Env wins over the file (same rule as `llm_api_keys`).
+- **Rate-limit friendly:** a cheap `posts/update` probe short-circuits a run
+  when nothing changed before touching `posts/all`/`posts/recent`; per-source
+  state (cursor + seen-set) lives in `output/sources/<name>.json` (gitignored).
+- **Team KBs:** integrations are a personal source — hard-off from the repo
+  `scribe.yaml` like capture, re-enabled per-person in `scribe.local.yaml`, and
+  trust-locked in the config-trust layer.
+- Bookmark `extended` notes are preserved into the article body, and Pinboard
+  tags (plus a `pinboard` provenance tag, and `to-read` for unread) carry into
+  frontmatter. Zero new Go dependencies (Pinboard v1 is JSON over HTTPS).
+
 ## [0.4.0] — 2026-07-10
 
 Everything that accreted on `main` after the v0.3.0 team-KB release, cut as one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,8 +72,9 @@ stars…) is a small file against the same `Source` interface.
     unauthenticated the `x` adapter soft-skips with a one-line install/auth hint
     instead of failing the run. No `scope`/`public_only` (those are Pinboard
     read-state concepts); `tags` matches against each tweet's #hashtags (the
-    only tag-like signal a bookmark carries) and `skip_domains` behaves as it
-    does for Pinboard. Zero new Go dependencies (`exec.Command` into `xurl`).
+    only tag-like signal a bookmark carries), honors `tags_mode`, and
+    `skip_domains` behaves as it does for Pinboard. Zero new Go dependencies
+    (`exec.Command` into `xurl`).
 
 ## [0.4.0] — 2026-07-10
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,8 +67,10 @@ make check        # test + vet
 | Claude handshake block      | `~/.claude/CLAUDE.md`                       | scribe-managed block between `<!-- scribe:begin -->`/`end` markers; written by `init` |
 | Codex handshake block       | `~/.codex/AGENTS.md`                         | same markers/block as the Claude one; written by `init` so Codex CLI sessions query the KB + write drop files |
 | iMessage chat DB            | `~/Library/Messages/chat.db`                | needs Full Disk Access            |
-| scribe user config          | `~/.config/scribe/config.yaml`              | global defaults                   |
+| scribe user config          | `~/.config/scribe/config.yaml`              | global defaults; `integration_tokens.<name>` holds pull-adapter API tokens (never in a KB's scribe.yaml) |
 | pending sessions queue      | `~/.config/scribe/pending-sessions.txt`     | drained by `sync --sessions`      |
+| pull-adapter state          | `$KB/output/sources/<name>.json`            | per-source cursor + seen set for `scribe pull` (gitignored) |
+| Pinboard API                | `https://api.pinboard.in/v1/`               | `scribe pull pinboard`; token via `SCRIBE_PINBOARD_TOKEN` or `integration_tokens.pinboard` |
 | LaunchAgents                | `~/Library/LaunchAgents/com.scribe.*.plist` | installed by `cron install`       |
 | KB root                     | `$SCRIBE_KB` or `scribe.yaml` in cwd        | every command resolves this first |
 

--- a/README.md
+++ b/README.md
@@ -452,10 +452,12 @@ xurl "/2/users/me"        # returns your user object if auth works
 integrations:
   x:
     enabled: true
-    tags: []                # OR filter matched against each tweet's hashtags
+    tags: []                # tag filter matched against each tweet's hashtags
                             # (case-insensitive, bare form: "golang" not "#golang");
-                            # empty = all. Most tweets carry no hashtags, so a
-                            # non-empty filter is deliberately strict.
+                            # empty = all. tags_mode: any|all applies here too,
+                            # though "all" across hashtags rarely matches.
+                            # Most tweets carry no hashtags, so any non-empty
+                            # filter is deliberately strict.
     skip_domains: []        # substring URL filter, same as capture.skip_domains
 ```
 

--- a/README.md
+++ b/README.md
@@ -355,8 +355,9 @@ integrations:
   pinboard:
     enabled: true
     scope: recent+unread    # recent+unread | unread | all  (by read-state/recency)
-    tags: []                # OR filter: only ingest bookmarks with >=1 of these
-                            # tags (case-insensitive); empty = all
+    tags: []                # tag filter (case-insensitive); empty = all
+    tags_mode: any          # any = bookmark carries >=1 listed tag (default)
+                            # all = must carry EVERY listed tag (Pinboard-style)
     public_only: false      # true = skip private bookmarks; default ingests all
     skip_domains: []        # substring filter, same as capture.skip_domains
 ```
@@ -364,10 +365,16 @@ integrations:
 - **`scope`** picks the set by read-state/recency: `recent+unread` (default —
   recent bookmarks plus anything flagged to-read), `unread` (only to-read), or
   `all` (whole archive).
-- **`tags`** is an independent OR filter: with `tags: [kb, elixir]`, only
-  bookmarks carrying `kb` **or** `elixir` are ingested; empty ingests everything
-  the scope returned. The two compose — `scope: all` + `tags: [kb]` means
-  "every bookmark I ever tagged `kb`".
+- **`tags`** is an independent tag filter; empty ingests everything the scope
+  returned. It composes with scope — `scope: all` + `tags: [kb]` means "every
+  bookmark I ever tagged `kb`".
+- **`tags_mode`** picks how multiple tags combine. The default `any` is an
+  ingest gate: `tags: [kb, elixir]` keeps bookmarks carrying `kb` **or**
+  `elixir` — the right shape when the list is "all my KB-worthy markers". Set
+  `all` to require **every** listed tag (`elixir` **and** `concurrency`),
+  which matches how Pinboard's own `/t:elixir/t:concurrency/` URL filtering
+  narrows. Note this deliberately differs from Pinboard's site default —
+  stacking tags there narrows, while an ingest filter usually widens.
 - **`public_only`** — an authenticated pull sees your **private** bookmarks too,
   and by default they're ingested. Set `public_only: true` (or pass
   `--public-only` for one run) to skip private (non-shared) bookmarks — worth it

--- a/README.md
+++ b/README.md
@@ -321,6 +321,70 @@ triage:
     # ... matching weights for each category
 ```
 
+### Pull integrations (Pinboard)
+
+`scribe pull` fetches bookmarks from external accounts into the ingest queue,
+where the same drain path as `ingest url` fetches → contextualizes → absorbs
+them. Pinboard is the first adapter; the framework is generic, so more can slot
+in later. Adapters only produce URLs — no page content is fetched by `pull`
+itself, so it's deterministic and fast (no LLM).
+
+**1. Get your token.** Grab it from <https://pinboard.in/settings/password> (it's
+`username:HEXTOKEN`, and grants full read+write, so treat it like a password).
+The token is a **secret** — it lives in `~/.config/scribe/config.yaml`
+(`integration_tokens.pinboard`) or the `SCRIBE_PINBOARD_TOKEN` env var, **never**
+the committed `scribe.yaml`:
+
+```yaml
+# ~/.config/scribe/config.yaml (per-machine, gitignored)
+integration_tokens:
+  pinboard: "username:HEXTOKEN"
+```
+
+Sanity-check it (`posts/update` is the cheapest, side-effect-free call):
+
+```sh
+curl -s "https://api.pinboard.in/v1/posts/update?format=json&auth_token=$SCRIBE_PINBOARD_TOKEN"
+# → {"update_time":"2026-07-01T..."}  means auth works
+```
+
+**2. Enable it** in `scribe.yaml` (non-secret knobs only):
+
+```yaml
+integrations:
+  pinboard:
+    enabled: true
+    scope: recent+unread    # recent+unread | unread | all  (by read-state/recency)
+    tags: []                # OR filter: only ingest bookmarks with >=1 of these
+                            # tags (case-insensitive); empty = all
+    skip_domains: []        # substring filter, same as capture.skip_domains
+```
+
+- **`scope`** picks the set by read-state/recency: `recent+unread` (default —
+  recent bookmarks plus anything flagged to-read), `unread` (only to-read), or
+  `all` (whole archive).
+- **`tags`** is an independent OR filter: with `tags: [kb, elixir]`, only
+  bookmarks carrying `kb` **or** `elixir` are ingested; empty ingests everything
+  the scope returned. The two compose — `scope: all` + `tags: [kb]` means
+  "every bookmark I ever tagged `kb`".
+
+**3. Run it:**
+
+```sh
+scribe pull --list                    # integrations + status (configured? last pull?)
+scribe pull pinboard -n               # dry-run: show what WOULD be queued, write nothing
+scribe pull pinboard                  # pull the configured scope + tags
+scribe pull pinboard --tag kb --tag elixir   # override the tag filter for this run
+scribe pull pinboard --all-history --max 200 # paced full backfill; re-run until it reports 0 new
+```
+
+Queued URLs land in `output/inbox/` and are fetched → contextualized → absorbed
+by the existing `ingest drain` (every 30 min) — or run `scribe ingest drain` to
+process them now. A cheap `posts/update` probe short-circuits runs when nothing
+changed, so the cron job (`scribe pull`, hourly) is kind to Pinboard's rate
+limits. In a **team** KB, integrations are hard-off from the repo config like
+capture — re-enable per-person in `scribe.local.yaml`.
+
 ### Local-mode — 100% Ollama (free, offline)
 
 As of 0.2.14, **every LLM-driven subcommand can run end-to-end against a local [Ollama](https://ollama.com) server** with zero Anthropic calls. `dream`, `assess`, `deep`, `session-mine`, `relations migrate`, all four absorb passes, and `contextualize` resolve their backend through a single top-level `llm:` block. The Anthropic path stays the default; flipping the whole pipeline to free/offline is one line of yaml.
@@ -532,6 +596,11 @@ llm_api_key: tok-xxxxxxxx          # single key, covers whichever provider llm.p
 # llm_api_keys:                    # OR per-provider, if you route ops to different providers
 #   together: tok-aaaa
 #   groq:     gsk_bbbb
+
+# Pull-adapter API tokens (Pinboard, …). Same rule as the LLM key: lives here,
+# never in a KB's scribe.yaml, so it can't be committed to a shared KB.
+# integration_tokens:
+#   pinboard: "username:HEXTOKEN"  # from pinboard.in/settings/password
 ```
 
 Resolution order is **env var → this file**: a one-off `export GROQ_API_KEY=…` still wins, but with the key in this file nothing needs exporting (this is what makes cron work without touching `~/.zshenv`). `chmod 600` it. The key never goes in a KB's `scribe.yaml`.
@@ -542,6 +611,7 @@ Resolution order is **env var → this file**: a one-off `export GROQ_API_KEY=�
 | -------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
 | `SCRIBE_KB`                | Override KB root for one command                                                                                          |
 | `SCRIBE_SELF_CHAT_ID`      | Override `capture.self_chat_handle` (accepts comma-separated values for accounts with phone + Apple-ID email)             |
+| `SCRIBE_PINBOARD_TOKEN`    | Pinboard API token (`username:HEXTOKEN`) for `scribe pull pinboard`; overrides `integration_tokens.pinboard`             |
 | `SCRIBE_SKIP_REINDEX`      | Skip the final `qmd` reindex (useful in tests / CI)                                                                       |
 | `SCRIBE_PROJECT_ROOTS`     | Colon-separated list of parent dirs treated as top-level project roots (default: `Projects:projects:src:code:repos:work`) |
 | `SCRIBE_PASS2_MODE`        | Override `absorb.pass2_mode` (`tools` or `json`) for one run without editing scribe.yaml                                  |

--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ integrations:
     scope: recent+unread    # recent+unread | unread | all  (by read-state/recency)
     tags: []                # OR filter: only ingest bookmarks with >=1 of these
                             # tags (case-insensitive); empty = all
+    public_only: false      # true = skip private bookmarks; default ingests all
     skip_domains: []        # substring filter, same as capture.skip_domains
 ```
 
@@ -367,6 +368,11 @@ integrations:
   bookmarks carrying `kb` **or** `elixir` are ingested; empty ingests everything
   the scope returned. The two compose — `scope: all` + `tags: [kb]` means
   "every bookmark I ever tagged `kb`".
+- **`public_only`** — an authenticated pull sees your **private** bookmarks too,
+  and by default they're ingested. Set `public_only: true` (or pass
+  `--public-only` for one run) to skip private (non-shared) bookmarks — worth it
+  if this KB might ever be shared or `scribe promote`d, so private links don't
+  ride along.
 
 **3. Run it:**
 

--- a/README.md
+++ b/README.md
@@ -406,6 +406,15 @@ API CLI — so scribe never implements OAuth or stores an X token. Unlike
 Pinboard, **no credential goes into scribe's config at all**: `xurl` owns the
 whole OAuth 2.0 flow and keeps the tokens in `~/.xurl`.
 
+The setup below is more involved than Pinboard's single token — X requires a
+developer account and prepaid billing, and there's no way around that. At any
+point, run the guided checklist and it tells you exactly which step you're on
+and what to do next:
+
+```sh
+scribe pull x --setup    # verifies each prerequisite; ends with one ~$0.001 live auth check
+```
+
 **1. One-time X setup.** This adapter talks to the real X API, so it needs a
 developer account and a trickle of pay-per-use credit:
 
@@ -457,6 +466,7 @@ adapter ignores them if present.
 **4. Run it** (same commands as any adapter):
 
 ```sh
+scribe pull x --setup                 # guided checklist: every prerequisite + live auth check
 scribe pull --list                    # integrations + status (configured? last pull?)
 scribe pull x -n                      # dry-run: show what WOULD be queued, write nothing
 scribe pull x                         # pull bookmarks into output/inbox/

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ triage:
     # ... matching weights for each category
 ```
 
-### Pull integrations (Pinboard)
+### Pull integrations (Pinboard, X)
 
 `scribe pull` fetches bookmarks from external accounts into the ingest queue,
 where the same drain path as `ingest url` fetches → contextualizes → absorbs
@@ -397,6 +397,93 @@ process them now. A cheap `posts/update` probe short-circuits runs when nothing
 changed, so the cron job (`scribe pull`, hourly) is kind to Pinboard's rate
 limits. In a **team** KB, integrations are hard-off from the repo config like
 capture — re-enable per-person in `scribe.local.yaml`.
+
+#### X (Twitter) bookmarks
+
+The `x` adapter pulls your X (formerly Twitter) bookmarks through X's official
+API, shelling out to [`xurl`](https://github.com/xdevplatform/xurl) — X's own
+API CLI — so scribe never implements OAuth or stores an X token. Unlike
+Pinboard, **no credential goes into scribe's config at all**: `xurl` owns the
+whole OAuth 2.0 flow and keeps the tokens in `~/.xurl`.
+
+**1. One-time X setup.** This adapter talks to the real X API, so it needs a
+developer account and a trickle of pay-per-use credit:
+
+- Sign up at <https://developer.x.com>, accept the developer agreement, and
+  create a Project + App (a one-line use-case description is enough).
+- In the app's settings, enable **OAuth 2.0** and register the redirect URI
+  `http://localhost:8080/callback`. Save the generated client id and secret —
+  `xurl` uses them for the browser flow below.
+- Add a small **prepaid** pay-per-use credit in the developer console. There's
+  no subscription and no minimum spend — reads bill $0.001 each (see costs
+  below), so a few dollars lasts a long time.
+
+**2. Install and authenticate `xurl`.** It's an optional tool, like `fzf` for
+triage — scribe soft-skips the `x` adapter with a one-line hint when it's
+missing or unauthenticated, so cron keeps flowing:
+
+```sh
+brew install --cask xdevplatform/tap/xurl        # or: go install github.com/xdevplatform/xurl@latest
+xurl auth apps add scribe --client-id YOUR_ID --client-secret YOUR_SECRET
+xurl auth oauth2 --app scribe                     # one-time browser flow; tokens land in ~/.xurl
+```
+
+`xurl auth oauth2 --app scribe` opens a browser once for the consent screen. After that the
+tokens live in `~/.xurl` and `xurl` refreshes them itself, so subsequent cron
+runs are headless with no further prompts. Sanity-check auth with a cheap
+owned-read:
+
+```sh
+xurl "/2/users/me"        # returns your user object if auth works
+```
+
+**3. Enable it** in `scribe.yaml`:
+
+```yaml
+integrations:
+  x:
+    enabled: true
+    tags: []                # OR filter matched against each tweet's hashtags
+                            # (case-insensitive, bare form: "golang" not "#golang");
+                            # empty = all. Most tweets carry no hashtags, so a
+                            # non-empty filter is deliberately strict.
+    skip_domains: []        # substring URL filter, same as capture.skip_domains
+```
+
+There's no `scope` or `public_only` here — those are Pinboard concepts
+(read-state and private-vs-public) that don't map to X bookmarks, so the `x`
+adapter ignores them if present.
+
+**4. Run it** (same commands as any adapter):
+
+```sh
+scribe pull --list                    # integrations + status (configured? last pull?)
+scribe pull x -n                      # dry-run: show what WOULD be queued, write nothing
+scribe pull x                         # pull bookmarks into output/inbox/
+scribe ingest drain                   # fetch → contextualize → absorb them now
+```
+
+Queued bookmarks are author-URL entries (`https://x.com/<user>/status/<id>`)
+that the existing `ingest drain` renders via its FxTwitter tier — no new
+fetching path is added.
+
+**Costs and limits (honest ones):**
+
+- **$0.001 per bookmark read,** billed against your prepaid credits. A first
+  full pull of ~800 bookmarks is ≈ $0.80, one time.
+- **The API only serves the ~800 most recent bookmarks.** It's a rolling
+  window, not an archive — older bookmarks aren't reachable through the API at
+  all. (A known pagination bug has been reported to stop even earlier, around
+  200–300 items — your first full pull will tell you where your account lands.)
+- **Incremental runs are cheap:** a run that finds nothing new costs a fraction
+  of a cent (one small probe page), so the hourly `pull-sources` cron job is
+  kind to your credit.
+- **Bookmark folders are not supported.** X's folder API is currently broken
+  (returns only 20 items and rejects pagination), so v1 skips folders entirely.
+- **For a full historical export beyond the ~800-item window,** use a
+  browser-side bookmark exporter (e.g. the open-source
+  [xarchive](https://github.com/sytelus/xarchive/) extension) and drop the
+  exported URLs into `output/inbox/` — the same inbox `scribe pull` writes to.
 
 ### Local-mode — 100% Ollama (free, offline)
 

--- a/cmd/scribe/config.go
+++ b/cmd/scribe/config.go
@@ -518,12 +518,17 @@ type IntegrationConfig struct {
 	// interpreted; Pinboard understands recent+unread | unread | all.
 	// Empty → adapter default (recent+unread).
 	Scope string `yaml:"scope"`
-	// Tags is an OR filter applied by the generic driver: a bookmark is
-	// ingested only if it carries at least one of these tags (case-
-	// insensitive). Empty (the default) ingests everything the scope
-	// returns. Orthogonal to Scope — e.g. scope: all + tags: [kb] means
-	// "every bookmark I ever tagged kb".
+	// Tags is a tag filter applied by the generic driver (case-insensitive).
+	// Empty (the default) ingests everything the scope returns. Orthogonal
+	// to Scope — e.g. scope: all + tags: [kb] means "every bookmark I ever
+	// tagged kb". How multiple tags combine is TagsMode's call.
 	Tags []string `yaml:"tags"`
+	// TagsMode selects how Tags matches: "any" (the default — a bookmark
+	// carrying at least one listed tag passes; the natural mode for an
+	// ingest gate over several KB-worthy markers) or "all" (it must carry
+	// every listed tag — the narrowing semantics Pinboard's own /t:a/t:b/
+	// URL filtering uses). Ignored while Tags is empty.
+	TagsMode string `yaml:"tags_mode"`
 	// PublicOnly, when true, skips private (non-shared) bookmarks so only
 	// public ones reach the KB. Default false ingests everything, since an
 	// authenticated pull sees private bookmarks too. Useful when the KB may

--- a/cmd/scribe/config.go
+++ b/cmd/scribe/config.go
@@ -524,6 +524,11 @@ type IntegrationConfig struct {
 	// returns. Orthogonal to Scope — e.g. scope: all + tags: [kb] means
 	// "every bookmark I ever tagged kb".
 	Tags []string `yaml:"tags"`
+	// PublicOnly, when true, skips private (non-shared) bookmarks so only
+	// public ones reach the KB. Default false ingests everything, since an
+	// authenticated pull sees private bookmarks too. Useful when the KB may
+	// be shared/promoted and private bookmarks shouldn't ride along.
+	PublicOnly bool `yaml:"public_only"`
 	// SkipDomains drops queued URLs containing any of these substrings —
 	// the same substring filter as capture.skip_domains.
 	SkipDomains []string `yaml:"skip_domains"`

--- a/cmd/scribe/config.go
+++ b/cmd/scribe/config.go
@@ -115,7 +115,12 @@ type ScribeConfig struct {
 	Sync    SyncConfig    `yaml:"sync"`
 	Deep    DeepConfig    `yaml:"deep"`
 	Capture CaptureConfig `yaml:"capture"`
-	Triage  TriageConfig  `yaml:"triage"`
+	// Integrations holds the non-secret config for pull adapters (`scribe
+	// pull` — Pinboard, and future bookmark sources). API tokens NEVER live
+	// here; they go in ~/.config/scribe/config.yaml under integration_tokens.
+	// Personal source like Capture: zeroed in team mode, re-enabled locally.
+	Integrations IntegrationsConfig `yaml:"integrations"`
+	Triage       TriageConfig       `yaml:"triage"`
 	// PriorityLanes tunes how sync drains pending-sessions.txt (issue
 	// #22) — see PriorityLanesConfig.
 	PriorityLanes PriorityLanesConfig `yaml:"priority_lanes"`
@@ -498,6 +503,42 @@ type CaptureConfig struct {
 	SkipDomains []string `yaml:"skip_domains"`
 }
 
+// IntegrationsConfig maps an integration name (e.g. "pinboard") to its
+// non-secret settings. Secrets (API tokens) never live here — they go in
+// ~/.config/scribe/config.yaml under integration_tokens, so a token can never
+// be committed to a shared KB. `scribe pull` iterates the source registry
+// (source.go) and pulls each configured integration.
+type IntegrationsConfig map[string]IntegrationConfig
+
+// IntegrationConfig holds the shared, non-secret knobs a pull adapter reads.
+type IntegrationConfig struct {
+	// Enabled gates the integration; a pull run soft-skips when false.
+	Enabled bool `yaml:"enabled"`
+	// Scope selects which items to pull by read-state/recency. Adapter-
+	// interpreted; Pinboard understands recent+unread | unread | all.
+	// Empty → adapter default (recent+unread).
+	Scope string `yaml:"scope"`
+	// Tags is an OR filter applied by the generic driver: a bookmark is
+	// ingested only if it carries at least one of these tags (case-
+	// insensitive). Empty (the default) ingests everything the scope
+	// returns. Orthogonal to Scope — e.g. scope: all + tags: [kb] means
+	// "every bookmark I ever tagged kb".
+	Tags []string `yaml:"tags"`
+	// SkipDomains drops queued URLs containing any of these substrings —
+	// the same substring filter as capture.skip_domains.
+	SkipDomains []string `yaml:"skip_domains"`
+}
+
+// integrationConfig returns the config block for a named integration and
+// whether it was present.
+func integrationConfig(cfg *ScribeConfig, name string) (IntegrationConfig, bool) {
+	if cfg == nil || cfg.Integrations == nil {
+		return IntegrationConfig{}, false
+	}
+	ic, ok := cfg.Integrations[name]
+	return ic, ok
+}
+
 type SyncConfig struct {
 	MaxExtractions      int `yaml:"max_extractions"`
 	MaxSessions         int `yaml:"max_sessions"`
@@ -833,6 +874,23 @@ type userConfig struct {
 	// not in any KB's scribe.yaml, so one KB can't set the machine budget
 	// for the others. Zero = disabled. See budget.go.
 	DailyOutputTokenCeiling int64 `yaml:"daily_output_token_ceiling,omitempty"`
+	// IntegrationTokens maps a pull-adapter name (pinboard, …) to its API
+	// token. It lives HERE — the per-machine user config — and never in a
+	// KB's scribe.yaml, so a token can't be committed to a shared KB (same
+	// rule as LLMAPIKeys). Env SCRIBE_<NAME>_TOKEN overrides an entry.
+	IntegrationTokens map[string]string `yaml:"integration_tokens,omitempty"`
+}
+
+// integrationToken resolves the API token for a pull integration. Env wins
+// (SCRIBE_<NAME>_TOKEN, so a one-off export overrides), then the per-machine
+// user config (integration_tokens.<name>). Never read from a KB's scribe.yaml
+// — a token must not be committable to a shared KB.
+func integrationToken(name string) string {
+	env := "SCRIBE_" + strings.ToUpper(name) + "_TOKEN"
+	if v := strings.TrimSpace(os.Getenv(env)); v != "" {
+		return v
+	}
+	return strings.TrimSpace(loadUserConfig().IntegrationTokens[name])
 }
 
 // loadUserConfig reads the user-level config. Returns zero value if missing.

--- a/cmd/scribe/config_trust.go
+++ b/cmd/scribe/config_trust.go
@@ -79,17 +79,21 @@ const localConfigName = "scribe.local.yaml"
 //   - SecretScan: the credential gate — a pushed disable/allow_paths
 //     change must not weaken what another member's machine commits.
 type sensitiveConfig struct {
-	Team              bool             `json:"team"`
-	Sources           SourcesConfig    `json:"sources"`
-	ClaudeProjectsDir string           `json:"claude_projects_dir"`
-	CodexSessionsDir  string           `json:"codex_sessions_dir"`
-	CcriderDB         string           `json:"ccrider_db"`
-	Capture           CaptureConfig    `json:"capture"`
-	OllamaURL         string           `json:"ollama_url"`
-	BaseURL           string           `json:"base_url"`
-	APIKeyEnv         string           `json:"api_key_env"`
-	CodexMine         bool             `json:"codex_mine"`
-	SecretScan        SecretScanConfig `json:"secret_scan"`
+	Team              bool          `json:"team"`
+	Sources           SourcesConfig `json:"sources"`
+	ClaudeProjectsDir string        `json:"claude_projects_dir"`
+	CodexSessionsDir  string        `json:"codex_sessions_dir"`
+	CcriderDB         string        `json:"ccrider_db"`
+	Capture           CaptureConfig `json:"capture"`
+	// Integrations is a personal ingestion source (pull adapters). Locked for
+	// the same reason as Capture: a pushed change widens what's ingested and
+	// from where. Also hard-off in team mode below.
+	Integrations IntegrationsConfig `json:"integrations"`
+	OllamaURL    string             `json:"ollama_url"`
+	BaseURL      string             `json:"base_url"`
+	APIKeyEnv    string             `json:"api_key_env"`
+	CodexMine    bool               `json:"codex_mine"`
+	SecretScan   SecretScanConfig   `json:"secret_scan"`
 
 	ExtractOllamaURL       string `json:"extract_ollama_url"`
 	DreamOllamaURL         string `json:"dream_ollama_url"`
@@ -154,6 +158,7 @@ func sensitiveFrom(cfg *ScribeConfig) sensitiveConfig {
 		CodexSessionsDir:  cfg.CodexSessionsDir,
 		CcriderDB:         cfg.CcriderDB,
 		Capture:           cfg.Capture,
+		Integrations:      cfg.Integrations,
 		OllamaURL:         cfg.LLM.OllamaURL,
 		BaseURL:           cfg.LLM.BaseURL,
 		APIKeyEnv:         cfg.LLM.APIKeyEnv,
@@ -199,6 +204,7 @@ func (s sensitiveConfig) applyTo(cfg *ScribeConfig) {
 	cfg.CodexSessionsDir = s.CodexSessionsDir
 	cfg.CcriderDB = s.CcriderDB
 	cfg.Capture = s.Capture
+	cfg.Integrations = s.Integrations
 	cfg.LLM.OllamaURL = s.OllamaURL
 	cfg.LLM.BaseURL = s.BaseURL
 	cfg.LLM.APIKeyEnv = s.APIKeyEnv
@@ -341,6 +347,12 @@ func enforceConfigTrust(root string, cfg *ScribeConfig) {
 		// ingestion is strictly a local decision: scribe.local.yaml or
 		// SCRIBE_SELF_CHAT_ID re-enable it after this point.
 		cfg.Capture = CaptureConfig{}
+		// Pull integrations (Pinboard, …) are personal sources for the same
+		// reason: a pushed `integrations.*.enabled: true` must not make every
+		// teammate pull from an account. Re-enable per-person via
+		// scribe.local.yaml. (Tokens live only in user config/env, so this is
+		// belt-and-suspenders — an unconfigured member already no-ops.)
+		cfg.Integrations = nil
 	}
 }
 
@@ -434,6 +446,7 @@ func sensitiveDiff(trusted, current sensitiveConfig) []string {
 		{"codex_sessions_dir", trusted.CodexSessionsDir, current.CodexSessionsDir},
 		{"ccrider_db", trusted.CcriderDB, current.CcriderDB},
 		{"capture", trusted.Capture, current.Capture},
+		{"integrations", trusted.Integrations, current.Integrations},
 		{"llm.ollama_url", trusted.OllamaURL, current.OllamaURL},
 		{"llm.base_url", trusted.BaseURL, current.BaseURL},
 		{"llm.api_key_env", trusted.APIKeyEnv, current.APIKeyEnv},

--- a/cmd/scribe/config_trust_test.go
+++ b/cmd/scribe/config_trust_test.go
@@ -111,6 +111,27 @@ func TestTeamCaptureHardOff(t *testing.T) {
 	}
 }
 
+func TestTeamIntegrationsHardOff(t *testing.T) {
+	// Repo config enables a pull integration in a team KB — must be ignored
+	// even with no trust record yet (personal source, like capture).
+	root := setupTrustKB(t,
+		"team: true\nintegrations:\n  pinboard:\n    enabled: true\n    scope: all\n", "")
+	cfg := loadConfig(root)
+	if len(cfg.Integrations) != 0 {
+		t.Errorf("team KB took integrations config from the repo file: %+v", cfg.Integrations)
+	}
+
+	// scribe.local.yaml re-enables it — local layer is sovereign.
+	if err := os.WriteFile(filepath.Join(root, localConfigName),
+		[]byte("integrations:\n  pinboard:\n    enabled: true\n    scope: unread\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg = loadConfig(root)
+	if ic, ok := cfg.Integrations["pinboard"]; !ok || !ic.Enabled || ic.Scope != "unread" {
+		t.Errorf("local integrations override lost: %+v", cfg.Integrations)
+	}
+}
+
 func TestSoloKBUnaffected(t *testing.T) {
 	root := setupTrustKB(t,
 		"capture:\n  self_chat_handle: \"+421900000000\"\nsources:\n  include: [\"/my/path\"]\n", "")

--- a/cmd/scribe/cron.go
+++ b/cmd/scribe/cron.go
@@ -140,6 +140,13 @@ func scribeJobs(binary string) []cronJob {
 			Schedule: schedSpec{Calendar: everyNMinutes(30)},
 		},
 		{
+			Name:     "pull-sources",
+			Desc:     "Pull configured integrations (Pinboard, …) into the ingest queue hourly at :17",
+			Command:  each("pull"),
+			LogFile:  filepath.Join(logDir, "scribe-pull.log"),
+			Schedule: schedSpec{Calendar: hourlyAt(17)},
+		},
+		{
 			Name:     "capture-refetch",
 			Desc:     "Retry stub links daily at 06:30 (parks failures in _unfetched-links.md)",
 			Command:  each("capture --refetch"),

--- a/cmd/scribe/ingest.go
+++ b/cmd/scribe/ingest.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -145,47 +146,152 @@ func markContextualized(root, rawBase string) {
 	}
 }
 
-// ingestQueue writes a small .url file to output/inbox/ and returns.
-func ingestQueue(root, rawURL, title string, tags []string, domain, fetcher string, dryRun bool) error {
-	inbox := filepath.Join(root, "output", "inbox")
+// queueFields is the content of one output/inbox/*.url entry. Shared by
+// `ingest url` and the pull adapters (source.go) so both agree on the on-disk
+// format that drainOne consumes. Note and Source are the adapter extensions:
+// Note is the user's own annotation (Pinboard `extended`), prepended to the
+// fetched body as a blockquote by drainOne; Source is a provenance tag
+// (e.g. "pinboard") merged into the article's frontmatter tags.
+type queueFields struct {
+	URL      string
+	Title    string
+	Tags     []string
+	Domain   string
+	Fetcher  string
+	Note     string
+	Source   string
+	QueuedAt time.Time
+}
 
-	ts := time.Now()
+func (f *queueFields) applyDefaults() {
+	if f.QueuedAt.IsZero() {
+		f.QueuedAt = time.Now()
+	}
+	if f.Domain == "" {
+		f.Domain = "general"
+	}
+}
+
+// renderQueueEntry serializes a queue entry to the line-based `key: value`
+// format parseQueueEntry reads. Callers apply defaults first.
+func renderQueueEntry(f queueFields) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "url: %s\n", f.URL)
+	if f.Title != "" {
+		fmt.Fprintf(&sb, "title: %s\n", f.Title)
+	}
+	if len(f.Tags) > 0 {
+		fmt.Fprintf(&sb, "tags: %s\n", strings.Join(f.Tags, ", "))
+	}
+	fmt.Fprintf(&sb, "domain: %s\n", f.Domain)
+	if f.Fetcher != "" && f.Fetcher != "auto" {
+		fmt.Fprintf(&sb, "fetcher: %s\n", f.Fetcher)
+	}
+	if f.Source != "" {
+		fmt.Fprintf(&sb, "source: %s\n", f.Source)
+	}
+	if f.Note != "" {
+		// The queue format is line-based, so the note is single-line encoded
+		// (newlines → \n sentinel) and decoded back in drainOne.
+		fmt.Fprintf(&sb, "note: %s\n", encodeQueueNote(f.Note))
+	}
+	fmt.Fprintf(&sb, "queued_at: %s\n", f.QueuedAt.Format(time.RFC3339))
+	return sb.String()
+}
+
+// uniqueQueuePath builds a collision-free inbox path. Bulk adapter pulls queue
+// many entries in the same second, so a numeric suffix disambiguates when the
+// timestamp+slug base already exists on disk.
+func uniqueQueuePath(inbox, rawURL string, ts time.Time) string {
 	stamp := ts.Format("2006-01-02-150405")
 	slug := slugify(rawURL)
 	if len(slug) > 40 {
 		slug = slug[:40]
 	}
-	fname := fmt.Sprintf("%s-%s.url", stamp, slug)
-	path := filepath.Join(inbox, fname)
+	base := stamp + "-" + slug
+	path := filepath.Join(inbox, base+".url")
+	for n := 2; fileExists(path); n++ {
+		path = filepath.Join(inbox, fmt.Sprintf("%s-%d.url", base, n))
+	}
+	return path
+}
 
-	var sb strings.Builder
-	fmt.Fprintf(&sb, "url: %s\n", rawURL)
-	if title != "" {
-		fmt.Fprintf(&sb, "title: %s\n", title)
+// writeQueueEntry atomically writes one queue entry into inbox and returns its
+// path. Temp-then-rename keeps a concurrent `ingest drain` from ever reading a
+// half-written *.url file.
+func writeQueueEntry(inbox string, f queueFields) (string, error) {
+	f.applyDefaults()
+	if err := os.MkdirAll(inbox, 0o755); err != nil {
+		return "", fmt.Errorf("create inbox: %w", err)
 	}
-	if len(tags) > 0 {
-		fmt.Fprintf(&sb, "tags: %s\n", strings.Join(tags, ", "))
+	path := uniqueQueuePath(inbox, f.URL, f.QueuedAt)
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, []byte(renderQueueEntry(f)), 0o644); err != nil {
+		return "", fmt.Errorf("write queue entry: %w", err)
 	}
-	fmt.Fprintf(&sb, "domain: %s\n", domain)
-	if fetcher != "" && fetcher != "auto" {
-		fmt.Fprintf(&sb, "fetcher: %s\n", fetcher)
+	if err := os.Rename(tmp, path); err != nil {
+		os.Remove(tmp)
+		return "", fmt.Errorf("finalize queue entry: %w", err)
 	}
-	fmt.Fprintf(&sb, "queued_at: %s\n", ts.Format(time.RFC3339))
+	return path, nil
+}
+
+// encodeQueueNote flattens a possibly multi-line note to a single line so it
+// survives the line-based queue format. decodeQueueNote reverses it.
+func encodeQueueNote(s string) string {
+	s = strings.ReplaceAll(s, "\\", "\\\\")
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	s = strings.ReplaceAll(s, "\r", "\n")
+	return strings.ReplaceAll(s, "\n", "\\n")
+}
+
+func decodeQueueNote(s string) string {
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' && i+1 < len(s) {
+			switch s[i+1] {
+			case 'n':
+				b.WriteByte('\n')
+				i++
+				continue
+			case '\\':
+				b.WriteByte('\\')
+				i++
+				continue
+			}
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
+}
+
+// queueNoteBlockquote renders a decoded note as a markdown blockquote so it
+// reads as the user's annotation above the fetched content.
+func queueNoteBlockquote(note string) string {
+	lines := strings.Split(strings.TrimSpace(note), "\n")
+	for i, ln := range lines {
+		lines[i] = strings.TrimRight("> "+ln, " ")
+	}
+	return strings.Join(lines, "\n")
+}
+
+// ingestQueue writes a small .url file to output/inbox/ and returns.
+func ingestQueue(root, rawURL, title string, tags []string, domain, fetcher string, dryRun bool) error {
+	inbox := filepath.Join(root, "output", "inbox")
+	f := queueFields{URL: rawURL, Title: title, Tags: tags, Domain: domain, Fetcher: fetcher}
+	f.applyDefaults()
 
 	if dryRun {
-		fmt.Printf("[dry-run] would queue: %s\n", path)
+		fmt.Printf("[dry-run] would queue: %s\n", uniqueQueuePath(inbox, rawURL, f.QueuedAt))
 		fmt.Println("---")
-		fmt.Println(sb.String())
+		fmt.Println(renderQueueEntry(f))
 		return nil
 	}
 
-	if err := os.MkdirAll(inbox, 0o755); err != nil {
-		return fmt.Errorf("create inbox: %w", err)
+	path, err := writeQueueEntry(inbox, f)
+	if err != nil {
+		return err
 	}
-	if err := os.WriteFile(path, []byte(sb.String()), 0o644); err != nil {
-		return fmt.Errorf("write queue entry: %w", err)
-	}
-
 	fmt.Printf("queued: %s\n", path)
 	return nil
 }
@@ -457,7 +563,19 @@ func drainOne(root, queuePath string, dryRun bool) error {
 		finalTitle = "Untitled"
 	}
 
-	path, content := buildRawArticle(root, rawURL, finalTitle, res.Body, res.Via, domain, tags)
+	// Adapter extensions: preserve the user's own annotation (note:) as a
+	// leading blockquote, and stamp the provenance tag (source:) into
+	// frontmatter. Both survive a successful fetch (the fetched body alone
+	// would otherwise drop the pull-time context).
+	body := res.Body
+	if note := decodeQueueNote(entry["note"]); strings.TrimSpace(note) != "" {
+		body = queueNoteBlockquote(note) + "\n\n" + body
+	}
+	if src := entry["source"]; src != "" && !slices.Contains(tags, src) {
+		tags = append(tags, src)
+	}
+
+	path, content := buildRawArticle(root, rawURL, finalTitle, body, res.Via, domain, tags)
 
 	if dryRun {
 		logMsg("ingest", "[dry-run] would write %s (via %s, %d bytes)", filepath.Base(path), res.Via, len(content))

--- a/cmd/scribe/main.go
+++ b/cmd/scribe/main.go
@@ -40,6 +40,7 @@ type CLI struct {
 	Ingest        IngestCmd        `cmd:"" group:"content" help:"Ingest a URL into raw/articles/ (queue or synchronous)."`
 	Absorb        AbsorbCmd        `cmd:"" group:"content" help:"Absorb a local file (md/txt/html) into the KB end-to-end: ingest → contextualize → absorb."`
 	Capture       CaptureCmd       `cmd:"" group:"content" help:"Capture iMessage self-chat URLs/notes into raw/articles/."`
+	Pull          PullCmd          `cmd:"" group:"content" help:"Pull bookmarks from configured integrations (Pinboard, …) into the ingest queue."`
 	Contextualize ContextualizeCmd `cmd:"" group:"content" help:"Insert LLM-generated retrieval-context paragraph into raw articles for better qmd search."`
 	Projects      ProjectsCmd      `cmd:"" group:"content" help:"List, approve, ignore, or review discovered projects."`
 	Scan          ScanCmd          `cmd:"" group:"content" help:"Pre-scan a project for extraction."`

--- a/cmd/scribe/source.go
+++ b/cmd/scribe/source.go
@@ -62,6 +62,7 @@ type FetchOpts struct {
 // entry here plus a file implementing Source.
 var sourceRegistry = map[string]Source{
 	"pinboard": pinboardSource{},
+	"x":        xSource{},
 }
 
 // registeredSources returns every adapter, sorted by name for stable output.

--- a/cmd/scribe/source.go
+++ b/cmd/scribe/source.go
@@ -28,7 +28,7 @@ type Source interface {
 	Configured(cfg *ScribeConfig) (ok bool, reason string)
 	// Fetch returns fresh items given the opaque prior cursor, plus the cursor
 	// to persist for the next run. Implementations own their cursor shape and
-	// resolve their own config (scope defaults, token) off cfg. The OR tag
+	// resolve their own config (scope defaults, token) off cfg. The tag
 	// filter and skip_domains are applied generically by the driver afterward.
 	Fetch(ctx context.Context, cfg *ScribeConfig, prev json.RawMessage, opts FetchOpts) (items []SourceItem, next json.RawMessage, err error)
 }
@@ -48,11 +48,12 @@ type SourceItem struct {
 }
 
 // FetchOpts carries the per-run knobs a Source honors. Empty Scope means
-// "use the configured default". Tags is the per-run override of the OR tag
-// filter the driver applies (empty → use the integration's configured tags).
+// "use the configured default". Tags is the per-run override of the tag
+// filter the driver applies (empty → use the integration's configured tags;
+// tags_mode always comes from config).
 type FetchOpts struct {
 	Scope      string   // "recent+unread" | "unread" | "all" | ""
-	Tags       []string // OR filter override; empty = use config
+	Tags       []string // tag filter override; empty = use config
 	PublicOnly bool     // force-skip private bookmarks for this run
 	Force      bool     // bypass the source's cheap unchanged-since-last-run probe
 }
@@ -178,9 +179,14 @@ func pullSource(root string, src Source, opts FetchOpts, maxItems int, dryRun bo
 	}
 
 	skip := integrationSkipDomains(cfg, src.Name())
-	// OR tag filter: a per-run --tag override wins, else the integration's
-	// configured tags. Empty → keep everything the scope returned.
-	tagFilter := effectiveTags(opts.Tags, integrationTags(cfg, src.Name()))
+	// Tag filter: a per-run --tag override wins, else the integration's
+	// configured tags; tags_mode picks any-vs-all matching. Empty → keep
+	// everything the scope returned.
+	tagsMode, err := integrationTagsMode(cfg, src.Name())
+	if err != nil {
+		return 0, err
+	}
+	tagFilter := effectiveTags(opts.Tags, integrationTags(cfg, src.Name()), tagsMode)
 	// public_only: skip private bookmarks. --public-only forces it on for a run.
 	publicOnly := opts.PublicOnly || integrationPublicOnly(cfg, src.Name())
 	inbox := filepath.Join(root, "output", "inbox")
@@ -297,13 +303,29 @@ func integrationSkipDomains(cfg *ScribeConfig, name string) []string {
 	return cfg.Integrations[name].SkipDomains
 }
 
-// integrationTags returns the configured OR tag filter for an integration
+// integrationTags returns the configured tag filter for an integration
 // (empty when the block is absent).
 func integrationTags(cfg *ScribeConfig, name string) []string {
 	if cfg == nil || cfg.Integrations == nil {
 		return nil
 	}
 	return cfg.Integrations[name].Tags
+}
+
+// integrationTagsMode returns the validated tags_mode for an integration:
+// ""/"any" → at-least-one matching, "all" → every-tag matching. Any other
+// value is a config error — a typo silently widening an ingest filter would
+// be worse than failing loudly.
+func integrationTagsMode(cfg *ScribeConfig, name string) (string, error) {
+	if cfg == nil || cfg.Integrations == nil {
+		return "", nil
+	}
+	raw := cfg.Integrations[name].TagsMode
+	switch mode := strings.ToLower(strings.TrimSpace(raw)); mode {
+	case "", "any", "all":
+		return mode, nil
+	}
+	return "", fmt.Errorf("integrations.%s.tags_mode: unknown value %q (want any or all)", name, raw)
 }
 
 // integrationPublicOnly reports whether an integration is configured to skip
@@ -315,39 +337,51 @@ func integrationPublicOnly(cfg *ScribeConfig, name string) bool {
 	return cfg.Integrations[name].PublicOnly
 }
 
-// tagSet is a case-insensitive OR filter over item tags. An empty set allows
-// everything (no filtering).
-type tagSet map[string]bool
-
-func (ts tagSet) allows(itemTags []string) bool {
-	if len(ts) == 0 {
-		return true
-	}
-	for _, t := range itemTags {
-		if ts[strings.ToLower(strings.TrimSpace(t))] {
-			return true
-		}
-	}
-	return false
+// tagSet is a case-insensitive filter over item tags. An empty set allows
+// everything (no filtering). requireAll=false (tags_mode: any, the default)
+// passes an item carrying at least one listed tag; requireAll=true
+// (tags_mode: all) demands every listed tag, matching the narrowing
+// semantics of Pinboard's own /t:a/t:b/ URL filtering.
+type tagSet struct {
+	set        map[string]bool
+	requireAll bool
 }
 
-// effectiveTags builds the OR filter for a run: the per-run override wins over
-// the configured tags; empty either way disables filtering.
-func effectiveTags(override, configured []string) tagSet {
+func (ts tagSet) allows(itemTags []string) bool {
+	if len(ts.set) == 0 {
+		return true
+	}
+	matched := make(map[string]bool, len(ts.set))
+	for _, t := range itemTags {
+		t = strings.ToLower(strings.TrimSpace(t))
+		if ts.set[t] {
+			if !ts.requireAll {
+				return true
+			}
+			matched[t] = true
+		}
+	}
+	return ts.requireAll && len(matched) == len(ts.set)
+}
+
+// effectiveTags builds the tag filter for a run: the per-run override wins
+// over the configured tags; empty either way disables filtering. mode is the
+// integration's validated tags_mode (""/"any" = at-least-one, "all" = every).
+func effectiveTags(override, configured []string, mode string) tagSet {
 	src := override
 	if len(src) == 0 {
 		src = configured
 	}
 	if len(src) == 0 {
-		return nil
+		return tagSet{}
 	}
-	ts := make(tagSet, len(src))
+	set := make(map[string]bool, len(src))
 	for _, t := range src {
 		if t = strings.ToLower(strings.TrimSpace(t)); t != "" {
-			ts[t] = true
+			set[t] = true
 		}
 	}
-	return ts
+	return tagSet{set: set, requireAll: mode == "all"}
 }
 
 // --- CLI ---
@@ -359,7 +393,7 @@ type PullCmd struct {
 	Source     string   `arg:"" optional:"" help:"Integration to pull (e.g. pinboard). Omit to pull every configured integration."`
 	Scope      string   `help:"Override scope for this run: recent+unread|unread|all." enum:"recent+unread,unread,all," default:""`
 	AllHistory bool     `help:"Backfill the entire archive this run (≡ --scope all). Pair with --max on a first big pull." name:"all-history"`
-	Tag        []string `help:"Only ingest bookmarks carrying at least one of these tags (repeatable, OR). Overrides the integration's configured tags for this run."`
+	Tag        []string `help:"Only ingest bookmarks matching these tags (repeatable; any-vs-all per the integration's tags_mode, default any). Overrides the integration's configured tags for this run."`
 	PublicOnly bool     `help:"Skip private bookmarks for this run (forces public_only on)." name:"public-only"`
 	Force      bool     `help:"Bypass the source's cheap unchanged-since-last-run probe."`
 	Max        int      `help:"Cap items queued this run (0 = no limit). Useful to pace a first --all-history backfill." default:"0"`

--- a/cmd/scribe/source.go
+++ b/cmd/scribe/source.go
@@ -1,0 +1,409 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Source is an external provider of bookmark-like items that scribe pulls
+// incrementally and queues into output/inbox/ for the existing ingest-drain
+// path to fetch → contextualize → absorb. Deterministic, no LLM — the same
+// budget class as capture/triage/hook.
+//
+// Pinboard is the first implementation (source_pinboard.go). The interface is
+// deliberately narrow so future sources with different pagination models — a
+// timestamp cursor (Pinboard), a page token (GitHub stars), a last-id marker
+// (Reddit saved) — all fit without widening it: each owns its opaque cursor.
+type Source interface {
+	// Name is the registry key: state-file stem, provenance tag, log prefix.
+	Name() string
+	// Configured reports whether the source is enabled and credentialed. The
+	// reason explains a false result for the CLI/log (soft-skip, not an error).
+	Configured(cfg *ScribeConfig) (ok bool, reason string)
+	// Fetch returns fresh items given the opaque prior cursor, plus the cursor
+	// to persist for the next run. Implementations own their cursor shape and
+	// resolve their own config (scope defaults, token) off cfg. The OR tag
+	// filter and skip_domains are applied generically by the driver afterward.
+	Fetch(ctx context.Context, cfg *ScribeConfig, prev json.RawMessage, opts FetchOpts) (items []SourceItem, next json.RawMessage, err error)
+}
+
+// SourceItem is one normalized bookmark from any Source.
+type SourceItem struct {
+	URL       string
+	Title     string
+	Tags      []string
+	Note      string    // the user's own annotation → article body
+	CreatedAt time.Time // when the bookmark was saved (best-effort)
+	ID        string    // stable dedup key (provider hash; falls back to URL)
+	Unread    bool
+}
+
+// FetchOpts carries the per-run knobs a Source honors. Empty Scope means
+// "use the configured default". Tags is the per-run override of the OR tag
+// filter the driver applies (empty → use the integration's configured tags).
+type FetchOpts struct {
+	Scope string   // "recent+unread" | "unread" | "all" | ""
+	Tags  []string // OR filter override; empty = use config
+	Force bool     // bypass the source's cheap unchanged-since-last-run probe
+}
+
+// sourceRegistry maps integration name → adapter. Adding an adapter is one
+// entry here plus a file implementing Source.
+var sourceRegistry = map[string]Source{
+	"pinboard": pinboardSource{},
+}
+
+// registeredSources returns every adapter, sorted by name for stable output.
+func registeredSources() []Source {
+	out := make([]Source, 0, len(sourceRegistry))
+	for _, s := range sourceRegistry {
+		out = append(out, s)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name() < out[j].Name() })
+	return out
+}
+
+func sourceNames() []string {
+	out := make([]string, 0, len(sourceRegistry))
+	for name := range sourceRegistry {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// sourceState is the persisted per-source state under output/sources/<name>.json.
+// output/ is gitignored, so this per-machine cursor never lands in a shared KB.
+type sourceState struct {
+	Cursor   json.RawMessage `json:"cursor,omitempty"` // opaque, owned by the Source
+	Seen     []string        `json:"seen"`             // dedup IDs already queued
+	LastPull string          `json:"last_pull,omitempty"`
+}
+
+func sourceStatePath(root, name string) string {
+	return filepath.Join(root, "output", "sources", name+".json")
+}
+
+func loadSourceState(path string) (*sourceState, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &sourceState{}, nil
+		}
+		return nil, err
+	}
+	var st sourceState
+	if err := json.Unmarshal(data, &st); err != nil {
+		return nil, fmt.Errorf("parse state json: %w", err)
+	}
+	return &st, nil
+}
+
+func saveSourceState(path string, st *sourceState) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(st, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	return nil
+}
+
+// pullSource runs one adapter end-to-end: configured gate → load state →
+// fetch → dedup + skip-domains → write queue entries → persist state. Returns
+// the number of items queued. An unconfigured source is a soft-skip (0, nil):
+// `scribe pull` over every registered source must not fail because one lacks a
+// token. A per-source lock keeps a manual run and the cron run from racing the
+// state file.
+func pullSource(root string, src Source, opts FetchOpts, maxItems int, dryRun bool) (int, error) {
+	cfg := loadConfig(root)
+	if err := cfg.requireParseable(); err != nil {
+		return 0, err
+	}
+	if ok, reason := src.Configured(cfg); !ok {
+		logMsg("pull", "%s: skipped (%s)", src.Name(), reason)
+		return 0, nil
+	}
+
+	if !dryRun {
+		lockPath := lockPathFor(cfg.LockDir, "pull-"+src.Name(), root)
+		lf, ok, err := acquireLock(lockPath)
+		if err != nil {
+			return 0, fmt.Errorf("lock %s: %w", lockPath, err)
+		}
+		if !ok {
+			logMsg("pull", "%s: blocked by existing pull-%s lock", src.Name(), src.Name())
+			return 0, nil
+		}
+		defer releaseLock(lf)
+	}
+
+	statePath := sourceStatePath(root, src.Name())
+	state, err := loadSourceState(statePath)
+	if err != nil {
+		return 0, fmt.Errorf("load %s state: %w", src.Name(), err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	items, cursor, err := src.Fetch(ctx, cfg, state.Cursor, opts)
+	if err != nil {
+		return 0, fmt.Errorf("%s fetch: %w", src.Name(), err)
+	}
+
+	seen := make(map[string]bool, len(state.Seen))
+	for _, id := range state.Seen {
+		seen[id] = true
+	}
+
+	skip := integrationSkipDomains(cfg, src.Name())
+	// OR tag filter: a per-run --tag override wins, else the integration's
+	// configured tags. Empty → keep everything the scope returned.
+	tagFilter := effectiveTags(opts.Tags, integrationTags(cfg, src.Name()))
+	inbox := filepath.Join(root, "output", "inbox")
+
+	queued := 0
+	capped := false
+	for _, it := range items {
+		id := it.ID
+		if id == "" {
+			id = it.URL
+		}
+		if id == "" || seen[id] {
+			continue
+		}
+		if it.URL == "" || shouldSkipURL(it.URL, skip) {
+			// Don't mark skipped as seen — a later config change that drops
+			// the skip rule should let the item through (mirrors capture).
+			continue
+		}
+		if !tagFilter.allows(it.Tags) {
+			// Same reasoning as skip: not marked seen, so widening the filter
+			// later (or --force / --all-history) re-includes it.
+			continue
+		}
+		if maxItems > 0 && queued >= maxItems {
+			capped = true
+			break
+		}
+
+		if dryRun {
+			fmt.Printf("  WOULD QUEUE: %s (%s)\n", it.URL, it.Title)
+			seen[id] = true
+			queued++
+			continue
+		}
+
+		if _, err := writeQueueEntry(inbox, sourceItemToQueue(src.Name(), it)); err != nil {
+			logMsg("pull", "%s: queue %s failed: %v", src.Name(), it.URL, err)
+			continue
+		}
+		seen[id] = true
+		queued++
+	}
+
+	if dryRun {
+		suffix := ""
+		if capped {
+			suffix = fmt.Sprintf(" (capped at --max %d)", maxItems)
+		}
+		logMsg("pull", "%s: %d item(s) would be queued%s (dry-run, state unchanged)", src.Name(), queued, suffix)
+		return queued, nil
+	}
+
+	// Advance the cursor only on a complete pass. When --max capped the run,
+	// keeping the old cursor lets the next `pull … --all-history` resume the
+	// backfill (seen dedups what already went through) instead of the cheap
+	// unchanged-probe short-circuiting it away.
+	if !capped {
+		state.Cursor = cursor
+	}
+	state.Seen = sortedKeys(seen)
+	state.LastPull = time.Now().UTC().Format(time.RFC3339)
+	if err := saveSourceState(statePath, state); err != nil {
+		return queued, fmt.Errorf("save %s state: %w", src.Name(), err)
+	}
+
+	if capped {
+		logMsg("pull", "%s: queued %d new item(s); --max %d reached, re-run to continue backfill", src.Name(), queued, maxItems)
+	} else {
+		logMsg("pull", "%s: queued %d new item(s)", src.Name(), queued)
+	}
+	return queued, nil
+}
+
+// sourceItemToQueue maps a normalized item to the shared inbox queue format.
+// The source name becomes a provenance tag; unread items also get "to-read".
+func sourceItemToQueue(name string, it SourceItem) queueFields {
+	tags := append([]string(nil), it.Tags...)
+	if it.Unread && !containsFold(tags, "to-read") {
+		tags = append(tags, "to-read")
+	}
+	f := queueFields{
+		URL:    it.URL,
+		Title:  it.Title,
+		Tags:   tags,
+		Domain: "general",
+		Note:   it.Note,
+		Source: name,
+	}
+	if !it.CreatedAt.IsZero() {
+		f.QueuedAt = it.CreatedAt
+	}
+	return f
+}
+
+func containsFold(ss []string, want string) bool {
+	for _, s := range ss {
+		if strings.EqualFold(s, want) {
+			return true
+		}
+	}
+	return false
+}
+
+// integrationSkipDomains returns the skip_domains configured for an
+// integration (empty when the block is absent).
+func integrationSkipDomains(cfg *ScribeConfig, name string) []string {
+	if cfg == nil || cfg.Integrations == nil {
+		return nil
+	}
+	return cfg.Integrations[name].SkipDomains
+}
+
+// integrationTags returns the configured OR tag filter for an integration
+// (empty when the block is absent).
+func integrationTags(cfg *ScribeConfig, name string) []string {
+	if cfg == nil || cfg.Integrations == nil {
+		return nil
+	}
+	return cfg.Integrations[name].Tags
+}
+
+// tagSet is a case-insensitive OR filter over item tags. An empty set allows
+// everything (no filtering).
+type tagSet map[string]bool
+
+func (ts tagSet) allows(itemTags []string) bool {
+	if len(ts) == 0 {
+		return true
+	}
+	for _, t := range itemTags {
+		if ts[strings.ToLower(strings.TrimSpace(t))] {
+			return true
+		}
+	}
+	return false
+}
+
+// effectiveTags builds the OR filter for a run: the per-run override wins over
+// the configured tags; empty either way disables filtering.
+func effectiveTags(override, configured []string) tagSet {
+	src := override
+	if len(src) == 0 {
+		src = configured
+	}
+	if len(src) == 0 {
+		return nil
+	}
+	ts := make(tagSet, len(src))
+	for _, t := range src {
+		if t = strings.ToLower(strings.TrimSpace(t)); t != "" {
+			ts[t] = true
+		}
+	}
+	return ts
+}
+
+// --- CLI ---
+
+// PullCmd pulls bookmarks from configured integrations (Pinboard, …) into the
+// ingest queue. Bare `scribe pull` pulls every configured source — that is
+// what the pull-sources cron job runs.
+type PullCmd struct {
+	Source     string   `arg:"" optional:"" help:"Integration to pull (e.g. pinboard). Omit to pull every configured integration."`
+	Scope      string   `help:"Override scope for this run: recent+unread|unread|all." enum:"recent+unread,unread,all," default:""`
+	AllHistory bool     `help:"Backfill the entire archive this run (≡ --scope all). Pair with --max on a first big pull." name:"all-history"`
+	Tag        []string `help:"Only ingest bookmarks carrying at least one of these tags (repeatable, OR). Overrides the integration's configured tags for this run."`
+	Force      bool     `help:"Bypass the source's cheap unchanged-since-last-run probe."`
+	Max        int      `help:"Cap items queued this run (0 = no limit). Useful to pace a first --all-history backfill." default:"0"`
+	List       bool     `help:"List integrations and their status; pull nothing."`
+	DryRun     bool     `help:"Print what would be queued without writing." short:"n"`
+}
+
+func (c *PullCmd) Run() error {
+	root, err := kbDir()
+	if err != nil {
+		return err
+	}
+	if c.List {
+		return listIntegrations(root)
+	}
+
+	scope := c.Scope
+	if c.AllHistory {
+		scope = "all"
+	}
+	opts := FetchOpts{Scope: scope, Tags: c.Tag, Force: c.Force || c.AllHistory}
+
+	var srcs []Source
+	if c.Source != "" {
+		s, ok := sourceRegistry[c.Source]
+		if !ok {
+			return fmt.Errorf("unknown integration %q (known: %s)", c.Source, strings.Join(sourceNames(), ", "))
+		}
+		srcs = []Source{s}
+	} else {
+		srcs = registeredSources()
+	}
+
+	total := 0
+	var firstErr error
+	for _, s := range srcs {
+		n, err := pullSource(root, s, opts, c.Max, c.DryRun)
+		total += n
+		if err != nil {
+			logMsg("pull", "%s: %v", s.Name(), err)
+			if firstErr == nil {
+				firstErr = err
+			}
+		}
+	}
+	logMsg("pull", "done: %d item(s) queued across %d integration(s)", total, len(srcs))
+	return firstErr
+}
+
+// listIntegrations prints each registered adapter with whether it is
+// configured and when it last pulled.
+func listIntegrations(root string) error {
+	cfg := loadConfig(root)
+	for _, s := range registeredSources() {
+		status := "ready"
+		if ok, reason := s.Configured(cfg); !ok {
+			status = "not configured: " + reason
+		}
+		last := "never"
+		if st, err := loadSourceState(sourceStatePath(root, s.Name())); err == nil && st.LastPull != "" {
+			last = st.LastPull
+		}
+		fmt.Printf("%-12s  %-40s  last pull: %s\n", s.Name(), status, last)
+	}
+	return nil
+}

--- a/cmd/scribe/source.go
+++ b/cmd/scribe/source.go
@@ -42,15 +42,19 @@ type SourceItem struct {
 	CreatedAt time.Time // when the bookmark was saved (best-effort)
 	ID        string    // stable dedup key (provider hash; falls back to URL)
 	Unread    bool
+	// Private marks a non-public bookmark. Sources without a public/private
+	// notion leave it false, so the public_only filter is a no-op for them.
+	Private bool
 }
 
 // FetchOpts carries the per-run knobs a Source honors. Empty Scope means
 // "use the configured default". Tags is the per-run override of the OR tag
 // filter the driver applies (empty → use the integration's configured tags).
 type FetchOpts struct {
-	Scope string   // "recent+unread" | "unread" | "all" | ""
-	Tags  []string // OR filter override; empty = use config
-	Force bool     // bypass the source's cheap unchanged-since-last-run probe
+	Scope      string   // "recent+unread" | "unread" | "all" | ""
+	Tags       []string // OR filter override; empty = use config
+	PublicOnly bool     // force-skip private bookmarks for this run
+	Force      bool     // bypass the source's cheap unchanged-since-last-run probe
 }
 
 // sourceRegistry maps integration name → adapter. Adding an adapter is one
@@ -177,6 +181,8 @@ func pullSource(root string, src Source, opts FetchOpts, maxItems int, dryRun bo
 	// OR tag filter: a per-run --tag override wins, else the integration's
 	// configured tags. Empty → keep everything the scope returned.
 	tagFilter := effectiveTags(opts.Tags, integrationTags(cfg, src.Name()))
+	// public_only: skip private bookmarks. --public-only forces it on for a run.
+	publicOnly := opts.PublicOnly || integrationPublicOnly(cfg, src.Name())
 	inbox := filepath.Join(root, "output", "inbox")
 
 	queued := 0
@@ -197,6 +203,9 @@ func pullSource(root string, src Source, opts FetchOpts, maxItems int, dryRun bo
 		if !tagFilter.allows(it.Tags) {
 			// Same reasoning as skip: not marked seen, so widening the filter
 			// later (or --force / --all-history) re-includes it.
+			continue
+		}
+		if publicOnly && it.Private {
 			continue
 		}
 		if maxItems > 0 && queued >= maxItems {
@@ -297,6 +306,15 @@ func integrationTags(cfg *ScribeConfig, name string) []string {
 	return cfg.Integrations[name].Tags
 }
 
+// integrationPublicOnly reports whether an integration is configured to skip
+// private bookmarks.
+func integrationPublicOnly(cfg *ScribeConfig, name string) bool {
+	if cfg == nil || cfg.Integrations == nil {
+		return false
+	}
+	return cfg.Integrations[name].PublicOnly
+}
+
 // tagSet is a case-insensitive OR filter over item tags. An empty set allows
 // everything (no filtering).
 type tagSet map[string]bool
@@ -342,6 +360,7 @@ type PullCmd struct {
 	Scope      string   `help:"Override scope for this run: recent+unread|unread|all." enum:"recent+unread,unread,all," default:""`
 	AllHistory bool     `help:"Backfill the entire archive this run (≡ --scope all). Pair with --max on a first big pull." name:"all-history"`
 	Tag        []string `help:"Only ingest bookmarks carrying at least one of these tags (repeatable, OR). Overrides the integration's configured tags for this run."`
+	PublicOnly bool     `help:"Skip private bookmarks for this run (forces public_only on)." name:"public-only"`
 	Force      bool     `help:"Bypass the source's cheap unchanged-since-last-run probe."`
 	Max        int      `help:"Cap items queued this run (0 = no limit). Useful to pace a first --all-history backfill." default:"0"`
 	List       bool     `help:"List integrations and their status; pull nothing."`
@@ -361,7 +380,7 @@ func (c *PullCmd) Run() error {
 	if c.AllHistory {
 		scope = "all"
 	}
-	opts := FetchOpts{Scope: scope, Tags: c.Tag, Force: c.Force || c.AllHistory}
+	opts := FetchOpts{Scope: scope, Tags: c.Tag, PublicOnly: c.PublicOnly, Force: c.Force || c.AllHistory}
 
 	var srcs []Source
 	if c.Source != "" {

--- a/cmd/scribe/source.go
+++ b/cmd/scribe/source.go
@@ -3,7 +3,9 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -31,6 +33,23 @@ type Source interface {
 	// resolve their own config (scope defaults, token) off cfg. The tag
 	// filter and skip_domains are applied generically by the driver afterward.
 	Fetch(ctx context.Context, cfg *ScribeConfig, prev json.RawMessage, opts FetchOpts) (items []SourceItem, next json.RawMessage, err error)
+}
+
+// setupGuider is an optional Source extension behind `scribe pull <source>
+// --setup`: a guided one-time checklist for integrations whose setup spans
+// more than pasting a token. Implementations re-check each prerequisite in
+// dependency order, print a ✓/✗ line per step with the exact fix for the
+// first failure, and may end with one cheap live call to prove auth
+// end-to-end. Offline checks must come first so the network (and any meter)
+// is only touched once everything local passes.
+type setupGuider interface {
+	Setup(ctx context.Context, cfg *ScribeConfig, out io.Writer) error
+}
+
+// errSetupIncomplete keeps `pull --setup` honest for scripts: the checklist
+// text explains the fix; the non-zero exit reports that setup isn't done.
+func errSetupIncomplete(name string) error {
+	return fmt.Errorf("%s: setup incomplete — fix the ✗ step above and re-run", name)
 }
 
 // SourceItem is one normalized bookmark from any Source.
@@ -400,6 +419,7 @@ type PullCmd struct {
 	Max        int      `help:"Cap items queued this run (0 = no limit). Useful to pace a first --all-history backfill." default:"0"`
 	List       bool     `help:"List integrations and their status; pull nothing."`
 	DryRun     bool     `help:"Print what would be queued without writing." short:"n"`
+	Setup      bool     `help:"Guided one-time setup checklist for one integration: verifies each prerequisite, prints the exact fix for the first failure; pulls nothing."`
 }
 
 func (c *PullCmd) Run() error {
@@ -409,6 +429,9 @@ func (c *PullCmd) Run() error {
 	}
 	if c.List {
 		return listIntegrations(root)
+	}
+	if c.Setup {
+		return runSetup(root, c.Source)
 	}
 
 	scope := c.Scope
@@ -442,6 +465,26 @@ func (c *PullCmd) Run() error {
 	}
 	logMsg("pull", "done: %d item(s) queued across %d integration(s)", total, len(srcs))
 	return firstErr
+}
+
+// runSetup dispatches `pull <source> --setup` to the source's guided
+// checklist. Sources without one (Pinboard's setup is a single token) point
+// at the README instead.
+func runSetup(root, name string) error {
+	if name == "" {
+		return errors.New("--setup needs an integration name, e.g. `scribe pull x --setup`")
+	}
+	s, ok := sourceRegistry[name]
+	if !ok {
+		return fmt.Errorf("unknown integration %q (known: %s)", name, strings.Join(sourceNames(), ", "))
+	}
+	g, ok := s.(setupGuider)
+	if !ok {
+		return fmt.Errorf("%s has no guided setup — see the README's Pull integrations section", name)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	return g.Setup(ctx, loadConfig(root), os.Stdout)
 }
 
 // listIntegrations prints each registered adapter with whether it is

--- a/cmd/scribe/source_pinboard.go
+++ b/cmd/scribe/source_pinboard.go
@@ -1,0 +1,295 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// pinboardSource pulls bookmarks from the Pinboard v1 API
+// (https://api.pinboard.in/v1/). It is a URL producer only: it queues hrefs
+// (with title, tags, and the user's `extended` note) into output/inbox/ and
+// lets the existing ingest-drain path fetch the content. No page content is
+// fetched here, so the adapter stays deterministic and fast.
+//
+// Auth is an API token of the form `username:HEXTOKEN` (from
+// pinboard.in/settings/password), resolved via integrationToken("pinboard")
+// — env SCRIBE_PINBOARD_TOKEN or ~/.config/scribe/config.yaml, never the
+// committed scribe.yaml.
+//
+// Rate limits (Pinboard bans abusive clients): the cheap posts/update probe
+// gates every run, so an unchanged account costs one small request; posts/all
+// is capped server-side to once / 5 min and posts/recent to once / min, both
+// comfortably within an hourly cron cadence.
+type pinboardSource struct {
+	// baseURL overrides the API base in tests (httptest). Empty → production.
+	baseURL string
+}
+
+const pinboardAPIBase = "https://api.pinboard.in/v1/"
+
+func (p pinboardSource) Name() string { return "pinboard" }
+
+func (p pinboardSource) base() string {
+	if p.baseURL != "" {
+		return p.baseURL
+	}
+	return pinboardAPIBase
+}
+
+func (p pinboardSource) Configured(cfg *ScribeConfig) (bool, string) {
+	ic, ok := integrationConfig(cfg, "pinboard")
+	if !ok || !ic.Enabled {
+		return false, "not enabled (set integrations.pinboard.enabled: true in scribe.yaml)"
+	}
+	if integrationToken("pinboard") == "" {
+		return false, "no token (set SCRIBE_PINBOARD_TOKEN or integration_tokens.pinboard in ~/.config/scribe/config.yaml)"
+	}
+	if s := resolvePinboardScope(ic, FetchOpts{}); !validPinboardScope(s) {
+		return false, fmt.Sprintf("unknown scope %q (want recent+unread | unread | all)", s)
+	}
+	return true, ""
+}
+
+func validPinboardScope(s string) bool {
+	switch s {
+	case "recent+unread", "unread", "all":
+		return true
+	}
+	return false
+}
+
+// pinboardCursor is the opaque per-source cursor persisted between runs. It is
+// just the last-seen posts/update timestamp, which lets Fetch short-circuit
+// when nothing changed.
+type pinboardCursor struct {
+	UpdateTime string `json:"update_time"`
+}
+
+func (p pinboardSource) Fetch(ctx context.Context, cfg *ScribeConfig, prev json.RawMessage, opts FetchOpts) ([]SourceItem, json.RawMessage, error) {
+	token := integrationToken("pinboard")
+	if token == "" {
+		return nil, prev, errors.New("no token")
+	}
+	ic, _ := integrationConfig(cfg, "pinboard")
+	scope := resolvePinboardScope(ic, opts)
+	if !validPinboardScope(scope) {
+		return nil, prev, fmt.Errorf("unknown scope %q (want recent+unread | unread | all)", scope)
+	}
+
+	var cur pinboardCursor
+	if len(prev) > 0 {
+		_ = json.Unmarshal(prev, &cur)
+	}
+
+	// Cheap change-probe first. Short-circuit an unchanged account unless the
+	// caller forced a run or this is the first pull (no cursor yet).
+	upd, err := p.postsUpdate(ctx, token)
+	if err != nil {
+		return nil, prev, err
+	}
+	if !opts.Force && cur.UpdateTime != "" && upd != "" && upd == cur.UpdateTime {
+		return nil, prev, nil
+	}
+
+	posts, err := p.fetchPosts(ctx, token, scope)
+	if err != nil {
+		return nil, prev, err
+	}
+
+	items := make([]SourceItem, 0, len(posts))
+	for _, b := range posts {
+		if it, ok := b.toItem(); ok {
+			items = append(items, it)
+		}
+	}
+
+	next, err := json.Marshal(pinboardCursor{UpdateTime: upd})
+	if err != nil {
+		return nil, prev, fmt.Errorf("encode cursor: %w", err)
+	}
+	return items, next, nil
+}
+
+// resolvePinboardScope resolves the effective scope: a per-run override wins,
+// then the configured value, then the recent+unread default.
+func resolvePinboardScope(ic IntegrationConfig, opts FetchOpts) string {
+	return firstNonEmpty(opts.Scope, ic.Scope, "recent+unread")
+}
+
+// fetchPosts selects the endpoint(s) for a scope.
+//   - all:            posts/all (whole archive)
+//   - unread:         posts/all?toread=yes
+//   - recent+unread:  posts/recent (last 100) ∪ posts/all?toread=yes
+//
+// Tag filtering is NOT done here — Pinboard's server-side tag filter is AND
+// (and capped at 3 tags), while the user-facing filter is OR. The generic
+// driver applies the OR filter over SourceItem.Tags after the fetch, so the
+// behavior is identical for every adapter.
+//
+// The driver's seen-set dedups across runs, so re-returning already-queued
+// posts is harmless; only genuinely new hrefs get queued.
+func (p pinboardSource) fetchPosts(ctx context.Context, token, scope string) ([]pinboardPost, error) {
+	switch scope {
+	case "all":
+		return p.postsAll(ctx, token, url.Values{})
+	case "unread":
+		return p.postsAll(ctx, token, url.Values{"toread": {"yes"}})
+	case "recent+unread":
+		recent, err := p.postsRecent(ctx, token, 100)
+		if err != nil {
+			return nil, err
+		}
+		unread, err := p.postsAll(ctx, token, url.Values{"toread": {"yes"}})
+		if err != nil {
+			return nil, err
+		}
+		return mergePostsByHash(recent, unread), nil
+	default:
+		return nil, fmt.Errorf("unknown scope %q", scope)
+	}
+}
+
+// pinboardPost mirrors a bookmark object in the v1 JSON API.
+type pinboardPost struct {
+	Href        string `json:"href"`
+	Description string `json:"description"` // the title the user gave
+	Extended    string `json:"extended"`    // longer note / annotation
+	Tags        string `json:"tags"`        // space-separated
+	Time        string `json:"time"`        // ISO 8601
+	ToRead      string `json:"toread"`      // "yes" | "no"
+	Hash        string `json:"hash"`        // stable per-URL id
+}
+
+func (b pinboardPost) toItem() (SourceItem, bool) {
+	href := strings.TrimSpace(b.Href)
+	if href == "" {
+		return SourceItem{}, false
+	}
+	id := b.Hash
+	if id == "" {
+		id = href
+	}
+	ts, _ := time.Parse(time.RFC3339, b.Time) // zero on parse failure — fine
+	return SourceItem{
+		URL:       href,
+		Title:     strings.TrimSpace(b.Description),
+		Tags:      strings.Fields(b.Tags),
+		Note:      b.Extended,
+		CreatedAt: ts,
+		ID:        id,
+		Unread:    b.ToRead == "yes",
+	}, true
+}
+
+// mergePostsByHash unions bookmark lists, deduping on hash (href fallback),
+// preserving first-seen order.
+func mergePostsByHash(lists ...[]pinboardPost) []pinboardPost {
+	seen := map[string]bool{}
+	var out []pinboardPost
+	for _, list := range lists {
+		for _, b := range list {
+			key := b.Hash
+			if key == "" {
+				key = b.Href
+			}
+			if key == "" || seen[key] {
+				continue
+			}
+			seen[key] = true
+			out = append(out, b)
+		}
+	}
+	return out
+}
+
+// --- API calls ---
+
+func (p pinboardSource) postsUpdate(ctx context.Context, token string) (string, error) {
+	body, err := p.get(ctx, token, "posts/update", url.Values{})
+	if err != nil {
+		return "", err
+	}
+	var r struct {
+		UpdateTime string `json:"update_time"`
+	}
+	if err := json.Unmarshal(body, &r); err != nil {
+		return "", fmt.Errorf("posts/update decode: %w", err)
+	}
+	return r.UpdateTime, nil
+}
+
+func (p pinboardSource) postsAll(ctx context.Context, token string, q url.Values) ([]pinboardPost, error) {
+	body, err := p.get(ctx, token, "posts/all", q)
+	if err != nil {
+		return nil, err
+	}
+	var posts []pinboardPost
+	if err := json.Unmarshal(body, &posts); err != nil {
+		return nil, fmt.Errorf("posts/all decode: %w", err)
+	}
+	return posts, nil
+}
+
+func (p pinboardSource) postsRecent(ctx context.Context, token string, count int) ([]pinboardPost, error) {
+	body, err := p.get(ctx, token, "posts/recent", url.Values{"count": {strconv.Itoa(count)}})
+	if err != nil {
+		return nil, err
+	}
+	var r struct {
+		Posts []pinboardPost `json:"posts"`
+	}
+	if err := json.Unmarshal(body, &r); err != nil {
+		return nil, fmt.Errorf("posts/recent decode: %w", err)
+	}
+	return r.Posts, nil
+}
+
+// get issues one authenticated GET and returns the body. auth_token is kept
+// literal (its `username:HEX` colon is a legal query char per RFC 3986) so it
+// matches the documented form exactly; other params are URL-encoded.
+func (p pinboardSource) get(ctx context.Context, token, endpoint string, q url.Values) ([]byte, error) {
+	full := p.base() + endpoint + "?format=json&auth_token=" + token
+	if enc := q.Encode(); enc != "" {
+		full += "&" + enc
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, full, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "scribe-ingest/1.0")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("%s request: %w", endpoint, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return nil, fmt.Errorf("%s: rate limited (429) — try again later", endpoint)
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, fmt.Errorf("%s: unauthorized (401) — check the API token", endpoint)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%s: status %d", endpoint, resp.StatusCode)
+	}
+	// Guard against a runaway body; a full Pinboard archive is a few MB.
+	return io.ReadAll(io.LimitReader(resp.Body, 64<<20))
+}
+
+// firstNonEmpty returns the first non-empty string, or "".
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/cmd/scribe/source_pinboard.go
+++ b/cmd/scribe/source_pinboard.go
@@ -165,6 +165,7 @@ type pinboardPost struct {
 	Tags        string `json:"tags"`        // space-separated
 	Time        string `json:"time"`        // ISO 8601
 	ToRead      string `json:"toread"`      // "yes" | "no"
+	Shared      string `json:"shared"`      // "yes" (public) | "no" (private)
 	Hash        string `json:"hash"`        // stable per-URL id
 }
 
@@ -186,6 +187,9 @@ func (b pinboardPost) toItem() (SourceItem, bool) {
 		CreatedAt: ts,
 		ID:        id,
 		Unread:    b.ToRead == "yes",
+		// Pinboard omits `shared` in some payloads; treat only an explicit
+		// "no" as private so a missing field defaults to public (no over-skip).
+		Private: b.Shared == "no",
 	}, true
 }
 

--- a/cmd/scribe/source_pinboard_test.go
+++ b/cmd/scribe/source_pinboard_test.go
@@ -57,6 +57,7 @@ func TestPinboardToItem(t *testing.T) {
 		Tags:        "go  rust   elixir",
 		Time:        "2026-06-01T12:00:00Z",
 		ToRead:      "yes",
+		Shared:      "no",
 		Hash:        "abc123",
 	}
 	it, ok := post.toItem()
@@ -77,6 +78,9 @@ func TestPinboardToItem(t *testing.T) {
 	}
 	if !it.Unread {
 		t.Error("Unread = false, want true for toread=yes")
+	}
+	if !it.Private {
+		t.Error("Private = false, want true for shared=no")
 	}
 	if it.ID != "abc123" {
 		t.Errorf("ID = %q, want the hash", it.ID)

--- a/cmd/scribe/source_pinboard_test.go
+++ b/cmd/scribe/source_pinboard_test.go
@@ -1,0 +1,236 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// fakePinboard stands in for api.pinboard.in. It records how many times each
+// endpoint was hit so the short-circuit behavior is observable, and asserts
+// the auth token + format are passed on every call.
+func fakePinboard(t *testing.T, hits map[string]int) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	guard := func(next http.HandlerFunc) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("auth_token"); got != "user:TESTTOKEN" {
+				t.Errorf("auth_token = %q, want user:TESTTOKEN", got)
+			}
+			if got := r.URL.Query().Get("format"); got != "json" {
+				t.Errorf("format = %q, want json", got)
+			}
+			next(w, r)
+		}
+	}
+	mux.HandleFunc("/posts/update", guard(func(w http.ResponseWriter, _ *http.Request) {
+		hits["update"]++
+		io.WriteString(w, `{"update_time":"2026-07-01T10:00:00Z"}`)
+	}))
+	mux.HandleFunc("/posts/all", guard(func(w http.ResponseWriter, r *http.Request) {
+		hits["all"]++
+		if r.URL.Query().Get("toread") == "yes" {
+			io.WriteString(w, `[{"href":"https://u.com","description":"Unread","tags":"read-later","time":"2026-06-01T00:00:00Z","toread":"yes","hash":"h-unread"}]`)
+			return
+		}
+		io.WriteString(w, `[{"href":"https://a.com","description":"A","extended":"note a","tags":"go rust","time":"2026-06-01T00:00:00Z","toread":"no","hash":"h-a"}]`)
+	}))
+	mux.HandleFunc("/posts/recent", guard(func(w http.ResponseWriter, _ *http.Request) {
+		hits["recent"]++
+		io.WriteString(w, `{"posts":[{"href":"https://r.com","description":"R","tags":"","time":"2026-06-02T00:00:00Z","toread":"no","hash":"h-r"}]}`)
+	}))
+	return httptest.NewServer(mux)
+}
+
+func pinboardTestCfg() *ScribeConfig {
+	return &ScribeConfig{Integrations: IntegrationsConfig{"pinboard": {Enabled: true}}}
+}
+
+func TestPinboardToItem(t *testing.T) {
+	post := pinboardPost{
+		Href:        "https://example.com/x",
+		Description: "  Title  ",
+		Extended:    "my note",
+		Tags:        "go  rust   elixir",
+		Time:        "2026-06-01T12:00:00Z",
+		ToRead:      "yes",
+		Hash:        "abc123",
+	}
+	it, ok := post.toItem()
+	if !ok {
+		t.Fatal("toItem returned ok=false for a valid post")
+	}
+	if it.URL != "https://example.com/x" {
+		t.Errorf("URL = %q", it.URL)
+	}
+	if it.Title != "Title" {
+		t.Errorf("Title = %q, want trimmed", it.Title)
+	}
+	if it.Note != "my note" {
+		t.Errorf("Note = %q", it.Note)
+	}
+	if len(it.Tags) != 3 || it.Tags[0] != "go" || it.Tags[2] != "elixir" {
+		t.Errorf("Tags = %v, want [go rust elixir]", it.Tags)
+	}
+	if !it.Unread {
+		t.Error("Unread = false, want true for toread=yes")
+	}
+	if it.ID != "abc123" {
+		t.Errorf("ID = %q, want the hash", it.ID)
+	}
+	if it.CreatedAt.IsZero() {
+		t.Error("CreatedAt is zero, want parsed time")
+	}
+}
+
+func TestPinboardToItemEmptyHrefSkipped(t *testing.T) {
+	if _, ok := (pinboardPost{Href: "  "}).toItem(); ok {
+		t.Error("blank href should yield ok=false")
+	}
+}
+
+func TestPinboardToItemIDFallsBackToHref(t *testing.T) {
+	it, _ := pinboardPost{Href: "https://h.com"}.toItem()
+	if it.ID != "https://h.com" {
+		t.Errorf("ID = %q, want href fallback when hash empty", it.ID)
+	}
+}
+
+func TestMergePostsByHash(t *testing.T) {
+	a := []pinboardPost{{Href: "https://1", Hash: "h1"}, {Href: "https://2", Hash: "h2"}}
+	b := []pinboardPost{{Href: "https://2", Hash: "h2"}, {Href: "https://3", Hash: "h3"}}
+	got := mergePostsByHash(a, b)
+	if len(got) != 3 {
+		t.Fatalf("merged len = %d, want 3 (dedup h2)", len(got))
+	}
+	if got[0].Hash != "h1" || got[2].Hash != "h3" {
+		t.Errorf("order not preserved: %+v", got)
+	}
+}
+
+func TestPinboardFetchScopeAll(t *testing.T) {
+	t.Setenv("SCRIBE_PINBOARD_TOKEN", "user:TESTTOKEN")
+	hits := map[string]int{}
+	srv := fakePinboard(t, hits)
+	defer srv.Close()
+	p := pinboardSource{baseURL: srv.URL + "/"}
+
+	items, cur, err := p.Fetch(context.Background(), pinboardTestCfg(), nil, FetchOpts{Scope: "all"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(items) != 1 || items[0].ID != "h-a" {
+		t.Fatalf("items = %+v, want one h-a", items)
+	}
+	if hits["update"] != 1 || hits["all"] != 1 || hits["recent"] != 0 {
+		t.Errorf("hits = %v, want update=1 all=1 recent=0", hits)
+	}
+	var pc pinboardCursor
+	if err := json.Unmarshal(cur, &pc); err != nil || pc.UpdateTime != "2026-07-01T10:00:00Z" {
+		t.Errorf("cursor = %s (err %v), want update_time persisted", cur, err)
+	}
+}
+
+func TestPinboardUpdateShortCircuit(t *testing.T) {
+	t.Setenv("SCRIBE_PINBOARD_TOKEN", "user:TESTTOKEN")
+	hits := map[string]int{}
+	srv := fakePinboard(t, hits)
+	defer srv.Close()
+	p := pinboardSource{baseURL: srv.URL + "/"}
+
+	// Cursor already at the server's update_time → nothing changed.
+	prev, err := json.Marshal(pinboardCursor{UpdateTime: "2026-07-01T10:00:00Z"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	items, cur, err := p.Fetch(context.Background(), pinboardTestCfg(), prev, FetchOpts{Scope: "all"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(items) != 0 {
+		t.Errorf("items = %d, want 0 on unchanged account", len(items))
+	}
+	if hits["all"] != 0 {
+		t.Errorf("posts/all hit %d times, want 0 (short-circuit before the expensive call)", hits["all"])
+	}
+	if string(cur) != string(prev) {
+		t.Errorf("cursor changed on short-circuit: %s", cur)
+	}
+}
+
+func TestPinboardForceBypassesShortCircuit(t *testing.T) {
+	t.Setenv("SCRIBE_PINBOARD_TOKEN", "user:TESTTOKEN")
+	hits := map[string]int{}
+	srv := fakePinboard(t, hits)
+	defer srv.Close()
+	p := pinboardSource{baseURL: srv.URL + "/"}
+
+	prev, err := json.Marshal(pinboardCursor{UpdateTime: "2026-07-01T10:00:00Z"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	items, _, err := p.Fetch(context.Background(), pinboardTestCfg(), prev, FetchOpts{Scope: "all", Force: true})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(items) != 1 {
+		t.Errorf("items = %d, want 1 (force bypasses short-circuit)", len(items))
+	}
+	if hits["all"] != 1 {
+		t.Errorf("posts/all hit %d times, want 1", hits["all"])
+	}
+}
+
+func TestPinboardRecentUnreadUnions(t *testing.T) {
+	t.Setenv("SCRIBE_PINBOARD_TOKEN", "user:TESTTOKEN")
+	hits := map[string]int{}
+	srv := fakePinboard(t, hits)
+	defer srv.Close()
+	p := pinboardSource{baseURL: srv.URL + "/"}
+
+	items, _, err := p.Fetch(context.Background(), pinboardTestCfg(), nil, FetchOpts{Scope: "recent+unread"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("items = %d, want 2 (recent ∪ unread)", len(items))
+	}
+	if hits["recent"] != 1 || hits["all"] != 1 {
+		t.Errorf("hits = %v, want recent=1 all=1", hits)
+	}
+}
+
+func TestPinboardUnknownScopeErrors(t *testing.T) {
+	t.Setenv("SCRIBE_PINBOARD_TOKEN", "user:TESTTOKEN")
+	hits := map[string]int{}
+	srv := fakePinboard(t, hits)
+	defer srv.Close()
+	p := pinboardSource{baseURL: srv.URL + "/"}
+
+	if _, _, err := p.Fetch(context.Background(), pinboardTestCfg(), nil, FetchOpts{Scope: "bogus"}); err == nil {
+		t.Error("an unknown scope should error")
+	}
+}
+
+func TestPinboardConfiguredGates(t *testing.T) {
+	p := pinboardSource{}
+
+	// disabled
+	if ok, _ := p.Configured(&ScribeConfig{}); ok {
+		t.Error("Configured true with no integrations block")
+	}
+	// enabled but no token
+	t.Setenv("SCRIBE_PINBOARD_TOKEN", "")
+	cfg := &ScribeConfig{Integrations: IntegrationsConfig{"pinboard": {Enabled: true}}}
+	if ok, reason := p.Configured(cfg); ok || reason == "" {
+		t.Errorf("Configured should fail without a token, got ok=%v reason=%q", ok, reason)
+	}
+	// enabled + token
+	t.Setenv("SCRIBE_PINBOARD_TOKEN", "user:TESTTOKEN")
+	if ok, reason := p.Configured(cfg); !ok {
+		t.Errorf("Configured false with token present: %q", reason)
+	}
+}

--- a/cmd/scribe/source_test.go
+++ b/cmd/scribe/source_test.go
@@ -223,6 +223,49 @@ func TestPullSourceTagFilterOverride(t *testing.T) {
 	}
 }
 
+func TestPullSourcePublicOnly(t *testing.T) {
+	// public_only: true drops items marked Private; public items pass.
+	root := testKB(t, "integrations:\n  fake:\n    public_only: true\n")
+	src := &fakeSource{name: "fake", items: []SourceItem{
+		{URL: "https://pub.com", ID: "p", Title: "p"},
+		{URL: "https://priv.com", ID: "q", Title: "q", Private: true},
+	}}
+	n, err := pullSource(root, src, FetchOpts{}, 0, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("queued %d, want 1 (private dropped)", n)
+	}
+	files := inboxFiles(t, root)
+	if len(files) != 1 || !strings.Contains(files[0], "pub-com") {
+		t.Errorf("inbox = %v, want only the public entry", files)
+	}
+	// Private item is NOT marked seen (flipping public_only off re-includes it).
+	st, _ := loadSourceState(sourceStatePath(root, "fake"))
+	for _, id := range st.Seen {
+		if id == "q" {
+			t.Error("private item marked seen; should stay eligible")
+		}
+	}
+}
+
+func TestPullSourcePublicOnlyOverride(t *testing.T) {
+	// --public-only forces the filter on even when config leaves it false.
+	root := testKB(t, "")
+	src := &fakeSource{name: "fake", items: []SourceItem{
+		{URL: "https://pub.com", ID: "p", Title: "p"},
+		{URL: "https://priv.com", ID: "q", Title: "q", Private: true},
+	}}
+	n, err := pullSource(root, src, FetchOpts{PublicOnly: true}, 0, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("queued %d, want 1 (--public-only drops private)", n)
+	}
+}
+
 func TestPullSourceNoTagFilterKeepsAll(t *testing.T) {
 	root := testKB(t, "")
 	src := &fakeSource{name: "fake", items: []SourceItem{

--- a/cmd/scribe/source_test.go
+++ b/cmd/scribe/source_test.go
@@ -1,0 +1,348 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fakeSource is a deterministic Source for driver tests. It records how many
+// times Fetch ran so short-circuit/dedup behavior is observable.
+type fakeSource struct {
+	name       string
+	items      []SourceItem
+	cursor     string
+	fetchCount int
+}
+
+func (f *fakeSource) Name() string                            { return f.name }
+func (f *fakeSource) Configured(*ScribeConfig) (bool, string) { return true, "" }
+func (f *fakeSource) Fetch(_ context.Context, _ *ScribeConfig, _ json.RawMessage, _ FetchOpts) ([]SourceItem, json.RawMessage, error) {
+	f.fetchCount++
+	cur, err := json.Marshal(map[string]string{"c": f.cursor})
+	if err != nil {
+		return nil, nil, err
+	}
+	return f.items, cur, nil
+}
+
+// testKB writes a minimal scribe.yaml pointing lock_dir at an isolated temp
+// dir, so pullSource never touches the machine-wide /tmp lock the real cron
+// uses. Extra yaml lines let callers add an integrations block.
+func testKB(t *testing.T, extraYAML string) string {
+	t.Helper()
+	root := t.TempDir()
+	lockDir := t.TempDir()
+	yaml := "lock_dir: " + lockDir + "\n" + extraYAML
+	if err := os.WriteFile(filepath.Join(root, "scribe.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func inboxFiles(t *testing.T, root string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(filepath.Join(root, "output", "inbox"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		t.Fatal(err)
+	}
+	var out []string
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".url") {
+			out = append(out, e.Name())
+		}
+	}
+	return out
+}
+
+func item(url, id string) SourceItem { return SourceItem{URL: url, ID: id, Title: id} }
+
+func TestPullSourceQueuesAndDedups(t *testing.T) {
+	root := testKB(t, "")
+	src := &fakeSource{name: "fake", cursor: "v1", items: []SourceItem{
+		item("https://a.com", "a"),
+		item("https://b.com", "b"),
+		item("https://c.com", "c"),
+	}}
+
+	n, err := pullSource(root, src, FetchOpts{}, 0, false)
+	if err != nil {
+		t.Fatalf("pullSource: %v", err)
+	}
+	if n != 3 {
+		t.Fatalf("queued %d, want 3", n)
+	}
+	if got := inboxFiles(t, root); len(got) != 3 {
+		t.Fatalf("inbox has %d .url files, want 3: %v", len(got), got)
+	}
+
+	// State persisted: seen has all three, cursor advanced.
+	st, err := loadSourceState(sourceStatePath(root, "fake"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(st.Seen) != 3 {
+		t.Errorf("seen = %v, want 3 ids", st.Seen)
+	}
+	if len(st.Cursor) == 0 {
+		t.Error("cursor not persisted after a complete pass")
+	}
+	if st.LastPull == "" {
+		t.Error("last_pull not stamped")
+	}
+
+	// Second run with the same items → nothing new queued (dedup via seen).
+	n2, err := pullSource(root, src, FetchOpts{}, 0, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n2 != 0 {
+		t.Errorf("second run queued %d, want 0 (all seen)", n2)
+	}
+	if got := inboxFiles(t, root); len(got) != 3 {
+		t.Errorf("inbox grew to %d, want still 3", len(got))
+	}
+}
+
+func TestPullSourceMaxCapDoesNotAdvanceCursor(t *testing.T) {
+	root := testKB(t, "")
+	src := &fakeSource{name: "fake", cursor: "v1", items: []SourceItem{
+		item("https://1", "1"), item("https://2", "2"), item("https://3", "3"),
+		item("https://4", "4"), item("https://5", "5"),
+	}}
+
+	// Capped run: only 2 of 5 queued, cursor must NOT advance so a later
+	// backfill run resumes instead of being short-circuited away.
+	n, err := pullSource(root, src, FetchOpts{}, 2, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 2 {
+		t.Fatalf("queued %d, want 2 (capped)", n)
+	}
+	st, _ := loadSourceState(sourceStatePath(root, "fake"))
+	if len(st.Cursor) != 0 {
+		t.Errorf("cursor advanced on a capped run: %s", st.Cursor)
+	}
+	if len(st.Seen) != 2 {
+		t.Errorf("seen = %v, want the 2 queued ids", st.Seen)
+	}
+
+	// Uncapped follow-up queues the remaining 3 and advances the cursor.
+	n2, err := pullSource(root, src, FetchOpts{}, 0, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n2 != 3 {
+		t.Fatalf("follow-up queued %d, want 3", n2)
+	}
+	st2, _ := loadSourceState(sourceStatePath(root, "fake"))
+	if len(st2.Cursor) == 0 {
+		t.Error("cursor not advanced after a complete pass")
+	}
+	if len(st2.Seen) != 5 {
+		t.Errorf("seen = %v, want all 5", st2.Seen)
+	}
+}
+
+func TestPullSourceSkipDomains(t *testing.T) {
+	root := testKB(t, "integrations:\n  fake:\n    skip_domains: [\"skip.com\"]\n")
+	src := &fakeSource{name: "fake", items: []SourceItem{
+		item("https://keep.com/x", "k"),
+		item("https://skip.com/y", "s"),
+	}}
+	n, err := pullSource(root, src, FetchOpts{}, 0, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("queued %d, want 1 (skip.com filtered)", n)
+	}
+	files := inboxFiles(t, root)
+	if len(files) != 1 || !strings.Contains(files[0], "keep-com") {
+		t.Errorf("inbox = %v, want only the keep.com entry", files)
+	}
+	// Skipped item is NOT marked seen (a later config change may allow it).
+	st, _ := loadSourceState(sourceStatePath(root, "fake"))
+	for _, id := range st.Seen {
+		if id == "s" {
+			t.Error("skipped item marked seen; should stay eligible")
+		}
+	}
+}
+
+func taggedItem(url, id string, tags ...string) SourceItem {
+	return SourceItem{URL: url, ID: id, Title: id, Tags: tags}
+}
+
+func TestPullSourceTagFilterFromConfig(t *testing.T) {
+	// OR filter: keep bookmarks carrying at least one configured tag, case-
+	// insensitively; drop the rest; untagged config ingests all.
+	root := testKB(t, "integrations:\n  fake:\n    tags: [\"kb\", \"read\"]\n")
+	src := &fakeSource{name: "fake", items: []SourceItem{
+		taggedItem("https://a.com", "a", "go", "KB"),  // has kb (case-insensitive) → keep
+		taggedItem("https://b.com", "b", "rust"),      // no match → drop
+		taggedItem("https://c.com", "c", "read", "x"), // has read → keep
+		taggedItem("https://d.com", "d"),              // no tags → drop
+	}}
+	n, err := pullSource(root, src, FetchOpts{}, 0, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 2 {
+		t.Fatalf("queued %d, want 2 (a and c)", n)
+	}
+	st, _ := loadSourceState(sourceStatePath(root, "fake"))
+	// Filtered-out items are NOT marked seen (widening the filter re-includes).
+	for _, id := range st.Seen {
+		if id == "b" || id == "d" {
+			t.Errorf("filtered item %q marked seen; should stay eligible", id)
+		}
+	}
+}
+
+func TestPullSourceTagFilterOverride(t *testing.T) {
+	// A per-run --tag override (FetchOpts.Tags) wins over the configured tags.
+	root := testKB(t, "integrations:\n  fake:\n    tags: [\"kb\"]\n")
+	src := &fakeSource{name: "fake", items: []SourceItem{
+		taggedItem("https://a.com", "a", "kb"),
+		taggedItem("https://b.com", "b", "elixir"),
+	}}
+	n, err := pullSource(root, src, FetchOpts{Tags: []string{"elixir"}}, 0, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("queued %d, want 1 (override selects elixir, not kb)", n)
+	}
+}
+
+func TestPullSourceNoTagFilterKeepsAll(t *testing.T) {
+	root := testKB(t, "")
+	src := &fakeSource{name: "fake", items: []SourceItem{
+		taggedItem("https://a.com", "a", "go"),
+		taggedItem("https://b.com", "b"),
+	}}
+	n, err := pullSource(root, src, FetchOpts{}, 0, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 2 {
+		t.Fatalf("queued %d, want 2 (no filter = all)", n)
+	}
+}
+
+func TestPullSourceDryRunWritesNothing(t *testing.T) {
+	root := testKB(t, "")
+	src := &fakeSource{name: "fake", items: []SourceItem{item("https://a.com", "a")}}
+	n, err := pullSource(root, src, FetchOpts{}, 0, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Errorf("dry-run reported %d would-queue, want 1", n)
+	}
+	if got := inboxFiles(t, root); len(got) != 0 {
+		t.Errorf("dry-run wrote %d files, want 0", len(got))
+	}
+	if _, err := os.Stat(sourceStatePath(root, "fake")); !os.IsNotExist(err) {
+		t.Error("dry-run wrote a state file, want none")
+	}
+}
+
+func TestSourceItemToQueue(t *testing.T) {
+	it := SourceItem{
+		URL:    "https://x.com",
+		Title:  "X",
+		Tags:   []string{"go"},
+		Note:   "annotation",
+		Unread: true,
+	}
+	f := sourceItemToQueue("pinboard", it)
+	if f.Source != "pinboard" {
+		t.Errorf("Source = %q", f.Source)
+	}
+	if f.Note != "annotation" {
+		t.Errorf("Note = %q", f.Note)
+	}
+	if !containsFold(f.Tags, "to-read") {
+		t.Errorf("Tags = %v, want to-read added for unread", f.Tags)
+	}
+	if f.Domain != "general" {
+		t.Errorf("Domain = %q, want general", f.Domain)
+	}
+}
+
+func TestQueueNoteRoundTrip(t *testing.T) {
+	cases := []string{
+		"single line",
+		"line one\nline two",
+		"has a \\ backslash",
+		"windows\r\nnewline",
+		"",
+	}
+	for _, in := range cases {
+		got := decodeQueueNote(encodeQueueNote(in))
+		want := strings.ReplaceAll(in, "\r\n", "\n")
+		if got != want {
+			t.Errorf("roundtrip(%q) = %q, want %q", in, got, want)
+		}
+		if strings.Contains(encodeQueueNote(in), "\n") {
+			t.Errorf("encoded note still contains a raw newline: %q", encodeQueueNote(in))
+		}
+	}
+}
+
+func TestQueueNoteBlockquote(t *testing.T) {
+	got := queueNoteBlockquote("first\nsecond")
+	if got != "> first\n> second" {
+		t.Errorf("blockquote = %q", got)
+	}
+}
+
+func TestWriteQueueEntryRoundTripsNoteAndSource(t *testing.T) {
+	inbox := t.TempDir()
+	path, err := writeQueueEntry(inbox, queueFields{
+		URL:    "https://x.com",
+		Title:  "X",
+		Tags:   []string{"go", "pinboard"},
+		Note:   "line one\nline two",
+		Source: "pinboard",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry := parseQueueEntry(string(data))
+	if entry["url"] != "https://x.com" || entry["source"] != "pinboard" {
+		t.Errorf("parsed entry missing fields: %v", entry)
+	}
+	if decodeQueueNote(entry["note"]) != "line one\nline two" {
+		t.Errorf("note did not round-trip: %q", entry["note"])
+	}
+}
+
+func TestWriteQueueEntryUniquePaths(t *testing.T) {
+	inbox := t.TempDir()
+	// Same URL twice → the second must not overwrite the first.
+	p1, err := writeQueueEntry(inbox, queueFields{URL: "https://x.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	p2, err := writeQueueEntry(inbox, queueFields{URL: "https://x.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p1 == p2 {
+		t.Errorf("both entries wrote to %s; expected disambiguated paths", p1)
+	}
+}

--- a/cmd/scribe/source_test.go
+++ b/cmd/scribe/source_test.go
@@ -223,6 +223,37 @@ func TestPullSourceTagFilterOverride(t *testing.T) {
 	}
 }
 
+func TestPullSourceTagsModeAll(t *testing.T) {
+	// tags_mode: all flips the filter to AND — only bookmarks carrying EVERY
+	// configured tag pass (Pinboard's own /t:a/t:b/ semantics), still
+	// case-insensitively.
+	root := testKB(t, "integrations:\n  fake:\n    tags: [\"elixir\", \"concurrency\"]\n    tags_mode: all\n")
+	src := &fakeSource{name: "fake", items: []SourceItem{
+		taggedItem("https://a.com", "a", "Elixir", "concurrency"), // both → keep
+		taggedItem("https://b.com", "b", "elixir"),                // one of two → drop
+		taggedItem("https://c.com", "c", "concurrency", "otp"),    // one of two → drop
+		taggedItem("https://d.com", "d"),                          // none → drop
+	}}
+	n, err := pullSource(root, src, FetchOpts{}, 0, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("queued %d, want 1 (only a carries both tags)", n)
+	}
+}
+
+func TestPullSourceTagsModeInvalid(t *testing.T) {
+	// A typo in tags_mode must fail loudly, not silently widen the filter.
+	root := testKB(t, "integrations:\n  fake:\n    tags: [\"kb\"]\n    tags_mode: sometimes\n")
+	src := &fakeSource{name: "fake", items: []SourceItem{
+		taggedItem("https://a.com", "a", "kb"),
+	}}
+	if _, err := pullSource(root, src, FetchOpts{}, 0, false); err == nil || !strings.Contains(err.Error(), "tags_mode") {
+		t.Fatalf("err = %v, want a tags_mode config error", err)
+	}
+}
+
 func TestPullSourcePublicOnly(t *testing.T) {
 	// public_only: true drops items marked Private; public items pass.
 	root := testKB(t, "integrations:\n  fake:\n    public_only: true\n")

--- a/cmd/scribe/source_x.go
+++ b/cmd/scribe/source_x.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/url"
 	"os"
 	"os/exec"
@@ -75,6 +76,62 @@ func (x xSource) Configured(cfg *ScribeConfig) (bool, string) {
 		}
 	}
 	return true, ""
+}
+
+// Setup is the guided checklist behind `scribe pull x --setup`. X is the one
+// integration whose setup spans a developer account, an OAuth app, prepaid
+// billing, and a separate CLI — this re-checks each prerequisite in
+// dependency order, prints the exact fix for the first failing step, and
+// finishes with a single live /2/users/me call (one owned read, ~$0.001) to
+// prove auth end-to-end. Offline checks run first so the network — and the
+// meter — is only touched once everything local passes.
+func (x xSource) Setup(ctx context.Context, cfg *ScribeConfig, out io.Writer) error {
+	if ic, ok := integrationConfig(cfg, "x"); !ok || !ic.Enabled {
+		fmt.Fprintln(out, "✗ integrations.x is not enabled — add to scribe.yaml:")
+		fmt.Fprintln(out, "      integrations:")
+		fmt.Fprintln(out, "        x:")
+		fmt.Fprintln(out, "          enabled: true")
+		return errSetupIncomplete("x")
+	}
+	fmt.Fprintln(out, "✓ integrations.x.enabled in scribe.yaml")
+
+	if _, err := exec.LookPath("xurl"); err != nil {
+		fmt.Fprintln(out, "✗ xurl not on PATH — install X's official API CLI:")
+		fmt.Fprintln(out, "      brew install --cask xdevplatform/tap/xurl")
+		fmt.Fprintln(out, "      # or: go install github.com/xdevplatform/xurl@latest")
+		return errSetupIncomplete("x")
+	}
+	fmt.Fprintln(out, "✓ xurl on PATH")
+
+	if home, err := os.UserHomeDir(); err == nil {
+		if _, statErr := os.Stat(filepath.Join(home, ".xurl")); statErr != nil {
+			fmt.Fprintln(out, "✗ no ~/.xurl — xurl has never authenticated. One-time setup:")
+			fmt.Fprintln(out, "    1. developer.x.com → create a Project + App; in the app's user")
+			fmt.Fprintln(out, "       authentication settings enable OAuth 2.0, redirect URI")
+			fmt.Fprintln(out, "       http://localhost:8080/callback, scopes bookmark.read")
+			fmt.Fprintln(out, "       tweet.read users.read offline.access")
+			fmt.Fprintln(out, "    2. add a few dollars of prepaid credit (reads bill $0.001 each)")
+			fmt.Fprintln(out, "    3. xurl auth apps add scribe --client-id YOUR_ID --client-secret YOUR_SECRET")
+			fmt.Fprintln(out, "    4. xurl auth oauth2 --app scribe   # one-time browser consent")
+			return errSetupIncomplete("x")
+		}
+		fmt.Fprintln(out, "✓ ~/.xurl present (xurl has authenticated before)")
+	}
+
+	fmt.Fprintln(out, "→ live check: GET /2/users/me (one owned read, ~$0.001)")
+	body, err := x.get(ctx, "/2/users/me")
+	if err != nil {
+		fmt.Fprintf(out, "✗ live check failed: %v\n", err)
+		return errSetupIncomplete("x")
+	}
+	var resp xUserResponse
+	if err := json.Unmarshal(body, &resp); err != nil || resp.Data.ID == "" {
+		fmt.Fprintf(out, "✗ live check returned no user object (decode error: %v)\n", err)
+		return errSetupIncomplete("x")
+	}
+	fmt.Fprintf(out, "✓ authenticated as @%s (id %s)\n", resp.Data.Username, resp.Data.ID)
+	fmt.Fprintln(out, "ready — next: scribe pull x -n   # dry-run: shows what would be queued")
+	return nil
 }
 
 // xCursor is the opaque per-source cursor persisted between runs. user_id is

--- a/cmd/scribe/source_x.go
+++ b/cmd/scribe/source_x.go
@@ -1,0 +1,340 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// xSource pulls the authenticated user's X/Twitter bookmarks via the official
+// v2 API. Like Pinboard it is a URL producer only: it queues tweet permalinks
+// (with the tweet text as title + note) into output/inbox/ and lets the
+// existing ingest-drain path fetch the content — scribe's fetch cascade already
+// has an fxtwitter tier that renders x.com URLs, so no page content is fetched
+// here and the adapter stays deterministic.
+//
+// Transport is the official `xurl` CLI (github.com/xdevplatform/xurl), which
+// owns the whole OAuth 2.0 PKCE dance — browser flow, token storage in
+// ~/.xurl, auto-refresh. scribe never implements OAuth or stores X tokens, and
+// no new Go dependency is added (exec-only), matching the repo's "prefer
+// shelling out to optional tools" convention.
+//
+// Cost model: owned reads are billed $0.001/resource, so a page of 100 costs
+// $0.10. A cheap max_results=1 probe gates every run (unchanged newest id ⇒
+// $0.001 no-op), and a hard 9-page cap bounds a full pull to the API's
+// documented ~800-bookmark reachable window.
+type xSource struct{}
+
+func (x xSource) Name() string { return "x" }
+
+// xurlRun executes `xurl <path>` and returns its stdout. It is a package
+// variable (mirroring the newLLMProvider seam in llm.go) purely so tests can
+// stub the transport without a real xurl binary or network; production code
+// never reassigns it. On a non-zero exit the returned error carries xurl's
+// stderr so auth/scope problems surface to the caller.
+var xurlRun = func(ctx context.Context, path string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "xurl", path)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		if msg := strings.TrimSpace(stderr.String()); msg != "" {
+			return nil, fmt.Errorf("%w: %s", err, msg)
+		}
+		return nil, err
+	}
+	return out, nil
+}
+
+func (x xSource) Configured(cfg *ScribeConfig) (bool, string) {
+	ic, ok := integrationConfig(cfg, "x")
+	if !ok || !ic.Enabled {
+		return false, "not enabled (set integrations.x.enabled: true in scribe.yaml)"
+	}
+	// No token check — xurl owns auth. A network probe would cost money, so
+	// Configured stays offline: PATH presence is the gate, an auth failure
+	// surfaces at Fetch time with the re-auth hint.
+	if _, err := exec.LookPath("xurl"); err != nil {
+		return false, "xurl not on PATH — brew install --cask xdevplatform/tap/xurl, then `xurl auth oauth2` (see README)"
+	}
+	// Cheap offline auth check: xurl keeps its tokens under ~/.xurl, so its
+	// absence means `xurl auth oauth2` was never run — soft-skip with the hint
+	// instead of hard-failing every cron pull at Fetch time. (An expired token
+	// still surfaces at Fetch; presence is all that's checkable for free.)
+	if home, err := os.UserHomeDir(); err == nil {
+		if _, err := os.Stat(filepath.Join(home, ".xurl")); err != nil {
+			return false, "xurl is not authenticated (no ~/.xurl) — run `xurl auth oauth2` (see README)"
+		}
+	}
+	return true, ""
+}
+
+// xCursor is the opaque per-source cursor persisted between runs. user_id is
+// resolved once and cached (saves a /2/users/me call per run); newest_id is the
+// id of the most recent bookmark seen last run, used both for the cheap probe
+// and the stop-on-seen boundary during pagination.
+type xCursor struct {
+	UserID   string `json:"user_id"`
+	NewestID string `json:"newest_id"`
+}
+
+// xMaxBookmarkPages caps a single run at 9 pages of 100 (~800 bookmarks, the
+// API's documented reachable depth). This is the money guard: each resource
+// read is billed and a buggy/looping next_token could otherwise page forever,
+// so the loop hard-stops here regardless of what the server returns.
+const xMaxBookmarkPages = 9
+
+func (x xSource) Fetch(ctx context.Context, _ *ScribeConfig, prev json.RawMessage, opts FetchOpts) ([]SourceItem, json.RawMessage, error) {
+	var cur xCursor
+	if len(prev) > 0 {
+		_ = json.Unmarshal(prev, &cur) // tolerant: a malformed cursor re-resolves
+	}
+
+	// Resolve + cache the user id once. /2/users/me is a fixed, cheap call and
+	// the id never changes, so later runs skip it.
+	if cur.UserID == "" {
+		id, err := x.resolveUserID(ctx)
+		if err != nil {
+			return nil, prev, err
+		}
+		cur.UserID = id
+	}
+
+	// Cheap probe (cost guard): fetch a single bookmark. Bookmarks are LIFO, so
+	// if the newest id is unchanged since last run nothing was added — bail for
+	// ~$0.001. Skipped on the first run (no newest_id yet) and under --force.
+	// The probe is purely a cost optimization, so any probe failure degrades to
+	// the full walk instead of failing the run — e.g. if the endpoint rejects
+	// max_results=1 (minimum page size unverified), the 100-per-page walk still
+	// works and stops at the boundary after one page. Real failures (auth,
+	// network) repeat identically in the walk and surface there.
+	if !opts.Force && cur.NewestID != "" {
+		probe, err := x.fetchBookmarksPage(ctx, cur.UserID, "", 1)
+		switch {
+		case err != nil:
+			logMsg("pull", "x: probe failed (%v) — falling back to a full page walk", err)
+		case len(probe.Data) > 0 && probe.Data[0].ID == cur.NewestID:
+			next, err := json.Marshal(cur)
+			if err != nil {
+				return nil, prev, fmt.Errorf("x: encode cursor: %w", err)
+			}
+			return nil, next, nil
+		}
+	}
+
+	// Full incremental pull: page newest→oldest, stopping at the known id.
+	items, newestID, more, err := x.collect(ctx, cur.UserID, cur.NewestID)
+	if err != nil {
+		return nil, prev, err
+	}
+	switch {
+	case more && cur.NewestID != "":
+		// The page cap ended the walk before the previous boundary was
+		// reached: everything between the cap and the old newest_id was never
+		// fetched. Advancing the cursor would skip that gap forever (the probe
+		// would short-circuit every later run), so keep the old boundary — the
+		// next run re-pages and the driver's seen-set absorbs the overlap.
+		// Mirrors the driver's own refusal to advance a capped run's cursor.
+		logMsg("pull", "x: %d-page cap hit before reaching the previous boundary — cursor not advanced, next run re-pages", xMaxBookmarkPages)
+	case newestID != "":
+		cur.NewestID = newestID
+	}
+	next, err := json.Marshal(cur)
+	if err != nil {
+		return nil, prev, fmt.Errorf("x: encode cursor: %w", err)
+	}
+	return items, next, nil
+}
+
+// collect pages bookmarks front-to-back, collecting items until it reaches the
+// known id (everything at/after it was queued on a prior run — the driver's
+// seen-set dedups the small overlap window too) or runs out of pages. The
+// newest id seen this run is returned to become the next cursor. The page loop
+// is hard-capped at xMaxBookmarkPages so a runaway next_token can't rack up
+// per-read cost; more=true reports that the cap fired while the server still
+// offered a next page, so the caller knows the walk has an unfetched gap and
+// must not advance its boundary across it.
+func (x xSource) collect(ctx context.Context, userID, knownID string) (items []SourceItem, newestID string, more bool, err error) {
+	token := ""
+	for range xMaxBookmarkPages {
+		resp, err := x.fetchBookmarksPage(ctx, userID, token, 100)
+		if err != nil {
+			return nil, "", false, err
+		}
+		users := usernameIndex(resp.Includes.Users)
+		for _, tw := range resp.Data {
+			if tw.ID == "" {
+				continue // malformed row: no id means no permalink, nothing to queue
+			}
+			if newestID == "" {
+				newestID = tw.ID // first (newest) bookmark seen this run
+			}
+			if knownID != "" && tw.ID == knownID {
+				return items, newestID, false, nil // boundary reached; rest is already seen
+			}
+			items = append(items, tw.toItem(users))
+		}
+		token = resp.Meta.NextToken
+		if token == "" {
+			return items, newestID, false, nil // no more pages
+		}
+	}
+	return items, newestID, true, nil // cap fired with a live next_token
+}
+
+// resolveUserID fetches the authenticated user's numeric id via /2/users/me.
+func (x xSource) resolveUserID(ctx context.Context) (string, error) {
+	body, err := x.get(ctx, "/2/users/me")
+	if err != nil {
+		return "", err
+	}
+	var resp xUserResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return "", fmt.Errorf("x: decode /2/users/me: %w", err)
+	}
+	if resp.Data.ID == "" {
+		return "", errors.New("x: /2/users/me returned no user id")
+	}
+	return resp.Data.ID, nil
+}
+
+// fetchBookmarksPage fetches one page of bookmarks. expansions=author_id plus
+// user.fields=username let each tweet's permalink use the author handle;
+// tweet.fields=created_at carries the tweet's post time (the API doesn't
+// expose when the bookmark was saved) and entities carries the tweet's
+// #hashtags, which become the item's Tags so the driver's OR tag filter has
+// something real to match against.
+func (x xSource) fetchBookmarksPage(ctx context.Context, userID, paginationToken string, maxResults int) (xBookmarksResponse, error) {
+	path := fmt.Sprintf("/2/users/%s/bookmarks?max_results=%d&expansions=author_id&tweet.fields=created_at,entities&user.fields=username", url.PathEscape(userID), maxResults)
+	if paginationToken != "" {
+		path += "&pagination_token=" + url.QueryEscape(paginationToken)
+	}
+	body, err := x.get(ctx, path)
+	if err != nil {
+		return xBookmarksResponse{}, err
+	}
+	var resp xBookmarksResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return xBookmarksResponse{}, fmt.Errorf("x: decode bookmarks page: %w", err)
+	}
+	return resp, nil
+}
+
+// get issues one xurl GET and returns the response body, wrapping failures with
+// the endpoint path. An authentication failure appends the re-auth hint so a
+// stale/absent token has an actionable fix.
+func (x xSource) get(ctx context.Context, path string) ([]byte, error) {
+	out, err := xurlRun(ctx, path)
+	if err != nil {
+		if mentionsAuth(err.Error()) {
+			return nil, fmt.Errorf("x: xurl %s: %w — run `xurl auth oauth2` to (re)authenticate", path, err)
+		}
+		return nil, fmt.Errorf("x: xurl %s: %w", path, err)
+	}
+	return out, nil
+}
+
+// mentionsAuth reports whether an xurl error looks like an authentication
+// failure (stale/missing token), so get can attach the re-auth hint.
+func mentionsAuth(s string) bool {
+	s = strings.ToLower(s)
+	return strings.Contains(s, "authenticat") || strings.Contains(s, "unauthorized") || strings.Contains(s, "401")
+}
+
+// --- response envelopes (tolerant: missing fields decode to zero, never panic) ---
+
+// xUserResponse is the /2/users/me envelope. Only the id is used.
+type xUserResponse struct {
+	Data struct {
+		ID       string `json:"id"`
+		Username string `json:"username"`
+	} `json:"data"`
+}
+
+// xBookmarksResponse is the /2/users/:id/bookmarks envelope.
+type xBookmarksResponse struct {
+	Data     []xTweet `json:"data"`
+	Includes struct {
+		Users []xUser `json:"users"`
+	} `json:"includes"`
+	Meta struct {
+		NextToken   string `json:"next_token"`
+		ResultCount int    `json:"result_count"`
+	} `json:"meta"`
+}
+
+type xTweet struct {
+	ID        string `json:"id"`
+	Text      string `json:"text"`
+	AuthorID  string `json:"author_id"`
+	CreatedAt string `json:"created_at"`
+	Entities  struct {
+		Hashtags []struct {
+			Tag string `json:"tag"`
+		} `json:"hashtags"`
+	} `json:"entities"`
+}
+
+type xUser struct {
+	ID       string `json:"id"`
+	Username string `json:"username"`
+}
+
+// usernameIndex maps author id → username from includes.users so a tweet's
+// permalink can use the handle; ids absent from the block fall back to /i/.
+func usernameIndex(users []xUser) map[string]string {
+	idx := make(map[string]string, len(users))
+	for _, u := range users {
+		if u.ID != "" {
+			idx[u.ID] = u.Username
+		}
+	}
+	return idx
+}
+
+func (t xTweet) toItem(users map[string]string) SourceItem {
+	permalink := "https://x.com/i/status/" + t.ID
+	if h := users[t.AuthorID]; h != "" {
+		permalink = "https://x.com/" + h + "/status/" + t.ID
+	}
+	created, _ := time.Parse(time.RFC3339, t.CreatedAt) // zero on parse failure — fine
+	// The tweet's #hashtags are the only tag-like signal a bookmark carries;
+	// surfacing them as Tags is what makes a configured integrations.x.tags
+	// filter match anything at all (the driver filters on Tags before queueing).
+	var tags []string
+	for _, h := range t.Entities.Hashtags {
+		if h.Tag != "" {
+			tags = append(tags, h.Tag)
+		}
+	}
+	return SourceItem{
+		URL:       permalink,
+		Title:     tweetTitle(t.Text),
+		Note:      t.Text, // full text survives later tweet deletion
+		CreatedAt: created,
+		Tags:      tags,
+		ID:        t.ID,
+		Unread:    false,
+		// Bookmarked tweets are public content; the bookmark *list* is private
+		// but that's the whole point of pulling it, so never over-skip.
+		Private: false,
+	}
+}
+
+// tweetTitle collapses tweet text to a single line and truncates to ~80 runes
+// for a queue-entry title. The full text still rides along as the note.
+func tweetTitle(text string) string {
+	title := strings.Join(strings.Fields(text), " ")
+	if r := []rune(title); len(r) > 80 {
+		title = strings.TrimSpace(string(r[:80]))
+	}
+	return title
+}

--- a/cmd/scribe/source_x_test.go
+++ b/cmd/scribe/source_x_test.go
@@ -1,0 +1,493 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func xTestCfg() *ScribeConfig {
+	return &ScribeConfig{Integrations: IntegrationsConfig{"x": {Enabled: true}}}
+}
+
+// stubXurl swaps the xurlRun transport seam for the duration of a test, so no
+// real xurl binary or network is ever touched.
+func stubXurl(t *testing.T, fn func(ctx context.Context, path string) ([]byte, error)) {
+	t.Helper()
+	orig := xurlRun
+	t.Cleanup(func() { xurlRun = orig })
+	xurlRun = fn
+}
+
+// fakeXurlOnPath drops an executable named `xurl` into a temp dir and points
+// PATH at it, so exec.LookPath("xurl") succeeds without a real install.
+func fakeXurlOnPath(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "xurl"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+}
+
+func TestXConfiguredGates(t *testing.T) {
+	x := xSource{}
+
+	// disabled / no integrations block
+	if ok, reason := x.Configured(&ScribeConfig{}); ok || reason == "" {
+		t.Errorf("Configured true with no integrations block (reason %q)", reason)
+	}
+
+	// enabled but xurl missing from PATH
+	t.Setenv("PATH", t.TempDir()) // empty dir → LookPath fails
+	if ok, reason := x.Configured(xTestCfg()); ok || !strings.Contains(reason, "install") {
+		t.Errorf("Configured = (%v, %q), want false with an install hint", ok, reason)
+	}
+
+	// enabled + xurl on PATH, but never authenticated (no ~/.xurl) → soft-skip
+	// with an auth hint rather than a hard Fetch error on every cron pull.
+	fakeXurlOnPath(t)
+	t.Setenv("HOME", t.TempDir()) // empty home → no ~/.xurl
+	if ok, reason := x.Configured(xTestCfg()); ok || !strings.Contains(reason, "xurl auth oauth2") {
+		t.Errorf("Configured = (%v, %q), want false with an auth hint when ~/.xurl is missing", ok, reason)
+	}
+
+	// enabled + xurl on PATH + ~/.xurl present
+	home := t.TempDir()
+	if err := os.WriteFile(filepath.Join(home, ".xurl"), []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+	if ok, reason := x.Configured(xTestCfg()); !ok {
+		t.Errorf("Configured false with xurl present and authenticated: %q", reason)
+	}
+}
+
+func TestXFetchResolvesAndCachesUserID(t *testing.T) {
+	calls := 0
+	stubXurl(t, func(_ context.Context, path string) ([]byte, error) {
+		calls++
+		switch {
+		case strings.HasPrefix(path, "/2/users/me"):
+			return []byte(`{"data":{"id":"u1","username":"me"}}`), nil
+		case strings.Contains(path, "/bookmarks"):
+			return []byte(`{"data":[{"id":"t9","text":"hello","author_id":"a1","created_at":"2026-07-01T00:00:00Z"}],"includes":{"users":[{"id":"a1","username":"alice"}]},"meta":{"result_count":1}}`), nil
+		}
+		return nil, fmt.Errorf("unexpected path %q", path)
+	})
+
+	items, cur, err := xSource{}.Fetch(context.Background(), xTestCfg(), nil, FetchOpts{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(items) != 1 || items[0].URL != "https://x.com/alice/status/t9" {
+		t.Fatalf("items = %+v, want one alice/t9", items)
+	}
+	var xc xCursor
+	if err := json.Unmarshal(cur, &xc); err != nil {
+		t.Fatalf("cursor unmarshal: %v", err)
+	}
+	if xc.UserID != "u1" || xc.NewestID != "t9" {
+		t.Errorf("cursor = %+v, want user_id=u1 newest_id=t9", xc)
+	}
+	if calls != 2 {
+		t.Errorf("xurl calls = %d, want 2 (me + one page)", calls)
+	}
+}
+
+func TestXFetchCheapProbeShortCircuit(t *testing.T) {
+	prev, err := json.Marshal(xCursor{UserID: "u1", NewestID: "t9"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	calls := 0
+	stubXurl(t, func(_ context.Context, path string) ([]byte, error) {
+		calls++
+		if !strings.Contains(path, "/bookmarks") || !strings.Contains(path, "max_results=1&") {
+			t.Errorf("unexpected call %q, want a single-item probe", path)
+		}
+		return []byte(`{"data":[{"id":"t9","text":"same","author_id":"a1"}],"includes":{"users":[{"id":"a1","username":"alice"}]},"meta":{"result_count":1}}`), nil
+	})
+
+	items, cur, err := xSource{}.Fetch(context.Background(), xTestCfg(), prev, FetchOpts{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(items) != 0 {
+		t.Errorf("items = %d, want 0 when newest id unchanged", len(items))
+	}
+	if calls != 1 {
+		t.Errorf("xurl calls = %d, want 1 (probe only, no full page)", calls)
+	}
+	var xc xCursor
+	if err := json.Unmarshal(cur, &xc); err != nil || xc.NewestID != "t9" {
+		t.Errorf("cursor = %s (err %v), want newest_id preserved", cur, err)
+	}
+}
+
+func TestXFetchForceBypassesProbe(t *testing.T) {
+	prev, err := json.Marshal(xCursor{UserID: "u1", NewestID: "t9"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sawProbe := false
+	stubXurl(t, func(_ context.Context, path string) ([]byte, error) {
+		if strings.Contains(path, "max_results=1&") {
+			sawProbe = true
+		}
+		// A --force run pages the full archive; return one new tweet, no next.
+		return []byte(`{"data":[{"id":"t10","text":"new","author_id":"a1"}],"includes":{"users":[{"id":"a1","username":"alice"}]},"meta":{"result_count":1}}`), nil
+	})
+
+	items, _, err := xSource{}.Fetch(context.Background(), xTestCfg(), prev, FetchOpts{Force: true})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if sawProbe {
+		t.Error("--force should skip the cheap max_results=1 probe")
+	}
+	if len(items) != 1 || items[0].ID != "t10" {
+		t.Errorf("items = %+v, want the new t10", items)
+	}
+}
+
+func TestXFetchPaginationStopsAtKnownID(t *testing.T) {
+	prev, err := json.Marshal(xCursor{UserID: "u1", NewestID: "old"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var pages []string
+	stubXurl(t, func(_ context.Context, path string) ([]byte, error) {
+		pages = append(pages, path)
+		switch {
+		case strings.Contains(path, "pagination_token=t2"):
+			return []byte(`{"data":[{"id":"n3","text":"c","author_id":"a1"},{"id":"old","text":"o","author_id":"a1"},{"id":"n4","text":"d","author_id":"a1"}],"includes":{"users":[{"id":"a1","username":"alice"}]},"meta":{"next_token":"t3","result_count":3}}`), nil
+		case strings.Contains(path, "/bookmarks"):
+			return []byte(`{"data":[{"id":"n1","text":"a","author_id":"a1"},{"id":"n2","text":"b","author_id":"a1"}],"includes":{"users":[{"id":"a1","username":"alice"}]},"meta":{"next_token":"t2","result_count":2}}`), nil
+		}
+		return nil, fmt.Errorf("unexpected path %q", path)
+	})
+
+	items, cur, err := xSource{}.Fetch(context.Background(), xTestCfg(), prev, FetchOpts{Force: true})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	gotIDs := make([]string, 0, len(items))
+	for _, it := range items {
+		gotIDs = append(gotIDs, it.ID)
+	}
+	if strings.Join(gotIDs, ",") != "n1,n2,n3" {
+		t.Errorf("collected ids = %v, want [n1 n2 n3] (stop at known 'old')", gotIDs)
+	}
+	if len(pages) != 2 {
+		t.Errorf("fetched %d pages, want 2 (stop after the page holding 'old')", len(pages))
+	}
+	var xc xCursor
+	if err := json.Unmarshal(cur, &xc); err != nil || xc.NewestID != "n1" {
+		t.Errorf("cursor = %s (err %v), want newest_id=n1", cur, err)
+	}
+}
+
+func TestXFetchHardPageCap(t *testing.T) {
+	// A never-ending next_token must not page forever: the loop hard-stops at
+	// xMaxBookmarkPages. user_id is cached and no newest_id is set, so every
+	// call here is a bookmark page (no /2/users/me, no probe).
+	prev, err := json.Marshal(xCursor{UserID: "u1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	calls := 0
+	stubXurl(t, func(_ context.Context, path string) ([]byte, error) {
+		calls++
+		if !strings.Contains(path, "/bookmarks") {
+			t.Errorf("unexpected non-bookmark call %q", path)
+		}
+		body := fmt.Sprintf(`{"data":[{"id":"t%d","text":"x","author_id":"a1"}],"includes":{"users":[{"id":"a1","username":"alice"}]},"meta":{"next_token":"nt%d","result_count":1}}`, calls, calls)
+		return []byte(body), nil
+	})
+
+	items, _, err := xSource{}.Fetch(context.Background(), xTestCfg(), prev, FetchOpts{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if calls != xMaxBookmarkPages {
+		t.Errorf("xurl bookmark calls = %d, want the %d-page hard cap", calls, xMaxBookmarkPages)
+	}
+	if len(items) != xMaxBookmarkPages {
+		t.Errorf("items = %d, want %d (one per capped page)", len(items), xMaxBookmarkPages)
+	}
+}
+
+func TestXToItemURL(t *testing.T) {
+	users := map[string]string{"a1": "alice"}
+
+	// author username present → handle permalink, full text as note.
+	it := xTweet{ID: "123", Text: "hello world", AuthorID: "a1", CreatedAt: "2026-07-01T00:00:00Z"}.toItem(users)
+	if it.URL != "https://x.com/alice/status/123" {
+		t.Errorf("URL = %q, want handle permalink", it.URL)
+	}
+	if it.Note != "hello world" {
+		t.Errorf("Note = %q, want full tweet text", it.Note)
+	}
+	if it.ID != "123" || it.Private || it.Unread {
+		t.Errorf("item flags off: %+v", it)
+	}
+	if it.CreatedAt.IsZero() {
+		t.Error("CreatedAt zero, want parsed time")
+	}
+
+	// author absent from includes.users → /i/ fallback permalink.
+	orphan := xTweet{ID: "456", Text: "orphan", AuthorID: "ghost"}.toItem(users)
+	if orphan.URL != "https://x.com/i/status/456" {
+		t.Errorf("URL = %q, want /i/ fallback when username missing", orphan.URL)
+	}
+}
+
+func TestXTweetTitle(t *testing.T) {
+	// multi-line / multi-space text collapses to one line.
+	if got := tweetTitle("line one\n\nline   two"); got != "line one line two" {
+		t.Errorf("tweetTitle collapse = %q", got)
+	}
+	// long text truncates to ~80 runes and stays single-line.
+	long := strings.Repeat("a", 200)
+	got := tweetTitle(long)
+	if n := len([]rune(got)); n > 80 {
+		t.Errorf("tweetTitle len = %d runes, want <= 80", n)
+	}
+	if strings.ContainsAny(got, "\n") {
+		t.Errorf("tweetTitle still multi-line: %q", got)
+	}
+}
+
+func TestXFetchMalformedBookmarksJSON(t *testing.T) {
+	prev, err := json.Marshal(xCursor{UserID: "u1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	stubXurl(t, func(_ context.Context, _ string) ([]byte, error) {
+		return []byte("not json{{{"), nil
+	})
+	if _, _, err := (xSource{}).Fetch(context.Background(), xTestCfg(), prev, FetchOpts{Force: true}); err == nil {
+		t.Error("malformed bookmarks JSON should error, not panic")
+	}
+}
+
+func TestXFetchMalformedUserJSON(t *testing.T) {
+	stubXurl(t, func(_ context.Context, _ string) ([]byte, error) {
+		return []byte("}{"), nil
+	})
+	if _, _, err := (xSource{}).Fetch(context.Background(), xTestCfg(), nil, FetchOpts{}); err == nil {
+		t.Error("malformed /2/users/me JSON should error, not panic")
+	}
+}
+
+func TestXToItemHashtagsBecomeTags(t *testing.T) {
+	// #hashtags are the only tag-like signal a bookmark carries; they must land
+	// in Tags or the driver's OR tag filter can never match an X item.
+	var tw xTweet
+	if err := json.Unmarshal([]byte(`{"id":"1","text":"post #Go #KB","author_id":"a1","entities":{"hashtags":[{"tag":"Go"},{"tag":"KB"}]}}`), &tw); err != nil {
+		t.Fatal(err)
+	}
+	it := tw.toItem(nil)
+	if strings.Join(it.Tags, ",") != "Go,KB" {
+		t.Errorf("Tags = %v, want [Go KB] from entities.hashtags", it.Tags)
+	}
+
+	// no entities block → no tags, no panic.
+	bare := xTweet{ID: "2", Text: "plain"}.toItem(nil)
+	if len(bare.Tags) != 0 {
+		t.Errorf("Tags = %v, want none without hashtags", bare.Tags)
+	}
+}
+
+func TestXFetchRequestsEntitiesAndExpansions(t *testing.T) {
+	// The permalink handle, save time, and hashtag tags all depend on these
+	// request params — a regression here degrades items silently (fallback /i/
+	// URLs, zero times, empty tags), so pin the wire format.
+	prev, err := json.Marshal(xCursor{UserID: "u1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	stubXurl(t, func(_ context.Context, path string) ([]byte, error) {
+		for _, param := range []string{"expansions=author_id", "tweet.fields=created_at,entities", "user.fields=username"} {
+			if !strings.Contains(path, param) {
+				t.Errorf("bookmarks path %q missing %q", path, param)
+			}
+		}
+		return []byte(`{"data":[{"id":"t1","text":"post #go","author_id":"a1","entities":{"hashtags":[{"tag":"go"}]}}],"includes":{"users":[{"id":"a1","username":"alice"}]},"meta":{"result_count":1}}`), nil
+	})
+
+	items, _, err := xSource{}.Fetch(context.Background(), xTestCfg(), prev, FetchOpts{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(items) != 1 || strings.Join(items[0].Tags, ",") != "go" {
+		t.Errorf("items = %+v, want one item tagged [go]", items)
+	}
+}
+
+func TestXFetchErrorMidPaginationPreservesCursor(t *testing.T) {
+	// A failure on page 2 must not advance the cursor past bookmarks that were
+	// never queued: Fetch returns the previous cursor untouched so the next run
+	// re-pages from the same boundary (the driver's seen-set absorbs the
+	// re-fetched overlap).
+	prev, err := json.Marshal(xCursor{UserID: "u1", NewestID: "old"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	stubXurl(t, func(_ context.Context, path string) ([]byte, error) {
+		if strings.Contains(path, "pagination_token=t2") {
+			return nil, errors.New("500 server error")
+		}
+		return []byte(`{"data":[{"id":"n1","text":"a","author_id":"a1"}],"includes":{"users":[{"id":"a1","username":"alice"}]},"meta":{"next_token":"t2","result_count":1}}`), nil
+	})
+
+	items, cur, err := xSource{}.Fetch(context.Background(), xTestCfg(), prev, FetchOpts{Force: true})
+	if err == nil {
+		t.Fatal("Fetch should surface the page-2 error")
+	}
+	if len(items) != 0 {
+		t.Errorf("items = %d, want none on a failed run", len(items))
+	}
+	if !bytes.Equal(cur, prev) {
+		t.Errorf("cursor advanced on error: %s, want previous %s", cur, prev)
+	}
+}
+
+func TestXFetchEmptyAccount(t *testing.T) {
+	// First run against an account with zero bookmarks: no items, no error, and
+	// the cursor caches the user id with no newest_id (so the next run probes
+	// nothing and pages from the top again).
+	stubXurl(t, func(_ context.Context, path string) ([]byte, error) {
+		if strings.HasPrefix(path, "/2/users/me") {
+			return []byte(`{"data":{"id":"u1","username":"me"}}`), nil
+		}
+		return []byte(`{"data":[],"meta":{"result_count":0}}`), nil
+	})
+
+	items, cur, err := xSource{}.Fetch(context.Background(), xTestCfg(), nil, FetchOpts{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(items) != 0 {
+		t.Errorf("items = %d, want 0 for an empty account", len(items))
+	}
+	var xc xCursor
+	if err := json.Unmarshal(cur, &xc); err != nil || xc.UserID != "u1" || xc.NewestID != "" {
+		t.Errorf("cursor = %s (err %v), want cached user_id and empty newest_id", cur, err)
+	}
+}
+
+func TestXFetchDuplicateIDsAcrossPages(t *testing.T) {
+	// The API's pagination has reported overlap bugs; a tweet repeated across
+	// pages must pass through without tripping the boundary logic — dedup is
+	// the driver's job (seen-set), not the adapter's. The id-less row on page 2
+	// exercises the malformed-row guard: it must be skipped, not queued as a
+	// garbage /i/status/ permalink.
+	prev, err := json.Marshal(xCursor{UserID: "u1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	stubXurl(t, func(_ context.Context, path string) ([]byte, error) {
+		if strings.Contains(path, "pagination_token=t2") {
+			return []byte(`{"data":[{"id":"n1","text":"dup","author_id":"a1"},{"id":"","text":"malformed"},{"id":"n2","text":"b","author_id":"a1"}],"includes":{"users":[{"id":"a1","username":"alice"}]},"meta":{"result_count":3}}`), nil
+		}
+		return []byte(`{"data":[{"id":"n1","text":"a","author_id":"a1"}],"includes":{"users":[{"id":"a1","username":"alice"}]},"meta":{"next_token":"t2","result_count":1}}`), nil
+	})
+
+	items, cur, err := xSource{}.Fetch(context.Background(), xTestCfg(), prev, FetchOpts{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	gotIDs := make([]string, 0, len(items))
+	for _, it := range items {
+		gotIDs = append(gotIDs, it.ID)
+	}
+	if strings.Join(gotIDs, ",") != "n1,n1,n2" {
+		t.Errorf("collected ids = %v, want duplicates passed through (and the id-less row skipped) as [n1 n1 n2]", gotIDs)
+	}
+	var xc xCursor
+	if err := json.Unmarshal(cur, &xc); err != nil || xc.NewestID != "n1" {
+		t.Errorf("cursor = %s (err %v), want newest_id=n1", cur, err)
+	}
+}
+
+func TestXFetchCapDoesNotAdvanceCursorPastGap(t *testing.T) {
+	// If the page cap fires while the server still offers a next page AND the
+	// previous boundary was never reached, there is an unfetched gap between
+	// the cap and the old newest_id. Advancing the cursor would make that gap
+	// permanently unreachable (the probe would short-circuit every later run),
+	// so the cursor must stay at the old boundary. Items fetched before the
+	// cap are still returned — the driver's seen-set dedups the re-walk.
+	prev, err := json.Marshal(xCursor{UserID: "u1", NewestID: "old"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	calls := 0
+	stubXurl(t, func(_ context.Context, path string) ([]byte, error) {
+		calls++
+		if !strings.Contains(path, "/bookmarks") {
+			t.Errorf("unexpected non-bookmark call %q", path)
+		}
+		// Endless pages that never contain "old".
+		body := fmt.Sprintf(`{"data":[{"id":"t%d","text":"x","author_id":"a1"}],"includes":{"users":[{"id":"a1","username":"alice"}]},"meta":{"next_token":"nt%d","result_count":1}}`, calls, calls)
+		return []byte(body), nil
+	})
+
+	items, cur, err := xSource{}.Fetch(context.Background(), xTestCfg(), prev, FetchOpts{Force: true})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(items) != xMaxBookmarkPages {
+		t.Errorf("items = %d, want %d (one per capped page)", len(items), xMaxBookmarkPages)
+	}
+	var xc xCursor
+	if err := json.Unmarshal(cur, &xc); err != nil || xc.NewestID != "old" {
+		t.Errorf("cursor = %s (err %v), want newest_id kept at 'old' when capped before the boundary", cur, err)
+	}
+}
+
+func TestXFetchProbeErrorFallsBackToWalk(t *testing.T) {
+	// The probe is a cost optimization, not a gate: if the single-item probe
+	// fails (e.g. the endpoint rejects max_results=1 — minimum page size is
+	// unverified), the run degrades to the normal 100-per-page walk instead of
+	// erroring out of every cron pull.
+	prev, err := json.Marshal(xCursor{UserID: "u1", NewestID: "old"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	stubXurl(t, func(_ context.Context, path string) ([]byte, error) {
+		if strings.Contains(path, "max_results=1&") {
+			return nil, errors.New("400 Bad Request: max_results below minimum")
+		}
+		return []byte(`{"data":[{"id":"n1","text":"a","author_id":"a1"},{"id":"old","text":"o","author_id":"a1"}],"includes":{"users":[{"id":"a1","username":"alice"}]},"meta":{"result_count":2}}`), nil
+	})
+
+	items, cur, err := xSource{}.Fetch(context.Background(), xTestCfg(), prev, FetchOpts{})
+	if err != nil {
+		t.Fatalf("Fetch should degrade past a probe failure, got: %v", err)
+	}
+	if len(items) != 1 || items[0].ID != "n1" {
+		t.Errorf("items = %+v, want the one new n1 from the fallback walk", items)
+	}
+	var xc xCursor
+	if err := json.Unmarshal(cur, &xc); err != nil || xc.NewestID != "n1" {
+		t.Errorf("cursor = %s (err %v), want newest_id=n1", cur, err)
+	}
+}
+
+func TestXFetchAuthErrorHint(t *testing.T) {
+	stubXurl(t, func(_ context.Context, _ string) ([]byte, error) {
+		return nil, errors.New("401 Unauthorized")
+	})
+	_, _, err := xSource{}.Fetch(context.Background(), xTestCfg(), nil, FetchOpts{})
+	if err == nil || !strings.Contains(err.Error(), "xurl auth oauth2") {
+		t.Errorf("err = %v, want a `xurl auth oauth2` re-auth hint", err)
+	}
+}

--- a/cmd/scribe/source_x_test.go
+++ b/cmd/scribe/source_x_test.go
@@ -69,6 +69,66 @@ func TestXConfiguredGates(t *testing.T) {
 	}
 }
 
+// TestXSetupChecklist walks `pull x --setup` through every failure step in
+// dependency order, then the happy path, asserting each stage prints the
+// exact fix and returns non-nil until the live check passes. t.Setenv state
+// (PATH, HOME) accumulates intentionally — each stage builds on the last.
+func TestXSetupChecklist(t *testing.T) {
+	x := xSource{}
+	ctx := context.Background()
+	var buf bytes.Buffer
+
+	// 1. integration not enabled → yaml snippet.
+	if err := x.Setup(ctx, &ScribeConfig{}, &buf); err == nil || !strings.Contains(buf.String(), "enabled: true") {
+		t.Errorf("setup(disabled): err=%v out=%q, want error + yaml fix", err, buf.String())
+	}
+
+	// 2. enabled but xurl missing → install command.
+	buf.Reset()
+	t.Setenv("PATH", t.TempDir())
+	if err := x.Setup(ctx, xTestCfg(), &buf); err == nil || !strings.Contains(buf.String(), "brew install --cask xdevplatform/tap/xurl") {
+		t.Errorf("setup(no xurl): err=%v out=%q, want error + install command", err, buf.String())
+	}
+
+	// 3. xurl present but never authenticated → dev-account walkthrough.
+	buf.Reset()
+	fakeXurlOnPath(t)
+	t.Setenv("HOME", t.TempDir())
+	if err := x.Setup(ctx, xTestCfg(), &buf); err == nil ||
+		!strings.Contains(buf.String(), "developer.x.com") ||
+		!strings.Contains(buf.String(), "xurl auth oauth2") {
+		t.Errorf("setup(no ~/.xurl): err=%v out=%q, want error + auth walkthrough", err, buf.String())
+	}
+
+	// 4. everything local in place, live check succeeds → ready + next command.
+	buf.Reset()
+	home := t.TempDir()
+	if err := os.WriteFile(filepath.Join(home, ".xurl"), []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+	stubXurl(t, func(_ context.Context, path string) ([]byte, error) {
+		if !strings.HasPrefix(path, "/2/users/me") {
+			t.Errorf("live check hit %q, want /2/users/me", path)
+		}
+		return []byte(`{"data":{"id":"u1","username":"alice"}}`), nil
+	})
+	if err := x.Setup(ctx, xTestCfg(), &buf); err != nil ||
+		!strings.Contains(buf.String(), "@alice") ||
+		!strings.Contains(buf.String(), "pull x -n") {
+		t.Errorf("setup(ready): err=%v out=%q, want nil error + @alice + next command", err, buf.String())
+	}
+
+	// 5. live check fails (stale token) → re-auth hint, non-nil error.
+	buf.Reset()
+	stubXurl(t, func(_ context.Context, _ string) ([]byte, error) {
+		return nil, errors.New("401 Unauthorized")
+	})
+	if err := x.Setup(ctx, xTestCfg(), &buf); err == nil || !strings.Contains(buf.String(), "xurl auth oauth2") {
+		t.Errorf("setup(stale token): err=%v out=%q, want error + re-auth hint", err, buf.String())
+	}
+}
+
 func TestXFetchResolvesAndCachesUserID(t *testing.T) {
 	calls := 0
 	stubXurl(t, func(_ context.Context, path string) ([]byte, error) {

--- a/cmd/scribe/templates/scribe.yaml
+++ b/cmd/scribe/templates/scribe.yaml
@@ -343,10 +343,12 @@ capture:
 #   pinboard:
 #     enabled: true
 #     scope: recent+unread    # recent+unread | unread | all  (by read-state/recency)
-#     tags: []                # OR filter: only ingest bookmarks with >=1 of these
-#                             # tags (case-insensitive); empty = all. Orthogonal to
-#                             # scope, e.g. scope: all + tags: [kb] = everything
-#                             # you ever tagged "kb".
+#     tags: []                # tag filter (case-insensitive); empty = all.
+#                             # Orthogonal to scope, e.g. scope: all + tags: [kb]
+#                             # = everything you ever tagged "kb".
+#     tags_mode: any          # any = carries >=1 listed tag (default, ingest-gate
+#                             # shape); all = must carry EVERY listed tag (how
+#                             # pinboard.in/t:a/t:b/ narrows).
 #     public_only: false      # true = skip private bookmarks (an authenticated
 #                             # pull sees private ones too); default ingests all.
 #     skip_domains: []        # substring filter, same as capture.skip_domains

--- a/cmd/scribe/templates/scribe.yaml
+++ b/cmd/scribe/templates/scribe.yaml
@@ -352,8 +352,22 @@ capture:
 #     public_only: false      # true = skip private bookmarks (an authenticated
 #                             # pull sees private ones too); default ingests all.
 #     skip_domains: []        # substring filter, same as capture.skip_domains
+#   x:                        # X (Twitter) bookmarks via X's official API.
+#     enabled: true           # No token here — auth lives entirely in `xurl` (X's
+#                             # API CLI): install it, run `xurl auth oauth2` once
+#                             # (browser), and tokens persist in ~/.xurl for
+#                             # headless cron. See README "Pull integrations".
+#     tags: []                # OR filter matched against each tweet's hashtags
+#                             # (case-insensitive, bare form: "golang" not
+#                             # "#golang"); empty = all. Most tweets carry no
+#                             # hashtags, so a non-empty filter is strict.
+#     skip_domains: []        # substring filter, same as capture.skip_domains.
+#                             # No scope/public_only — not meaningful for X. The
+#                             # API serves only the ~800 most recent bookmarks
+#                             # (rolling window, not an archive); reads bill
+#                             # $0.001 each against prepaid pay-per-use credits.
 #
-# Token goes in ~/.config/scribe/config.yaml:
+# Pinboard's token goes in ~/.config/scribe/config.yaml (X needs none — see above):
 #   integration_tokens:
 #     pinboard: "username:HEXTOKEN"   # from pinboard.in/settings/password
 

--- a/cmd/scribe/templates/scribe.yaml
+++ b/cmd/scribe/templates/scribe.yaml
@@ -356,7 +356,8 @@ capture:
 #     enabled: true           # No token here — auth lives entirely in `xurl` (X's
 #                             # API CLI): install it, run `xurl auth oauth2` once
 #                             # (browser), and tokens persist in ~/.xurl for
-#                             # headless cron. See README "Pull integrations".
+#                             # headless cron. `scribe pull x --setup` walks the
+#                             # whole chain. See README "Pull integrations".
 #     tags: []                # OR filter matched against each tweet's hashtags
 #                             # (case-insensitive, bare form: "golang" not
 #                             # "#golang"); empty = all. Most tweets carry no

--- a/cmd/scribe/templates/scribe.yaml
+++ b/cmd/scribe/templates/scribe.yaml
@@ -347,6 +347,8 @@ capture:
 #                             # tags (case-insensitive); empty = all. Orthogonal to
 #                             # scope, e.g. scope: all + tags: [kb] = everything
 #                             # you ever tagged "kb".
+#     public_only: false      # true = skip private bookmarks (an authenticated
+#                             # pull sees private ones too); default ingests all.
 #     skip_domains: []        # substring filter, same as capture.skip_domains
 #
 # Token goes in ~/.config/scribe/config.yaml:

--- a/cmd/scribe/templates/scribe.yaml
+++ b/cmd/scribe/templates/scribe.yaml
@@ -358,10 +358,11 @@ capture:
 #                             # (browser), and tokens persist in ~/.xurl for
 #                             # headless cron. `scribe pull x --setup` walks the
 #                             # whole chain. See README "Pull integrations".
-#     tags: []                # OR filter matched against each tweet's hashtags
+#     tags: []                # tag filter matched against each tweet's hashtags
 #                             # (case-insensitive, bare form: "golang" not
-#                             # "#golang"); empty = all. Most tweets carry no
-#                             # hashtags, so a non-empty filter is strict.
+#                             # "#golang"); empty = all. tags_mode any|all works
+#                             # here too. Most tweets carry no hashtags, so a
+#                             # non-empty filter is strict.
 #     skip_domains: []        # substring filter, same as capture.skip_domains.
 #                             # No scope/public_only — not meaningful for X. The
 #                             # API serves only the ~800 most recent bookmarks

--- a/cmd/scribe/templates/scribe.yaml
+++ b/cmd/scribe/templates/scribe.yaml
@@ -332,6 +332,27 @@ capture:
   self_chat_handles:
     - "{{.SelfChatHandle}}"
 
+# Pull adapters — external accounts `scribe pull` fetches bookmarks from into
+# the ingest queue (output/inbox/), drained by the same path as `ingest url`.
+# API tokens NEVER live here: put them in ~/.config/scribe/config.yaml under
+# integration_tokens (gitignored, per-machine), or export SCRIBE_<NAME>_TOKEN.
+# Personal source like capture — disabled in team mode; re-enable per-person
+# in scribe.local.yaml.
+#
+# integrations:
+#   pinboard:
+#     enabled: true
+#     scope: recent+unread    # recent+unread | unread | all  (by read-state/recency)
+#     tags: []                # OR filter: only ingest bookmarks with >=1 of these
+#                             # tags (case-insensitive); empty = all. Orthogonal to
+#                             # scope, e.g. scope: all + tags: [kb] = everything
+#                             # you ever tagged "kb".
+#     skip_domains: []        # substring filter, same as capture.skip_domains
+#
+# Token goes in ~/.config/scribe/config.yaml:
+#   integration_tokens:
+#     pinboard: "username:HEXTOKEN"   # from pinboard.in/settings/password
+
 # Triage keyword categories for `scribe triage` (BM25 FTS5 scoring).
 # Edit any MATCH expression to tune to your stack. Weights multiply per hit.
 triage:


### PR DESCRIPTION
Revived from an abandoned agent worktree (`.worktrees/pinboard-pr`) on 2026-08-11. Opened as a **draft** purely so the work is not lost — it is **not** mergeable as-is. See "What remains" below.

> **Updated 2026-08-11, after #52 merged.** This body was first written while #52 was still open; the analysis below reflects `main` at `c590a67`.

## What this branch was trying to do

Add an **X (Twitter) bookmarks pull-adapter** on top of the Pinboard pull-adapter framework — the framework has since landed on `main` via #52.

The adapter (`cmd/scribe/source_x.go` ~400 lines + `source_x_test.go` ~550 lines) is a URL producer only: it queues tweet permalinks (tweet text as title + note) into `output/inbox/` and lets the existing ingest-drain path fetch content — scribe's fetch cascade already has an fxtwitter tier for `x.com` URLs.

Design points worth keeping:

- **Transport is the official `xurl` CLI** (`github.com/xdevplatform/xurl`), which owns the whole OAuth 2.0 PKCE dance — browser flow, token storage in `~/.xurl`, auto-refresh. scribe never implements OAuth and never stores X tokens, and **no new Go dependency is added** (exec-only), matching the repo's "prefer shelling out to optional tools" convention.
- **Cost model is explicit.** Owned reads bill at $0.001/resource, so a 100-item page costs $0.10. A cheap `max_results=1` probe gates every run (unchanged newest id ⇒ $0.001 no-op), and a hard 9-page cap bounds a full pull to the API's documented ~800-bookmark reachable window.
- `xurlRun` is a package-level seam (mirroring `newLLMProvider` in `llm.go`) so tests stub the transport without a real `xurl` binary or network.
- Adds a `setupGuider` optional Source extension + `scribe pull <source> --setup` guided checklist, implemented for `x`.

## Commit breakdown — only the last 3 are wanted

| Commit | Status vs `main` @ `c590a67` |
| --- | --- |
| `a234f35` add Pinboard pull-adapter framework | **Superseded** — #52's reworked version is on main. **Drop this commit.** |
| `769f3d9` add `public_only` filter | Already on main via #52 |
| `7134eb0` add `tags_mode any\|all` knob | Already on main via #52 |
| `02f2c45` **add X bookmarks pull-adapter via xurl** | **Unique — wanted** |
| `48fb332` **add `--setup` guided checklist, implemented for x** | **Unique — wanted** |
| `b711961` **docs: `tags_mode` applies to x hashtag filtering too** | **Unique — wanted** |

`cmd/scribe/source_x.go` and `cmd/scribe/source_x_test.go` exist **nowhere else** — not on `main`, not on the merged #52 lineage.

## Build / test status

Verified on 2026-08-11 at `b711961`, unrebased (i.e. against its own old base, not current main):

- `make build` — **passes** (CGO_ENABLED=1, `-tags sqlite_fts5`)
- `go vet -tags sqlite_fts5 ./...` — **clean**
- `go test -tags sqlite_fts5 -count=1 ./...` — **passes** (`ok github.com/oliver-kriska/scribe/cmd/scribe 241.606s`)

Not re-verified against current `main`, because it does not merge cleanly (below).

## Rebase status: STALE, not rebased

6 commits ahead of `main`, **64 behind**. Deliberately **not** rebased — `git merge-tree` against `c590a67` reports conflicts in:

- `CHANGELOG.md`
- `README.md`
- `cmd/scribe/ingest.go`
- `cmd/scribe/source.go` (add/add)
- `cmd/scribe/source_pinboard.go` (add/add)
- `cmd/scribe/templates/scribe.yaml`

Most of these are the *expected* collision between this branch's old framework copy and the merged #52 version — which is exactly why the branch should not be merged wholesale.

## What remains to be done

1. **Do not merge this branch.** Cherry-pick the 3 unique commits (`02f2c45`, `48fb332`, `b711961`) onto current `main` and **drop `a234f35`**. Merging as-is would revert #52's `c590a67` fix — *"stop the token leak, queue injection, redirect leak, and lost checkpoints"* — because this branch's framework copy predates it. That is the single biggest hazard here.
2. **Good news on portability:** the `Source` interface (`Name` / `Configured` / `Fetch`) is **byte-identical** between this branch and current `main`, so `source_x.go` should port without redesign. The one piece needing re-application by hand is the `setupGuider` extension + `--setup` wiring that `48fb332` adds to `source.go` (~43 lines), since main's `source.go` came from the #52 rework.
3. Re-run `make build` / `make check` after the cherry-pick — the numbers above were measured on the old base.
4. Re-verify `xurl`'s API surface and X's per-read pricing before shipping — both are external, and this code was written before 2026-08-11.
