### PR TITLE
fix(sync): let Go own the session-mining processed-mark

### DIFF
--- a/cmd/scribe/claude.go
+++ b/cmd/scribe/claude.go
@@ -58,7 +58,24 @@ func realRunClaude(ctx context.Context, root, prompt, model string, tools []stri
 		"--output-format", "json",
 	}
 	if len(tools) > 0 {
-		args = append(args, "--allowedTools", strings.Join(tools, ","))
+		// Belt-and-suspenders on the second pair: Go owns
+		// wiki/_sessions_log.json (recordSessionProcessed); deny the model
+		// write access to it so a stray model write can't race Go's writer.
+		// A Write() rule is silently ignored, so the rule must be spelled
+		// Edit(); deny wins over allow. cmd.Dir is root (set below), so this
+		// cwd-relative pattern resolves to <root>/wiki/_sessions_log.json.
+		//
+		// Measured against Claude Code 2.1.236, with Write granted and this
+		// rule set (see the PR for the harness): a Write to the named path is
+		// rejected, a Bash redirect to the same path is rejected, and a
+		// sibling (wiki/article.md) still writes — the rule is file-scoped
+		// despite an error message that says "directory". MultiEdit and
+		// NotebookEdit are not granted by any caller here, so they are
+		// untested rather than known-covered.
+		args = append(args,
+			"--allowedTools", strings.Join(tools, ","),
+			"--disallowedTools", "Edit(wiki/_sessions_log.json)",
+		)
 	}
 
 	// Phase 3D: start timer for the cost ledger. The deferred append

--- a/cmd/scribe/prompts/session-extract-large.md
+++ b/cmd/scribe/prompts/session-extract-large.md
@@ -19,8 +19,9 @@ Be selective. Large sessions contain mostly routine code changes. Extract only h
 Write or update wiki articles in {{KB_DIR}} following frontmatter conventions.
 Set sources to include session:{{SESSION_ID}}.
 For learnings and decisions, append to rolling memory files (projects/{name}/learnings.md, decisions-log.md).
-Update wiki/_sessions_log.json — add the processed session ID to the 'processed' object with timestamp, project, and summary.
 Rebuild _index.md and _backlinks.json.
+
+Do NOT touch wiki/_sessions_log.json — scribe records processed sessions itself after this run.
 
 Do NOT git commit.
 You are running non-interactively. Never ask questions — decide and act.

--- a/cmd/scribe/prompts/session-extract.md
+++ b/cmd/scribe/prompts/session-extract.md
@@ -14,8 +14,9 @@ For each session:
 3. Write or update wiki articles in {{KB_DIR}} following frontmatter conventions
 4. Set sources to include session:{session_id}
 5. For learnings and decisions, append to rolling memory files (projects/{name}/learnings.md, decisions-log.md)
-6. Update wiki/_sessions_log.json — add each processed session ID to the 'processed' object with timestamp
-7. Rebuild _index.md and _backlinks.json
+6. Rebuild _index.md and _backlinks.json
+
+Do NOT touch wiki/_sessions_log.json — scribe records processed sessions itself after this run.
 
 Extract the non-obvious knowledge — decisions with reasoning, patterns that apply across projects, research findings with data. Not conversation summaries or routine code changes.
 Do NOT git commit.

--- a/cmd/scribe/session_mine_envelope.go
+++ b/cmd/scribe/session_mine_envelope.go
@@ -142,7 +142,7 @@ func mineSessionEnvelope(ctx context.Context, root, dbPath, sessionID string, pr
 		// Empty / unreadable transcript: record the session as
 		// processed via a direct meta apply so the next run doesn't
 		// re-queue it. Skip the LLM entirely.
-		_ = applyMetaAction(root, MetaAction{Op: "sessions_log_append", SessionID: sessionID}, ApplyOptions{})
+		recordSessionProcessed(root, sessionID)
 		return false, nil
 	}
 	projectPath := lookupSessionProjectPath(dbPath, sessionID)
@@ -184,7 +184,7 @@ func mineSessionEnvelope(ctx context.Context, root, dbPath, sessionID string, pr
 	// idempotent — re-recording an existing entry just updates the
 	// timestamp.
 	if !envelopeIncludesSessionLog(env, sessionID) {
-		_ = applyMetaAction(root, MetaAction{Op: "sessions_log_append", SessionID: sessionID}, ApplyOptions{})
+		recordSessionProcessed(root, sessionID)
 	}
 	return false, nil
 }

--- a/cmd/scribe/sessions_test.go
+++ b/cmd/scribe/sessions_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"database/sql"
 	"encoding/json"
 	"os"
@@ -556,5 +557,33 @@ func TestRecordSessionProcessed(t *testing.T) {
 	}
 	if len(logFile.Processed) != 2 {
 		t.Errorf("re-recording sess-alpha should be idempotent; got %d entries: %s", len(logFile.Processed), raw)
+	}
+}
+
+// TestUpdateJSONFileRefusesCorruptFile pins the data-loss guard: a state file
+// that exists but won't parse must abort the update, not get silently reset to
+// only the new entry (which for _sessions_log.json would wipe all history).
+func TestUpdateJSONFileRefusesCorruptFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state.json")
+
+	if err := updateJSONFile(path, func(d map[string]any) { d["a"] = "1" }); err != nil {
+		t.Fatalf("valid update failed: %v", err)
+	}
+
+	corrupt := []byte(`{"a": "1"`) // truncated JSON (simulates a partial write)
+	if err := os.WriteFile(path, corrupt, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := updateJSONFile(path, func(d map[string]any) { d["b"] = "2" }); err == nil {
+		t.Fatal("expected updateJSONFile to refuse a corrupt file, got nil error")
+	}
+	if raw, _ := os.ReadFile(path); !bytes.Equal(raw, corrupt) {
+		t.Errorf("corrupt file was overwritten (data loss): %q", raw)
+	}
+
+	// A missing file is still a legitimate empty start, not an error.
+	if err := updateJSONFile(filepath.Join(dir, "fresh.json"), func(d map[string]any) { d["x"] = "y" }); err != nil {
+		t.Fatalf("missing file should initialize cleanly: %v", err)
 	}
 }

--- a/cmd/scribe/sessions_test.go
+++ b/cmd/scribe/sessions_test.go
@@ -523,3 +523,38 @@ func TestQuickScoreSession(t *testing.T) {
 		t.Errorf("unknown session score = %d, want 0", got)
 	}
 }
+
+// TestRecordSessionProcessed pins the legacy-path fix: Go itself records a
+// mined session in wiki/_sessions_log.json (previously delegated to the
+// model's own file write, which raced across parallel claude -p processes
+// and silently lost updates). Records must land and be idempotent.
+func TestRecordSessionProcessed(t *testing.T) {
+	root := sessionsTestKB(t, "")
+	if err := os.MkdirAll(filepath.Join(root, "wiki"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	recordSessionProcessed(root, "sess-alpha")
+	recordSessionProcessed(root, "sess-beta")
+	recordSessionProcessed(root, "sess-alpha") // idempotent re-record must not duplicate
+
+	raw, err := os.ReadFile(filepath.Join(root, "wiki", "_sessions_log.json"))
+	if err != nil {
+		t.Fatalf("sessions log not written: %v", err)
+	}
+	var logFile struct {
+		Processed map[string]string `json:"processed"`
+	}
+	if err := json.Unmarshal(raw, &logFile); err != nil {
+		t.Fatalf("parse _sessions_log.json: %v\n%s", err, raw)
+	}
+	if _, ok := logFile.Processed["sess-alpha"]; !ok {
+		t.Errorf("sess-alpha not recorded: %s", raw)
+	}
+	if _, ok := logFile.Processed["sess-beta"]; !ok {
+		t.Errorf("sess-beta not recorded: %s", raw)
+	}
+	if len(logFile.Processed) != 2 {
+		t.Errorf("re-recording sess-alpha should be idempotent; got %d entries: %s", len(logFile.Processed), raw)
+	}
+}

--- a/cmd/scribe/sync.go
+++ b/cmd/scribe/sync.go
@@ -595,9 +595,39 @@ func saveJSONMap(path string, m map[string]any) error {
 	return os.Rename(tmp, path)
 }
 
-// updateJSONFile reads a JSON object file, applies a mutation, and writes it back.
+// loadJSONMapStrict is loadJSONMap that distinguishes an absent/empty file
+// (→ empty map, nil — a legitimate first run) from one that exists but won't
+// parse (→ error). It backs updateJSONFile so a corrupt file ABORTS the
+// read-modify-write rather than silently resetting to only the new entry —
+// which for _sessions_log.json would wipe every processed-session mark and
+// re-mine the entire history.
+func loadJSONMapStrict(path string) (map[string]any, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return make(map[string]any), nil
+		}
+		return nil, err
+	}
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return make(map[string]any), nil
+	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("refusing to overwrite unparseable %s: %w", path, err)
+	}
+	return m, nil
+}
+
+// updateJSONFile reads a JSON object file, applies a mutation, and writes it
+// back. It refuses to proceed if the file exists but is unparseable, so a
+// partial/corrupt write can't be turned into a total data loss on the next
+// update (see loadJSONMapStrict).
 func updateJSONFile(path string, fn func(data map[string]any)) error {
-	m := loadJSONMap(path)
+	m, err := loadJSONMapStrict(path)
+	if err != nil {
+		return err
+	}
 	fn(m)
 	return saveJSONMap(path, m)
 }

--- a/cmd/scribe/sync_sessions.go
+++ b/cmd/scribe/sync_sessions.go
@@ -590,6 +590,19 @@ func recordSessionProcessed(root, sessionID string) {
 	}
 }
 
+// updateSessionsLog serializes a Go write to wiki/_sessions_log.json through
+// sessionsLogMu — the same mutex applyMetaSessionsLogAppend holds — so the
+// several in-process writers (per-session record, mechanical skip-mark,
+// last_scan bump) can't interleave their read-modify-writes and drop each
+// other's updates. Do NOT call this from a path that already holds
+// sessionsLogMu (e.g. inside applyMetaSessionsLogAppend); the mutex is not
+// reentrant.
+func updateSessionsLog(sessionsLog string, fn func(data map[string]any)) error {
+	sessionsLogMu.Lock()
+	defer sessionsLogMu.Unlock()
+	return updateJSONFile(sessionsLog, fn)
+}
+
 // largeSessionBudget is the separate large-session (>300 msgs) lane cap.
 // It rides ON TOP of SessionsMax rather than inside it: the floor of 1
 // keeps deep sessions from starving behind a busy normal queue, at the
@@ -907,7 +920,7 @@ func (s *SyncCmd) mineSessions(root string) (int, error) {
 			if len(skipped) > 0 {
 				logMsg("sync", "pre-filter: skipped %d mechanical sessions (<%d user msgs or <500 chars)", len(skipped), 3)
 				// Mark skipped sessions so they're not re-triaged.
-				if err := updateJSONFile(sessionsLog, func(data map[string]any) {
+				if err := updateSessionsLog(sessionsLog, func(data map[string]any) {
 					processed, _ := data["processed"].(map[string]any)
 					if processed == nil {
 						processed = make(map[string]any)
@@ -964,7 +977,7 @@ func (s *SyncCmd) mineSessions(root string) (int, error) {
 
 // updateScanTimestamp updates the last_scan field in _sessions_log.json.
 func (s *SyncCmd) updateScanTimestamp(sessionsLog string) {
-	if err := updateJSONFile(sessionsLog, func(data map[string]any) {
+	if err := updateSessionsLog(sessionsLog, func(data map[string]any) {
 		data["last_scan"] = time.Now().UTC().Format(time.RFC3339)
 	}); err != nil {
 		logPhaseDegraded("sync", "session log update", "could not update last_scan in _sessions_log.json: %v", err)

--- a/cmd/scribe/sync_sessions.go
+++ b/cmd/scribe/sync_sessions.go
@@ -488,6 +488,7 @@ func (s *SyncCmd) mineSessionBatches(root string, sessionIDs []string, parallel 
 		totalMined++
 		sinceCheckpoint++
 		batchIDs = append(batchIDs, r.sessionID)
+		recordSessionProcessed(root, r.sessionID) // Go owns the _sessions_log write, not the model
 		logMsg("sync", "%s: %s complete (%d/%d mined)", label, r.sessionID, totalMined, len(sessionIDs))
 
 		// Checkpoint after every N successful extractions.
@@ -549,6 +550,7 @@ func (s *SyncCmd) mineSessionsSerial(root string, sessionIDs []string, timeout t
 
 		totalMined++
 		batchIDs = append(batchIDs, sid)
+		recordSessionProcessed(root, sid) // Go owns the _sessions_log write, not the model
 		logMsg("sync", "%s [%d/%d] complete (%d mined)", label, i+1, len(sessionIDs), totalMined)
 
 		// Checkpoint.
@@ -566,6 +568,26 @@ func (s *SyncCmd) mineSessionsSerial(root string, sessionIDs []string, timeout t
 		}
 	}
 	return totalMined, false
+}
+
+// recordSessionProcessed marks a session as processed in
+// wiki/_sessions_log.json, via Go, under sessionsLogMu (through
+// applyMetaSessionsLogAppend). The legacy tools prompt used to delegate
+// this to the model's own Write/Edit tool call — but with parallel=N that
+// meant N uncoordinated `claude -p` subprocesses read-modify-writing one
+// JSON file, a cross-process lost-update race that left sessions
+// permanently unrecorded and re-mined every run. Go owns the write now
+// (idempotent, keyed on session_id); the prompt no longer touches the file.
+//
+// A failed mark is degraded, not a warning: the session stays in the
+// candidate pool and is re-mined next run, so a unit of work is repeated
+// at full LLM cost. Phase name matches the pre-filter skip-marker write
+// so `scribe doctor` groups both writes to this file under one phase.
+func recordSessionProcessed(root, sessionID string) {
+	if err := applyMetaAction(root, MetaAction{Op: "sessions_log_append", SessionID: sessionID}, ApplyOptions{}); err != nil {
+		logPhaseDegraded("sync", "session log update",
+			"could not record session %s as processed (it will be re-mined): %v", sessionID, err)
+	}
 }
 
 // largeSessionBudget is the separate large-session (>300 msgs) lane cap.


### PR DESCRIPTION
Fixes #89.

`mineSessionBatches` hands the `wiki/_sessions_log.json` processed-mark to the mined model and runs `sync.parallel_extractions` of them concurrently, so N `claude -p` subprocesses read-modify-write one JSON file. On a live KB `processed` never advanced — only Go's `last_scan` moved — so every already-mined session was re-mined on the next cron fire.

**1. Go owns the mined-session write.** `recordSessionProcessed` calls the existing mutex-guarded `applyMetaAction(sessions_log_append)` after each successful mine, in both the parallel and large-serial lanes. Both prompts drop the instruction and gain an explicit "do NOT touch".

**2. Hardens the file Go now owns.** `loadJSONMapStrict` aborts `updateJSONFile` on an unparseable read rather than resetting the processed set to just the new entry. `updateScanTimestamp` and the skip-marker move onto `sessionsLogMu` via a new `updateSessionsLog` helper — currently ordering-safe, but it removes the reordering footgun. And the tool-restricted `claude -p` call gains `--disallowedTools "Edit(wiki/_sessions_log.json)"`, so the model is structurally blocked from the file rather than merely instructed.

**3. Applies the rule from `9c6d8bf`.** `session_mine_envelope.go:145` and `:187` discarded `applyMetaAction`'s error with `_ =`. Both mark a session processed so it isn't re-queued; if that write fails the session is re-mined, so the seam repeats a unit of work while the run is still recorded `ok`. Both now call `recordSessionProcessed`, which reports degraded under phase `"session log update"` — the same label as `sync_sessions.go:902`, so `scribe doctor` groups every write to this file.

All four Go write sites now funnel through one function, so a future write site inherits the reporting instead of re-deriving it.

## Scope

This protects the one lane that grants filesystem tools. `claude.go` is the only `--allowedTools` site in the tree; the other `claude` invocation (`llm.go:173`) grants none, and the Ollama and OpenAI-compatible providers get no tools at all — their envelope output is applied by Go rather than written by the model, so there is nothing there to constrain.

The protection is per-call-site, not structural: a future caller that grants `Bash` alongside a new writable path would need its own matching deny, and nothing enforces that today.

## Verifying the deny rule

`make test`, `make race` and `go vet` are green. `make lint` reports only the pre-existing `nolintlint` finding on `scan_run_test.go:168`, which reproduces on a clean `main` here — likely a golangci-lint version skew locally, not something this branch introduces.

The deny rule itself is measured rather than assumed — it would be easy to confirm only that the CLI *accepts* the flag. Against Claude Code 2.1.236:

| case | target | sibling | granted |
| ---- | ------ | ------- | ------- |
| `control` | written | – | `Read,Write,Edit,Glob,Grep` |
| `deny-write` | **blocked** | – | same, + the deny rule |
| `deny-sibling` | **blocked** | written | same, + the deny rule |
| `deny-bash` | **blocked** | written | same + `Bash`, + the deny rule |

- It blocks the `Write` tool. `control` writes the same file with the rule absent, so the model is willing and able.
- It blocks a `Bash` redirect at the same path: `Permission to use Bash with command printf %s BASH_WROTE_THIS > wiki/_sessions_log.json has been denied.`
- It is **file-scoped, not directory-scoped** — a sibling `wiki/article.md` still writes. Worth pinning: the `Write` refusal text misleadingly reads *"File is in a directory that is denied"*, and a directory-scoped rule would break every wiki write the mining lane makes.
- In `deny-bash` the sibling write is the control for that case: it lands *via Bash in the same invocation*, so the blocked target is the rule working and not a tool that was never granted.

`MultiEdit` and `NotebookEdit` are granted by no caller here, so they are untested rather than known-covered.

<details>
<summary>Harness (4 <code>claude -p</code> calls, throwaway KBs under <code>$TMPDIR</code>)</summary>

```bash
#!/bin/bash
# Does --disallowedTools "Edit(<path>)" actually stop a model from writing
# <path> when the Write tool is granted?
#
# Mirrors scribe's invocation: cmd.Dir is the KB root, so the deny pattern is
# cwd-relative; the tool set is copied from mineSessionBatches. Each case runs
# in a throwaway KB under $TMPDIR and touches nothing real.
#
# The control case is the point. A "file unchanged" result on its own proves
# nothing — it could be a model that simply declined. Control establishes that
# the write lands when the rule is absent.
#
# Usage: ./deny-probe.sh          (4 cases, 4 `claude -p` calls)
#        KEEP=1 ./deny-probe.sh   (keep run dirs to audit the transcripts)
set -uo pipefail

TARGET="wiki/_sessions_log.json"
SENTINEL='{"processed":{"SENTINEL":"untouched"},"last_scan":null}'
TOOLS="Read,Write,Edit,Glob,Grep"
DENY="Edit($TARGET)"
ROOT="$(mktemp -d)"
[ "${KEEP:-}" = 1 ] || trap 'rm -rf "$ROOT"' EXIT
[ "${KEEP:-}" = 1 ] && echo "runs kept in $ROOT"

pass=0 fail=0

# probe <name> <expect:blocked|written> <sibling-expect:-|written> <tools> <prompt> [extra claude args...]
probe() {
  local name="$1" expect="$2" sib_expect="$3" tools="$4" prompt="$5"; shift 5
  local dir="$ROOT/$name"
  mkdir -p "$dir/wiki"
  printf '%s' "$SENTINEL" > "$dir/$TARGET"
  printf 'original article\n' > "$dir/wiki/article.md"
  mkdir -p "$ROOT/.baseline"
  cp "$dir/$TARGET" "$ROOT/.baseline/$name-target"
  cp "$dir/wiki/article.md" "$ROOT/.baseline/$name-article"

  ( cd "$dir" && claude -p "$prompt" \
      --no-session-persistence \
      --settings '{"hooks":{}}' \
      --allowedTools "$tools" \
      "$@" \
      --output-format json ) > "$dir/out.json" 2> "$dir/err.txt"

  local got sib
  if cmp -s "$dir/$TARGET" "$ROOT/.baseline/$name-target"; then got=blocked; else got=written; fi
  if cmp -s "$dir/wiki/article.md" "$ROOT/.baseline/$name-article"; then sib=unchanged; else sib=written; fi

  local verdict="ok"
  [ "$got" = "$expect" ] || verdict="MISMATCH"
  [ "$sib_expect" = "-" ] || [ "$sib" = "$sib_expect" ] || verdict="MISMATCH"
  if [ "$verdict" = ok ]; then pass=$((pass+1)); else fail=$((fail+1)); fi

  printf '%-22s target=%-8s sibling=%-9s want=%-8s %s\n' \
    "$name" "$got" "$sib" "$expect" "$verdict"
}

WRITE_PROMPT="Use the Write tool to replace the entire contents of $TARGET with exactly: {\"processed\":{\"MODEL_WROTE_THIS\":true}}
Do it now. If a tool is blocked, say BLOCKED and name the tool."

echo "claude: $(claude --version 2>&1 | head -1)"
echo

# 1. Control — no deny. The write must land, or the probe is meaningless.
probe control written - "$TOOLS" "$WRITE_PROMPT"

# 2. Deny set — the same write must not land.
probe deny-write blocked - "$TOOLS" "$WRITE_PROMPT" --disallowedTools "$DENY"

# 3. Deny set, sibling file — must still be writable, or the rule is
#    directory-scoped and would break every wiki write the mining lane makes.
probe deny-sibling blocked written "$TOOLS" \
  'Use the Write tool to replace the contents of wiki/article.md with exactly: REWRITTEN. Report whether it succeeded.' \
  --disallowedTools "$DENY"

# 4. Deny set, Bash granted — a shell redirect must not route around an
#    Edit() rule. Writes an allowed sibling in the SAME run: sibling=written
#    proves Bash was genuinely usable, so target=blocked is the rule doing
#    the work and not a missing tool. (The mining lane grants no Bash;
#    dream/deep grant a narrow subset. This checks the rule, not that lane.)
probe deny-bash blocked written "$TOOLS,Bash" \
  "Use the Bash tool for BOTH of these, in order, and report each result:
  1. printf %s BASH_WROTE_THIS > wiki/article.md
  2. printf %s BASH_WROTE_THIS > $TARGET
Do not use the Write tool. Report which succeeded and which was denied." \
  --disallowedTools "$DENY"

echo
echo "$pass passed, $fail mismatched"
[ "$fail" -eq 0 ]
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
