### PR TITLE
fix(sync): make staged drop files trigger extraction

### DIFF
--- a/cmd/scribe/sync_extract.go
+++ b/cmd/scribe/sync_extract.go
@@ -208,6 +208,19 @@ func (s *SyncCmd) projectsNeedingExtraction(root string, manifest *Manifest) []s
 			continue
 		}
 
+		// Staged drop files are pending work even when the repo has not
+		// moved. collectDropFiles stages them into output/drops-<name>/ and
+		// only extractProject consumes them, so a project whose sole pending
+		// work is a drop must still be a candidate. Without this a low-churn
+		// repo strands its drops forever: the SHA never changes, extraction
+		// never runs, and collectDropFiles re-copies and re-logs the same
+		// files every run while the summary reports them collected and
+		// absorbed 0 — a green signal for work that never happened.
+		if hasPendingDrops(root, entry.Name) {
+			result = append(result, key)
+			continue
+		}
+
 		// Never extracted.
 		if entry.LastSHA == "" {
 			result = append(result, key)
@@ -265,6 +278,18 @@ func (s *SyncCmd) projectsNeedingExtraction(root string, manifest *Manifest) []s
 
 	sort.Strings(result)
 	return result
+}
+
+// hasPendingDrops reports whether collectDropFiles has staged drop files
+// for this project that extraction has not consumed yet. extractProject
+// clears the staging dir only on a successful run, so a failed extraction
+// correctly leaves the project a candidate for the next one.
+//
+// pname is entry.Name — the short display name collectDropFiles uses to
+// build the staging path, never the manifest's canonical-path key.
+func hasPendingDrops(root, pname string) bool {
+	drops, _ := filepath.Glob(filepath.Join(root, "output", "drops-"+pname, "*.md"))
+	return len(drops) > 0
 }
 
 // hasNewerFiles checks if any .md files in a non-git project are newer than the last extraction.

--- a/cmd/scribe/sync_extract_test.go
+++ b/cmd/scribe/sync_extract_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -78,5 +80,78 @@ func TestProjectsNeedingExtractionUnchangedSummary(t *testing.T) {
 				t.Errorf("summary %q missing from output:\n%s", tc.wantSummary, out)
 			}
 		})
+	}
+}
+
+// TestProjectsNeedingExtractionPendingDrops locks the drop-file gap: a
+// project whose repo has not moved is normally "unchanged", but a drop file
+// staged into output/drops-<name>/ is pending work that ONLY extractProject
+// consumes. Before this, a low-churn repo stranded its drops forever —
+// collectDropFiles re-copied and re-logged the same files every run while
+// the summary reported them collected and absorbed 0.
+func TestProjectsNeedingExtractionPendingDrops(t *testing.T) {
+	root := t.TempDir()
+	idle := &ProjectEntry{
+		Name:          "idle-project",
+		Path:          t.TempDir(),
+		LastSHA:       "deadbeef",
+		LastExtracted: time.Now().UTC().Format(time.RFC3339),
+	}
+	m := &Manifest{Projects: map[string]*ProjectEntry{idle.Path: idle}}
+	s := &SyncCmd{}
+	captureSyncLog(t)
+
+	// Baseline: unchanged and no drops staged → not a candidate.
+	if got := s.projectsNeedingExtraction(root, m); len(got) != 0 {
+		t.Fatalf("unchanged project with no drops should not need extraction, got %v", got)
+	}
+
+	// Stage a drop exactly as collectDropFiles does (entry.Name, not the key).
+	staging := filepath.Join(root, "output", "drops-"+idle.Name)
+	if err := os.MkdirAll(staging, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(staging, "2026-01-01-note.md"), []byte("# note\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := s.projectsNeedingExtraction(root, m)
+	if len(got) != 1 {
+		t.Fatalf("project with a staged drop file should need extraction, got %v", got)
+	}
+	if got[0] != idle.Path {
+		t.Errorf("returned key %q, want the manifest key %q", got[0], idle.Path)
+	}
+}
+
+// TestHasPendingDropsIgnoresNonMarkdownAndMissingDir guards the predicate
+// itself: only *.md counts (collectDropFiles writes markdown), and a
+// missing staging dir is not an error.
+func TestHasPendingDropsIgnoresNonMarkdownAndMissingDir(t *testing.T) {
+	root := t.TempDir()
+	if hasPendingDrops(root, "nope") {
+		t.Error("missing staging dir should report no pending drops")
+	}
+
+	staging := filepath.Join(root, "output", "drops-proj")
+	if err := os.MkdirAll(staging, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if hasPendingDrops(root, "proj") {
+		t.Error("empty staging dir should report no pending drops")
+	}
+
+	if err := os.WriteFile(filepath.Join(staging, "notes.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if hasPendingDrops(root, "proj") {
+		t.Error("non-markdown file should not count as a pending drop")
+	}
+
+	if err := os.WriteFile(filepath.Join(staging, "real.md"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !hasPendingDrops(root, "proj") {
+		t.Error("markdown drop file should count as pending")
 	}
 }


### PR DESCRIPTION
Fixes #104.

## The gap

Drop files are consumed only inside `extractProject` — `collectDropFiles` stages them into `output/drops-<name>/`, the extraction prompt is told to process them, and the staging dir is cleared afterwards. But `projectsNeedingExtraction` selected candidates purely on a changed git SHA (or newer `.md` files for non-git projects) and never looked at the staging dir, so a project whose only pending work was a drop file was classified `unchanged` and skipped.

For a low-churn repo that is permanent: the SHA never moves, extraction never runs, and `collectDropFiles` re-copies the same files on every run — logging `N drop file(s) collected` each time while the summary reports `absorbed: 0`. The log line implies the drops were handled, which is what makes it hard to notice.

## The change

Treat a non-empty staging dir as pending work, alongside the existing "newer `.md` files make a non-git project eligible" rule:

```go
if hasPendingDrops(root, entry.Name) {
    result = append(result, key)
    continue
}
```

plus a small predicate that globs `output/drops-<name>/*.md`.

`pname` is `entry.Name`, matching what `collectDropFiles` uses to build the staging path — not the manifest's canonical-path key.

## Why this is safe

- **Retries rather than loses.** `extractProject` returns early at `sync_extract.go:384` on extraction error and stamps `LastDropProcessed` / removes the staging dir only on success, so a failed drop-triggered extraction leaves the project a candidate next run. The alternative (stamping on failure) would turn a stall into data loss.
- **Heals in one run.** `collectPhase` runs before `extractPhase` in the same sync, so a drop staged at the top of a run is picked up by extraction later in that same run — no "wait for the next cron" gap.
- **Doesn't fight the file-count gate.** A drop-triggered extraction on an unchanged repo has 0 changed files, so `sync.max_extract_files` doesn't block it.

## Tests

Two added:

- `TestProjectsNeedingExtractionPendingDrops` — asserts an unchanged project is *not* a candidate with no drops, then *is* one after a drop is staged the way `collectDropFiles` stages it.
- `TestHasPendingDropsIgnoresNonMarkdownAndMissingDir` — guards the predicate: missing dir, empty dir, and non-markdown files all report no pending drops; a `.md` does.

Verified the first test actually catches the bug — with the production change reverted it fails with exactly the observed symptom (`got []`), and passes with it. `make check` (full suite + `go vet`) is green, `gofmt` clean.

12 lines of production code, no behaviour change for any project that already extracts.
