### PR TITLE
fix(sync): treat a linked worktree as the git repo it is

### DIFF
--- a/cmd/scribe/gitops.go
+++ b/cmd/scribe/gitops.go
@@ -66,11 +66,12 @@ func gitChangedFiles(repoPath, oldSHA string, patterns []string) []string {
 // .gitignore-aware counterpart to findFiles, used for a project's first
 // extraction where there is no old SHA to diff against.
 //
-// Returns ok=false when repoPath has no `.git` directory or git fails, so
-// the caller can fall back to a plain filesystem walk. An empty result with
-// ok=true is meaningful: the repo genuinely has no matching files.
+// Returns ok=false when repoPath is not inside a git work tree, or git
+// fails, so the caller can fall back to a plain filesystem walk. An empty
+// result with ok=true is meaningful: the repo genuinely has no matching
+// files.
 func gitListFiles(repoPath string, patterns []string) ([]string, bool) {
-	if !hasGit(repoPath) {
+	if !insideGitWorkTree(repoPath) {
 		return nil, false
 	}
 
@@ -83,8 +84,9 @@ func gitListFiles(repoPath string, patterns []string) ([]string, bool) {
 	// output; NUL separation keeps them byte-exact.
 	out, err := runCmdRaw("", "git", args...)
 	if err != nil {
-		// hasGit said yes, so this is a real git failure, not a plain
-		// directory — dubious-ownership under cron, a corrupt index. The
+		// The work-tree probe said yes, so this is a real git failure,
+		// not a plain directory — dubious-ownership under cron, a
+		// corrupt index. The
 		// caller silently falls back to the filesystem walk, which
 		// reintroduces the #86 overcount; say so, or it is undiagnosable.
 		logMsg("git", "git ls-files failed in %s (%v) — falling back to a filesystem walk, which ignores .gitignore", repoPath, err)
@@ -482,4 +484,17 @@ func findFiles(root string, patterns []string) []string {
 // hasGit returns true if path contains a .git directory.
 func hasGit(path string) bool {
 	return dirExists(filepath.Join(path, ".git"))
+}
+
+// insideGitWorkTree reports whether git treats path as part of a work
+// tree. Deliberately broader than hasGit, which stats for a .git
+// *directory*: a linked worktree's .git is a regular file and a
+// subdirectory of a checkout has no .git at all, yet git lists both
+// correctly. Worktree paths do reach extraction — discovery folds them
+// into the main checkout now, but scripts/projects.json still carries
+// entries enrolled before it did — and a false negative there is not
+// harmless: it silently reinstates the issue #86 filesystem walk that
+// counts gitignored dependency trees.
+func insideGitWorkTree(path string) bool {
+	return runCmd(path, "git", "rev-parse", "--is-inside-work-tree") == "true"
 }

--- a/cmd/scribe/gitops_listfiles_test.go
+++ b/cmd/scribe/gitops_listfiles_test.go
@@ -118,6 +118,47 @@ func TestGitChangedFiles_FirstExtractionIgnoresGitignored(t *testing.T) {
 	}
 }
 
+// A linked worktree's .git is a regular file, not a directory, so a
+// hasGit stat reads it as "not a repo" and drops first extraction back to
+// findFiles — reinstating this bug for exactly the worktree entries
+// scripts/projects.json still carries from before discovery folded them
+// into their main checkout.
+func TestGitListFiles_LinkedWorktreeIsStillAGitRepo(t *testing.T) {
+	repo := buildIgnoreRepo(t)
+	wt := filepath.Join(t.TempDir(), "wt")
+	gitRun(t, repo, "worktree", "add", "-q", "-b", "probe", wt)
+
+	if hasGit(wt) {
+		t.Fatal("fixture no longer reproduces: a linked worktree's .git should be a file, not a directory")
+	}
+
+	// The worktree only carries the tracked files; give it its own
+	// ignored tree and its own uncommitted doc so both halves of the
+	// rule are exercised where the checkout actually is.
+	writeTestArticle(t, wt, ".venv/lib/site-packages/pkg/README.md", "x")
+	writeTestArticle(t, wt, "docs/new-in-worktree.md", "# fresh")
+
+	got, ok := gitListFiles(wt, extractScanPatterns)
+	if !ok {
+		t.Fatalf("linked worktree should be listable by git")
+	}
+
+	rel := make([]string, 0, len(got))
+	for _, f := range got {
+		r, err := filepath.Rel(wt, f)
+		if err != nil {
+			t.Fatalf("Rel(%q): %v", f, err)
+		}
+		rel = append(rel, filepath.ToSlash(r))
+	}
+	slices.Sort(rel)
+
+	want := []string{"README.md", "docs/design.md", "docs/new-in-worktree.md", "notes.txt"}
+	if !slices.Equal(rel, want) {
+		t.Fatalf("gitListFiles in worktree = %v, want %v", rel, want)
+	}
+}
+
 func TestGitListFiles_NonRepoFallsBack(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "a.md"), []byte("x"), 0o644); err != nil {


### PR DESCRIPTION
Follow-on to #86 — the fix landed in `e90c16a`, but one path still falls through it.

## The gap

`gitListFiles` gated on `hasGit`, which stats for a `.git` **directory**. A linked worktree's `.git` is a regular *file*, so the gate reads "not a repo" and drops back to the `findFiles` walk the fix exists to avoid — the gitignored dependency tree gets counted again, `sync.max_extract_files` trips again, `status` re-holds the project every run again. Silently, and only for worktrees.

Not hypothetical: `scripts/projects.json` on this machine still holds `worktrees/enaia/ena-8885-…` with an empty `last_sha` — a worktree enrolled directly, never extracted, which is precisely the first-extraction path. Discovery folds worktrees into their main checkout now (`projects_add.go:68`, `sync_discover.go:57`), so new entries are fine; entries predating that are not, and nothing migrates them.

## The change

`git rev-parse --is-inside-work-tree` is the question actually being asked. True for a repo root, a linked worktree, and a subdirectory of either — the last of which also stops a monorepo subdirectory falling back to the walk. Outside a work tree it fails, so the plain-directory fallback is unchanged.

`hasGit` keeps its twelve other call sites: those ask "may I write git state here", a different question the stat answers correctly.

## Verification

- `TestGitListFiles_LinkedWorktreeIsStillAGitRepo` pins the fixture (`hasGit(wt)` must be false, or it has stopped reproducing) and **fails on the old gate** — verified by reverting the one line:
  ```
  --- FAIL: TestGitListFiles_LinkedWorktreeIsStillAGitRepo (0.12s)
      gitops_listfiles_test.go:143: linked worktree should be listable by git
  ```
- `make check`, `make lint`, `make race` — all green locally.

Reported by @louis-byers in #86, whose diagnosis named the exact fallback.