### PR TITLE
fix(config): default the anthropic model so an unset model stops 400ing

### DIFF
--- a/cmd/scribe/config_llm.go
+++ b/cmd/scribe/config_llm.go
@@ -364,6 +364,18 @@ func inheritLLMOpBase(provider, model, ollamaURL *string, llm LLMConfig) {
 	if *model == "" {
 		*model = llm.Model
 	}
+	// Backstop the model the same way the provider is backstopped above.
+	// An anthropic op that reaches the backend with model=="" sends
+	// `--model ""`, which the Claude CLI rejects with `API Error: 400
+	// model: String should have at least 1 character` — and because the
+	// per-op config inherits an empty top-level llm.model, that failure
+	// is silent and permanent (it broke `dream --hot` on every run).
+	// Only anthropic gets a literal default: ollama is handled by
+	// coerceProviderModel, and guessing a model id for a hosted provider
+	// would trade a clear 400 for a confusing one.
+	if *model == "" && strings.EqualFold(*provider, "anthropic") {
+		*model = defaultAnthropicModel
+	}
 	if *ollamaURL == "" {
 		*ollamaURL = llm.OllamaURL
 	}
@@ -550,6 +562,11 @@ const ollamaRecommendedModel = "gemma3:4b"
 // fallback whenever neither a per-op block nor the top-level llm block
 // sets ollama_url.
 const defaultOllamaURL = "http://localhost:11434"
+
+// defaultAnthropicModel is the last-resort model for an anthropic op
+// whose model is unset at every config level. Matches the
+// `default_model` seeded by init (config.go).
+const defaultAnthropicModel = "sonnet"
 
 // claudeModelAliases are the model names `claude -p` accepts. Anything in
 // this list is a red flag when the provider is ollama — the user probably

--- a/cmd/scribe/dream_hot_test.go
+++ b/cmd/scribe/dream_hot_test.go
@@ -560,3 +560,78 @@ func TestRunHotDream_DryRunMakesNoLLMCallsOrCommits(t *testing.T) {
 		t.Errorf("git log changed under --dry-run: before=%q after=%q", beforeLog, afterLog)
 	}
 }
+
+// An anthropic op with no model anywhere in the config resolved to
+// `--model ""`, which the Claude CLI rejects with
+// `API Error: 400 model: String should have at least 1 character`.
+// The KB ships `llm: {provider: anthropic, model: ""}` and no `dream:`
+// section, so every dream --hot run failed on it. inheritLLMOpBase now
+// backstops the model the same way it already backstops the provider.
+func TestInheritLLMOpBase_AnthropicNeverYieldsEmptyModel(t *testing.T) {
+	ops := map[string]func(LLMConfig) string{
+		"dream": func(llm LLMConfig) string {
+			c := DreamConfig{}
+			applyDreamDefaults(&c, llm)
+			return c.Model
+		},
+		"assess": func(llm LLMConfig) string {
+			c := AssessConfig{}
+			applyAssessDefaults(&c, llm)
+			return c.Model
+		},
+		"deep_ingest": func(llm LLMConfig) string {
+			c := DeepIngestConfig{}
+			applyDeepIngestDefaults(&c, llm)
+			return c.Model
+		},
+		"extract": func(llm LLMConfig) string {
+			c := ExtractConfig{}
+			applyExtractDefaults(&c, llm)
+			return c.Model
+		},
+		"relations": func(llm LLMConfig) string {
+			c := RelationsConfig{}
+			applyRelationsDefaults(&c, llm)
+			return c.Model
+		},
+		"session_mine": func(llm LLMConfig) string {
+			c := SessionMineConfig{}
+			applySessionMineDefaults(&c, llm)
+			return c.Model
+		},
+	}
+
+	// The exact shape of the maintainer KB's scribe.yaml.
+	llm := LLMConfig{Provider: "anthropic", Model: ""}
+	for name, resolve := range ops {
+		if got := resolve(llm); got == "" {
+			t.Errorf("%s: model resolved to \"\" — would send --model \"\" and 400", name)
+		}
+	}
+
+	// A wholly empty LLMConfig also lands on anthropic (provider
+	// fallback), so it must get a model too.
+	for name, resolve := range ops {
+		if got := resolve(LLMConfig{}); got == "" {
+			t.Errorf("%s: empty LLMConfig resolved model to \"\"", name)
+		}
+	}
+
+	// An explicit model is never overridden.
+	for name, resolve := range ops {
+		if got := resolve(LLMConfig{Provider: "anthropic", Model: "haiku"}); got != "haiku" {
+			t.Errorf("%s: model = %q, want %q (explicit config must win)", name, got, "haiku")
+		}
+	}
+
+	// The anthropic default must not leak onto ollama: an ollama op with
+	// no model is coerceProviderModel's job and must land on the
+	// recommended ollama model, never a Claude alias. Guards the
+	// EqualFold(provider, "anthropic") condition — drop it and every
+	// ollama-only KB silently starts asking Ollama for "sonnet".
+	for name, resolve := range ops {
+		if got := resolve(LLMConfig{Provider: "ollama", Model: ""}); got != ollamaRecommendedModel {
+			t.Errorf("%s: ollama model = %q, want %q (anthropic default must not leak)", name, got, ollamaRecommendedModel)
+		}
+	}
+}

--- a/cmd/scribe/llm.go
+++ b/cmd/scribe/llm.go
@@ -199,7 +199,7 @@ func (a *anthropicProvider) Generate(ctx context.Context, prompt string) (string
 		default:
 			entry.ErrKind = "other"
 		}
-		return tailLines(combined, 15), fmt.Errorf("claude -p: %w", err)
+		return tailLines(combined, 15), fmt.Errorf("claude -p: %w\n%s", err, tailLines(combined, 15))
 	}
 
 	env, ok := parseClaudeResult(stdoutStr)


### PR DESCRIPTION
Fixes #96.

`inheritLLMOpBase` backstops the provider twice but never the model, and `coerceProviderModel` returns early unless the provider is `ollama`. So a KB with `llm: {provider: anthropic, model: ""}` — what `init` seeds when run without a model — and no per-op section resolved to an empty model for all six ops sharing the helper, sending `--model ""` and taking a 400 on every run.

**The fix** adds a literal default for `anthropic` only. `ollama` is already handled by `coerceProviderModel`, and guessing an id for a hosted provider would trade a clear 400 for a confusing one. `defaultAnthropicModel` is `"sonnet"`, matching the `DefaultModel` that `init` seeds at `config.go:682`.

**Also stops `llm.go` discarding the diagnosis.** `llm.go:202` returned a bare `claude -p: exit status 1` while `claude.go:154` already appended the stderr tail; that asymmetry is why 12 days of run records carried no cause. Now identical.

## Verification

A table over all six ops (`relations`, `dream`, `assess`, `deep-ingest`, `extract`, `session-mine`) asserts none resolves to an empty model, in four scenarios:

- the maintainer-KB shape (`{anthropic, ""}`)
- a wholly empty `LLMConfig`, which lands on `anthropic` via the provider fallback and so also needs a model
- an explicit model still wins and is never overridden
- **the anthropic default does not leak onto ollama** — an ollama op with no model must land on `ollamaRecommendedModel`. Drop the `EqualFold` guard and every ollama-only KB silently starts asking Ollama for `"sonnet"`; this pins that.

End to end: `dream --hot` completes against a real KB (2 actions applied, 206 → 207 articles), and that run's record is the first `status=ok` dream-hot since 2026-08-17.

`make test`, `make race` and `go vet` are green. `make lint` reports only the pre-existing `nolintlint` finding on `scan_run_test.go:168`, which reproduces on a clean `main` here and passed CI on #90 — a local golangci-lint version skew, not this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
