### PR TITLE
fix(sync): honor .gitignore on first-extraction file selection

### DIFF
--- a/cmd/scribe/gitops.go
+++ b/cmd/scribe/gitops.go
@@ -30,7 +30,18 @@ func gitRemoteURL(repoPath string) string {
 // gitChangedFiles returns files changed between two SHAs (or all files if oldSHA is empty).
 func gitChangedFiles(repoPath, oldSHA string, patterns []string) []string {
 	if oldSHA == "" {
-		// Never synced: list all matching files
+		// Never synced: list all matching files. In a git repo, use
+		// `git ls-files` so .gitignore is honored — a raw filesystem walk
+		// (findFiles) sweeps in gitignored dependency trees (.venv,
+		// site-packages, __pycache__) whose text files match the extract
+		// patterns, inflating the count past sync.max_extract_files so the
+		// whole project is skipped. The git-diff path below is already
+		// gitignore-aware (diff only sees tracked files); this keeps the
+		// first-extraction path consistent with it. findFiles remains the
+		// fallback for a non-git directory.
+		if hasGit(repoPath) {
+			return gitListFiles(repoPath, patterns)
+		}
 		return findFiles(repoPath, patterns)
 	}
 
@@ -47,6 +58,31 @@ func gitChangedFiles(repoPath, oldSHA string, patterns []string) []string {
 		if line != "" {
 			files = append(files, filepath.Join(repoPath, line))
 		}
+	}
+	return files
+}
+
+// gitListFiles returns tracked and untracked-but-not-ignored files under
+// repoPath matching patterns, honoring .gitignore via --exclude-standard.
+// It's the first-extraction (empty oldSHA) counterpart to gitChangedFiles'
+// `git diff` path — both stay gitignore-aware, unlike the findFiles
+// filesystem walk. patterns are git pathspecs (e.g. "*.md") and match at
+// any depth. Returns absolute paths; nil on any git error (callers then
+// treat the project as having no changed files this run).
+func gitListFiles(repoPath string, patterns []string) []string {
+	args := make([]string, 0, 7+len(patterns))
+	args = append(args, "-C", repoPath, "ls-files", "-z", "--cached", "--others", "--exclude-standard", "--")
+	args = append(args, patterns...)
+	out, err := runCmdRaw("", "git", args...)
+	if err != nil {
+		return nil
+	}
+	var files []string
+	for rel := range strings.SplitSeq(string(out), "\x00") {
+		if rel == "" {
+			continue
+		}
+		files = append(files, filepath.Join(repoPath, rel))
 	}
 	return files
 }

--- a/cmd/scribe/gitops_test.go
+++ b/cmd/scribe/gitops_test.go
@@ -1,6 +1,50 @@
 package main
 
-import "testing"
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGitChangedFiles_FirstExtractionHonorsGitignore(t *testing.T) {
+	repo := initTestGitRepo(t, "Extract Tester")
+
+	// Tracked source doc + a gitignored dependency tree whose text files
+	// match the extract patterns (the .venv-blows-past-the-cap case).
+	writeTestArticle(t, repo, "README.md", "# proj\n")
+	writeTestArticle(t, repo, ".gitignore", ".venv/\n")
+	writeTestArticle(t, repo, ".venv/lib/pkg.txt", "junk\n")
+	writeTestArticle(t, repo, ".venv/notes.md", "junk\n")
+	gitRun(t, repo, "add", "README.md", ".gitignore")
+	gitRun(t, repo, "commit", "-q", "-m", "init")
+	// Untracked but NOT ignored — must still be extracted.
+	writeTestArticle(t, repo, "docs/guide.txt", "kept\n")
+
+	got := gitChangedFiles(repo, "", []string{"*.md", "*.txt", "*.exs", "*.ex"})
+
+	has := func(suffix string) bool {
+		for _, f := range got {
+			if strings.HasSuffix(f, suffix) {
+				return true
+			}
+		}
+		return false
+	}
+	if !has("/README.md") {
+		t.Errorf("tracked README.md missing from first-extraction set: %v", got)
+	}
+	if !has("/docs/guide.txt") {
+		t.Errorf("untracked-non-ignored docs/guide.txt missing: %v", got)
+	}
+	for _, f := range got {
+		if strings.Contains(f, "/.venv/") {
+			t.Errorf("gitignored .venv file leaked into extraction set: %s", f)
+		}
+		if !filepath.IsAbs(f) {
+			t.Errorf("returned path is not absolute: %s", f)
+		}
+	}
+}
 
 func TestPullBeforeSyncEnabled_DefaultsTrue(t *testing.T) {
 	if !pullBeforeSyncEnabled(nil) {


### PR DESCRIPTION
Fixes #86.

`gitChangedFiles` with an empty `oldSHA` fell back to `findFiles`, a filesystem walk that never consults `.gitignore`. Gitignored dependency trees (`.venv/**/site-packages`, full of `*.md` and `*.txt`) inflated the count past `sync.max_extract_files`, so the project was skipped — and re-held every run.

Adds `gitListFiles`, using `git ls-files --cached --others --exclude-standard`, for the empty-`oldSHA` case. `findFiles` stays as the fallback for a non-git directory, so behaviour outside a repo is unchanged. This makes first extraction consistent with the incremental path, which was already gitignore-aware because `git diff` only sees tracked files.

Measured on two Python repos with a gitignored `.venv`: **287 → 38** and **887 → 24** files. Both tripped the default cap of 100; both now extract.

Covered by a new test in `gitops_test.go`. `make test`, `make race` and `make lint` are green locally.

<sub>The commit body mentions `TestTargetIsFreshForDecay` failing on main — that's an unrelated pre-existing flake, fixed separately in #85.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
