### PR TITLE
fix(sync): stop undrainable sessions from occupying every admission slot

### DIFF
--- a/cmd/scribe/sync_sessions.go
+++ b/cmd/scribe/sync_sessions.go
@@ -120,6 +120,50 @@ func filterSessionsByScope(root, dbPath string, sessionIDs []string) []string {
 	return kept
 }
 
+// Drop reasons returned by sessionDropReason. Empty string means the
+// session is admissible.
+const (
+	dropReasonKB      = "kb"      // session was spent inside a scribe KB
+	dropReasonScope   = "scope"   // ignored, too shallow, or excluded by sources
+	dropReasonPending = "pending" // project exists but is not approved yet
+)
+
+// sessionDropReason is the single definition of "the miner cannot process
+// a session from this project", covering every drop that leaves the
+// session UNMARKED — i.e. still a candidate on the next run. The
+// mechanical/thin gate is deliberately not here: those are marked
+// processed and leave the pool for good.
+//
+// Two callers share it, and they must agree or the admission window
+// starves. preFilterSessions applies it after triage has already picked
+// the top N; `triage --in-scope` applies it while picking, so a session
+// this returns non-empty for never consumes one of those N slots. When
+// they disagreed, a project deep enough to be approved but shallow enough
+// to be ignored (every repo directly under a mount root: /Volumes/X/repo
+// is 3 segments, isIgnored wants 4) produced a permanent deadlock —
+// status counted the sessions as pending, triage ranked them top, the
+// pre-filter dropped them unmarked, and they ranked top again forever
+// while admissible sessions never got a slot. See issue #86's sibling.
+func sessionDropReason(cfg *ScribeConfig, manifest *Manifest, root, projectPath string) string {
+	if sessionInKB(root, projectPath) {
+		return dropReasonKB
+	}
+	if !projectScopeAllowed(cfg, manifest, projectPath) {
+		return dropReasonScope
+	}
+	// entryForPath rather than a keyed lookup: a session run inside a
+	// pending project's WORKTREE must inherit the pending status (the
+	// worktree's basename is not a manifest key), and a basename
+	// collision must not let one project's approval state govern
+	// another's sessions.
+	if manifest != nil && projectPath != "" {
+		if entry := manifest.entryForPath(projectPath); entry != nil && !entry.IsApproved() {
+			return dropReasonPending
+		}
+	}
+	return ""
+}
+
 // preFilterSessions removes sessions that are too mechanical to be worth
 // extracting, and — independently — sessions that were spent inside the KB
 // itself (mining those re-emits the wiki's own content). Queries ccrider DB
@@ -159,32 +203,23 @@ func preFilterSessions(root, dbPath string, sessionIDs []string) (kept, skipped 
 			kept = append(kept, sid) // On error, keep the session.
 			continue
 		}
-		if sessionInKB(root, stats.ProjectPath) {
-			// Drop silently (not into `skipped`): the caller marks
-			// skipped IDs as mechanically processed, which would be the
-			// wrong reason. KB sessions can't resurface anyway — triage
-			// now excludes them and the hook no longer queues them.
+		// Every branch here drops SILENTLY (not into `skipped`): the
+		// caller marks skipped IDs as mechanically processed, which
+		// would be the wrong reason, and a scope/approval drop must stay
+		// re-mineable if the KB's scope later widens. Because they stay
+		// unmarked they also keep ranking, which is why `triage
+		// --in-scope` applies the same predicate while picking — see
+		// sessionDropReason.
+		switch sessionDropReason(cfg, manifest, root, stats.ProjectPath) {
+		case dropReasonKB:
 			kbSkipped++
 			continue
-		}
-		if !projectScopeAllowed(cfg, manifest, stats.ProjectPath) {
-			// Out-of-scope for this KB (ignored or excluded by sources).
-			// Drop silently like KB sessions: marking them processed would
-			// lie, and they must stay re-mineable if the KB's scope later
-			// widens to include the project.
+		case dropReasonScope:
 			scopeSkipped++
 			continue
-		}
-		if manifest != nil && stats.ProjectPath != "" {
-			// entryForPath rather than a keyed lookup: a session run
-			// inside a pending project's WORKTREE must inherit the
-			// pending status (the worktree's basename is not a manifest
-			// key), and a basename collision must not let one project's
-			// approval state govern another's sessions.
-			if entry := manifest.entryForPath(stats.ProjectPath); entry != nil && !entry.IsApproved() {
-				pendingSkipped++
-				continue
-			}
+		case dropReasonPending:
+			pendingSkipped++
+			continue
 		}
 		if stats.filterVerdict() != "" {
 			skipped = append(skipped, sid)
@@ -913,7 +948,7 @@ func (s *SyncCmd) mineSessions(root string) (int, error) {
 	// every slot and starve approved projects indefinitely (they rank
 	// N+1 forever). Priority-lane admission (admitForPool) handles the
 	// trim to SessionsMax internally, after the filter below runs.
-	triagedNormal := s.triageSessionsScored(s.SessionsMax*3, "--message-limit", "300")
+	triagedNormal := s.triageSessionsScored(s.SessionsMax*3, "--in-scope", "--message-limit", "300")
 	normalIDs := admitForPool(pendingNormal, triagedNormal, s.SessionsMax, cfg.PriorityLanes,
 		func(ids []string) []string {
 			kept, skipped := preFilterSessions(root, cfg.CcriderDB, ids)
@@ -960,7 +995,7 @@ func (s *SyncCmd) mineSessions(root string) (int, error) {
 		// normal-pool over-fetch rationale — otherwise the 70/30 split
 		// silently collapses to 100% Normal whenever Hot's candidate pool
 		// is thin (see docs/issue-22-priority-lanes-plan.md §3.5).
-		triagedLarge := s.triageSessionsScored(largeMax*3, "--min-messages", "301")
+		triagedLarge := s.triageSessionsScored(largeMax*3, "--in-scope", "--min-messages", "301")
 		largeIDs := admitForPool(pendingLarge, triagedLarge, largeMax, cfg.PriorityLanes,
 			func(ids []string) []string { return filterSessionsByScope(root, cfg.CcriderDB, ids) })
 		if len(largeIDs) > 0 {

--- a/cmd/scribe/triage.go
+++ b/cmd/scribe/triage.go
@@ -21,6 +21,7 @@ type TriageCmd struct {
 	Sort         string `help:"Sort order: score (default) or date (newest first)." default:"score" enum:"score,date"`
 	MessageLimit int    `help:"Only include sessions with at most N messages (0=no limit)." name:"message-limit" default:"0"`
 	MinMessages  int    `help:"Only include sessions with at least N messages." name:"min-messages" default:"0"`
+	InScope      bool   `name:"in-scope" help:"Only sessions this KB could actually mine (drops ignored, too-shallow, out-of-sources and unapproved projects). Used by sync so undrainable sessions cannot occupy admission slots."`
 	IDs          bool   `name:"ids" help:"Output session IDs only (for piping)."`
 	Stats        bool   `help:"Show score distribution stats."`
 	JSON         bool   `help:"Output JSON."`
@@ -143,6 +144,76 @@ type triageResult struct {
 	Date      string  `json:"date"`
 	Hours     float64 `json:"hours"`
 	Summary   string  `json:"summary"`
+
+	// rawPath is s.project_path verbatim, unstripped and unexported so it
+	// never reaches --json output. --in-scope needs the real path: the
+	// `project` column above has the ~/Projects prefix removed for display.
+	rawPath string
+}
+
+// inScopeOverfetch is how many rows --in-scope reads per row it intends to
+// return. The predicate runs in Go (path depth, ignore list, sources
+// globs, manifest approval — none of it expressible in this query), so the
+// blockers have to be read before they can be dropped.
+//
+// 20x rather than a smaller constant because the blockers are not randomly
+// distributed: a mount root that collapses many repos into one shallow
+// path tends to score HIGH (long, dense sessions) and so clusters at the
+// exact top of the ordering the miner reads. On the KB this was written
+// for, 10 of the top 11 were undrainable. The cap keeps the worst case
+// bounded on a large ccrider DB.
+const (
+	inScopeOverfetch    = 20
+	inScopeOverfetchCap = 2000
+)
+
+// scanLimit is the SQL LIMIT: t.Top normally, over-fetched under
+// --in-scope so keepInScope can drop blockers and still fill t.Top.
+func (t *TriageCmd) scanLimit() int {
+	if !t.InScope {
+		return t.Top
+	}
+	n := t.Top * inScopeOverfetch
+	if n > inScopeOverfetchCap {
+		n = inScopeOverfetchCap
+	}
+	// Floor applied AFTER the cap on purpose: the cap bounds the
+	// over-fetch, never the request. `--all` sets Top to 99999, and
+	// returning 2000 rows for it would silently truncate.
+	if n < t.Top {
+		n = t.Top
+	}
+	return n
+}
+
+// keepInScope drops sessions the miner could never process and trims back
+// to t.Top. Without --in-scope it is a no-op, so the human-facing `scribe
+// triage` still shows everything (seeing the blockers ranked first is how
+// you diagnose a stalled queue).
+//
+// The predicate is sessionDropReason — the same one preFilterSessions
+// applies after admission. Sharing it is the point: when triage ranked a
+// session the pre-filter then dropped unmarked, that session kept its slot
+// forever and admissible work behind it never ran.
+func (t *TriageCmd) keepInScope(root string, cfg *ScribeConfig, results []triageResult) []triageResult {
+	if !t.InScope {
+		return results
+	}
+	// Fails open on a manifest read error, matching preFilterSessions:
+	// mining a session that should have been skipped is recoverable,
+	// mining nothing is not.
+	manifest, _ := loadManifest(root)
+	kept := make([]triageResult, 0, min(len(results), t.Top))
+	for _, r := range results {
+		if sessionDropReason(cfg, manifest, root, r.rawPath) != "" {
+			continue
+		}
+		kept = append(kept, r)
+		if len(kept) == t.Top {
+			break
+		}
+	}
+	return kept
 }
 
 func (t *TriageCmd) runScoring(db *sql.DB, _ string, excludeIDs []string) error {
@@ -167,6 +238,7 @@ func (t *TriageCmd) runScoring(db *sql.DB, _ string, excludeIDs []string) error 
 	SELECT
 		s.session_id,
 		REPLACE(s.project_path, '%s', '') as project,
+		s.project_path as raw_project_path,
 		s.message_count as msgs,
 		%s as total_score,
 		%s,
@@ -188,7 +260,7 @@ func (t *TriageCmd) runScoring(db *sql.DB, _ string, excludeIDs []string) error 
 	ORDER BY %s
 	LIMIT %d`,
 		ctes, homeProjects, scoreExpr, selectCols, anyHitExpr,
-		excludeClause, kbExcludeClause, projectClause, t.messageLimitClause(), t.orderClause(), t.Top)
+		excludeClause, kbExcludeClause, projectClause, t.messageLimitClause(), t.orderClause(), t.scanLimit())
 
 	rows, err := db.Query(query) //nolint:noctx // CLI top-level, no ctx in scope
 	if err != nil {
@@ -201,7 +273,7 @@ func (t *TriageCmd) runScoring(db *sql.DB, _ string, excludeIDs []string) error 
 		var r triageResult
 		var date, summary sql.NullString
 		var hours sql.NullFloat64
-		err := rows.Scan(&r.SessionID, &r.Project, &r.Msgs, &r.Score,
+		err := rows.Scan(&r.SessionID, &r.Project, &r.rawPath, &r.Msgs, &r.Score,
 			&r.Dec, &r.Arch, &r.Res, &r.Learn, &r.Eval, &r.Deep,
 			&date, &hours, &summary)
 		if err != nil {
@@ -215,6 +287,7 @@ func (t *TriageCmd) runScoring(db *sql.DB, _ string, excludeIDs []string) error 
 	if err := rows.Err(); err != nil {
 		return fmt.Errorf("iterate scoring rows: %w", err)
 	}
+	results = t.keepInScope(root, cfg, results)
 
 	if t.Interactive {
 		// Build fzf input: "session_id\tscore\tproject\tmsgs\tdate\tsummary"

--- a/cmd/scribe/triage_test.go
+++ b/cmd/scribe/triage_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -262,5 +263,125 @@ func TestTriageKeywordTerms(t *testing.T) {
 	}
 	if triageKeywordTerms("   ") != nil {
 		t.Error("blank keyword string should yield nil")
+	}
+}
+
+// The starvation regression. A project can be approved in the manifest and
+// still be undrainable by the miner: isIgnored wants >=4 non-empty path
+// segments, so every repo sitting directly under a mount root
+// (/Volumes/CaseSensitive/dabrain — 3) is dropped as too shallow. Those
+// drops are silent and leave the session UNMARKED, so it keeps its rank.
+//
+// Before --in-scope the miner asked triage for SessionsMax*3 rows and
+// filtered afterwards, so a cluster of shallow-path sessions ranked at the
+// top consumed the whole admission window every run. Observed live: 10 of
+// the top 11, `no normal sessions to mine`, and a 72-session backlog that
+// never moved. keepInScope drops them while picking instead.
+func TestKeepInScope_BlockersDoNotConsumeAdmissionSlots(t *testing.T) {
+	root := sessionsTestKB(t, "")
+	deep := "/home/dev/projects/alpha"  // 4 segments — admissible
+	shallow := "/Volumes/CaseSensitive" // 2 segments — always too shallow
+
+	manifest := `{"projects": {"alpha": {"path": ` + jsonQuote(deep) + `, "status": "approved"}}}`
+	writeKBFile(t, root, "scripts/projects.json", manifest)
+	cfg := loadConfig(root)
+
+	// Ten blockers outranking three admissible sessions, mirroring the
+	// live ordering (blockers score high: they are long, dense sessions).
+	results := make([]triageResult, 0, 13)
+	for i := range 10 {
+		results = append(results, triageResult{
+			SessionID: fmt.Sprintf("blocker-%d", i), Score: 100 - i, rawPath: shallow,
+		})
+	}
+	for i := range 3 {
+		results = append(results, triageResult{
+			SessionID: fmt.Sprintf("good-%d", i), Score: 50 - i, rawPath: deep,
+		})
+	}
+
+	t.Run("in-scope drops blockers and fills the window", func(t *testing.T) {
+		cmd := &TriageCmd{Top: 3, InScope: true}
+		got := cmd.keepInScope(root, cfg, results)
+		if len(got) != 3 {
+			t.Fatalf("got %d rows, want 3 — blockers still consuming slots", len(got))
+		}
+		for _, r := range got {
+			if r.rawPath != deep {
+				t.Errorf("admitted %s from %s, want only %s", r.SessionID, r.rawPath, deep)
+			}
+		}
+	})
+
+	t.Run("without the flag nothing is filtered", func(t *testing.T) {
+		cmd := &TriageCmd{Top: 3, InScope: false}
+		got := cmd.keepInScope(root, cfg, results)
+		if len(got) != len(results) {
+			t.Errorf("got %d rows, want %d — plain `scribe triage` must still show blockers", len(got), len(results))
+		}
+	})
+
+	t.Run("trims to Top even when everything is admissible", func(t *testing.T) {
+		onlyGood := results[10:]
+		cmd := &TriageCmd{Top: 2, InScope: true}
+		if got := cmd.keepInScope(root, cfg, onlyGood); len(got) != 2 {
+			t.Errorf("got %d rows, want 2", len(got))
+		}
+	})
+}
+
+// scanLimit must over-fetch under --in-scope (the predicate is Go-side, so
+// blockers have to be read before they can be dropped) and must not change
+// the row count a plain `scribe triage --top N` reads.
+func TestScanLimit_OverfetchesOnlyForInScope(t *testing.T) {
+	if got := (&TriageCmd{Top: 9}).scanLimit(); got != 9 {
+		t.Errorf("plain triage scanLimit = %d, want 9 (unchanged)", got)
+	}
+	if got := (&TriageCmd{Top: 9, InScope: true}).scanLimit(); got != 9*inScopeOverfetch {
+		t.Errorf("in-scope scanLimit = %d, want %d", got, 9*inScopeOverfetch)
+	}
+	// The cap bounds the OVER-FETCH, not the request: at Top=200 the 20x
+	// would be 4000, so the cap applies.
+	if got := (&TriageCmd{Top: 200, InScope: true}).scanLimit(); got != inScopeOverfetchCap {
+		t.Errorf("capped scanLimit = %d, want %d", got, inScopeOverfetchCap)
+	}
+	// But --all sets Top to 99999, and scanning fewer rows than Top would
+	// silently truncate what was explicitly asked for — the floor wins.
+	if got := (&TriageCmd{Top: 99999, InScope: true}).scanLimit(); got != 99999 {
+		t.Errorf("--all scanLimit = %d, want 99999 (floor beats cap)", got)
+	}
+}
+
+// sessionDropReason is shared by keepInScope and preFilterSessions; if they
+// disagree the window starves again. Pins each reason, including the
+// approved-but-too-shallow case that caused the live deadlock.
+func TestSessionDropReason(t *testing.T) {
+	root := sessionsTestKB(t, "")
+	deep := "/home/dev/projects/alpha"
+	pendingProj := "/home/dev/projects/beta"
+	manifest := `{"projects": {` +
+		`"alpha": {"path": ` + jsonQuote(deep) + `, "status": "approved"},` +
+		`"beta": {"path": ` + jsonQuote(pendingProj) + `, "status": "pending"}}}`
+	writeKBFile(t, root, "scripts/projects.json", manifest)
+	cfg := loadConfig(root)
+	m, err := loadManifest(root)
+	if err != nil {
+		t.Fatalf("loadManifest: %v", err)
+	}
+
+	cases := []struct{ name, path, want string }{
+		{"approved and deep enough", deep, ""},
+		{"approved but too shallow", "/Volumes/CaseSensitive", dropReasonScope},
+		{"repo directly under a mount root", "/Volumes/CaseSensitive/dabrain", dropReasonScope},
+		{"session run inside the KB", root, dropReasonKB},
+		{"project not approved yet", pendingProj, dropReasonPending},
+		{"no provenance recorded", "", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := sessionDropReason(cfg, m, root, c.path); got != c.want {
+				t.Errorf("sessionDropReason(%q) = %q, want %q", c.path, got, c.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fixes #102.

A scope-rejected session is left unmarked on purpose, so it keeps its score and wins the same admission slot every run. The scope filter runs *after* the fixed `SessionsMax*3` window has already been picked, so once enough blockers outrank the admissible work, nothing is ever admitted again.

The fix applies the predicate while **picking** instead of after admitting.

- **`sessionDropReason`** is now the single definition of "the miner cannot process a session from this project" — `kb` / `scope` / `pending` / `""`. It covers every drop that leaves a session unmarked and therefore still competing. The mechanical/thin gate stays out of it deliberately: those *are* marked processed and leave the pool for good.
- **`preFilterSessions`** routes its branches through it, keeping its per-reason counters and log lines unchanged.
- **`triage --in-scope`** applies the same predicate while selecting, so a blocker never consumes a slot. Both mining lanes pass it. Plain `scribe triage` is untouched — seeing the blockers ranked first is how a stalled queue gets diagnosed in the first place.

Sharing one predicate is the point rather than an aesthetic: the two sites starve the moment they disagree, which is exactly what happened when a project could be approved by the manifest and rejected by the depth floor.

## Implementation notes

`--in-scope` over-fetches 20× internally, capped at 2000. The predicate is Go — path depth, ignore list, `sources` globs, manifest approval, none of it expressible in the scoring query — so blockers have to be read before they can be dropped. 20× rather than something smaller because blockers cluster at the *top* of the ordering: a collapsed mount root aggregates long, dense sessions, which is what triage scores highest.

The floor is applied after the cap, so `--all` (`Top=99999`) is not silently truncated to 2000.

## Verification

Same corpus, same window of 9, before and after:

| | admission window |
| --- | --- |
| before | 9/9 undrainable — mount root and the KB's own repo |
| after | 9/9 admissible — depth-6 worktrees across four approved projects |

`TestKeepInScope_BlockersDoNotConsumeAdmissionSlots` reproduces the live shape — 10 blockers outranking 3 admissible — and fails on the old behaviour. Alongside it: the no-flag no-op (plain `triage` must still show everything), the trim case, `scanLimit`'s cap-then-floor ordering, and a `sessionDropReason` table pinning each reason including the approved-but-too-shallow case that caused the deadlock.

`make test`, `make race` and `go vet` are green. `make lint` reports only the pre-existing `nolintlint` finding on `scan_run_test.go:168`, which reproduces on a clean `main` here and passed CI on #90 — a local golangci-lint version skew, not this branch.

## Not addressed here

The depth floor itself. Requiring 4 non-empty segments means an ordinary layout like `/Volumes/Work/myrepo` can never be mined, which seems worth a separate conversation — but it is a design question, the deadlock is fixable without touching it, and this change does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
