### PR TITLE
fix(manifest): stop the depth floor from vetoing enrolled projects

### DIFF
--- a/cmd/scribe/manifest.go
+++ b/cmd/scribe/manifest.go
@@ -216,6 +216,22 @@ func (m *Manifest) save() error {
 
 // isIgnored checks if a path is in the ignored list, too shallow, or under a
 // macOS TCC-protected location whose first access would prompt the user.
+//
+// The depth floor is an *enrollment* heuristic: it stops discovery from
+// auto-enrolling a path so broad it would sweep every repo beneath it
+// (~/src, a bare mount root). It is not a claim that such a path is
+// unusable, so it must not outlive the decision it guards — once a project
+// is in the manifest the user has already made that call explicitly, via
+// discovery-plus-approval or `scribe projects add`. Applying the floor to an
+// enrolled project instead silently voids that decision on every path that
+// consults this, and the session lane is one of them: a repo checked out
+// directly under a mount root (3 segments) has every one of its sessions
+// dropped by projectScopeAllowed, forever, with no log line and no way to
+// override it from config.
+//
+// The TCC, within-a-KB and explicit-ignore gates below are deliberately NOT
+// waived for enrolled projects. Those encode hazards and explicit user
+// intent respectively; the depth floor encodes neither.
 func (m *Manifest) isIgnored(path string) bool {
 	parts := strings.Split(path, "/")
 	nonEmpty := 0
@@ -224,7 +240,7 @@ func (m *Manifest) isIgnored(path string) bool {
 			nonEmpty++
 		}
 	}
-	if nonEmpty < 4 {
+	if nonEmpty < 4 && m.entryForPath(path) == nil {
 		return true
 	}
 	if isTCCProtected(path) {

--- a/cmd/scribe/manifest_test.go
+++ b/cmd/scribe/manifest_test.go
@@ -904,3 +904,60 @@ func TestManifestUniqueName(t *testing.T) {
 		t.Errorf("self-match = %q, want api (not a collision with its own entry)", got)
 	}
 }
+
+// TestManifestIsIgnoredEnrolledProjectDefeatsDepthFloor pins the split
+// between the depth heuristic and the hazard gates. The floor exists to stop
+// discovery auto-enrolling an over-broad path; once a project IS enrolled the
+// user has made that call, so the floor must not keep vetoing it. A repo
+// checked out directly under a mount root (/Volumes/Vol/repo, 3 segments) is
+// the case that matters: before this, projectScopeAllowed dropped every
+// session from such a project, permanently and silently.
+//
+// TCC, within-a-KB and the explicit ignore list are NOT waived by enrollment
+// — they encode a real hazard and an explicit user decision, not a guess.
+func TestManifestIsIgnoredEnrolledProjectDefeatsDepthFloor(t *testing.T) {
+	t.Setenv("HOME", "/Users/x")
+
+	const shallow = "/Volumes/Vol/repo" // 3 non-empty segments
+	enrolled := &Manifest{Projects: map[string]*ProjectEntry{
+		shallow: {Path: shallow, Name: "repo", Worktrees: []string{"/Volumes/Vol/repo-wt"}},
+	}}
+	bare := &Manifest{Projects: map[string]*ProjectEntry{}}
+
+	if bare.isIgnored(shallow) != true {
+		t.Error("un-enrolled shallow path must stay ignored — the discovery heuristic is unchanged")
+	}
+	if enrolled.isIgnored(shallow) != false {
+		t.Error("enrolled shallow path must not be ignored; this is what strands its sessions")
+	}
+	// entryForPath resolves worktrees to their parent, so a linked worktree
+	// of an enrolled shallow project is enrolled too.
+	if enrolled.isIgnored("/Volumes/Vol/repo-wt") != false {
+		t.Error("worktree of an enrolled shallow project must not be ignored")
+	}
+	// Enrollment does not launder an explicit ignore.
+	ignored := &Manifest{
+		Projects:     map[string]*ProjectEntry{shallow: {Path: shallow, Name: "repo"}},
+		IgnoredPaths: []string{shallow},
+	}
+	if ignored.isIgnored(shallow) != true {
+		t.Error("explicit ignored_paths entry must still win over enrollment")
+	}
+	// Enrollment does not waive the TCC guard (3 segments, so the floor
+	// would have caught it first — TCC must catch it on its own).
+	tcc := &Manifest{Projects: map[string]*ProjectEntry{
+		"/Users/x/Downloads": {Path: "/Users/x/Downloads", Name: "dl"},
+	}}
+	if tcc.isIgnored("/Users/x/Downloads") != true {
+		t.Error("TCC-protected path must stay ignored even when enrolled")
+	}
+	// Enrollment does not waive the never-harvest-a-KB guard.
+	kb := t.TempDir()
+	if err := os.WriteFile(filepath.Join(kb, "scribe.yaml"), []byte("owner_name: t\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	inKB := &Manifest{Projects: map[string]*ProjectEntry{kb: {Path: kb, Name: "kb"}}}
+	if inKB.isIgnored(kb) != true {
+		t.Error("a scribe KB must stay ignored even when enrolled")
+	}
+}


### PR DESCRIPTION
Fixes #108. Follow-up to #102 — the half #103 did not touch.

## The gap

`isIgnored` (`manifest.go:227`) rejects any path with fewer than 4 non-empty segments. That floor is an *enrollment* heuristic: it stops discovery auto-enrolling a path so broad it would sweep every repo beneath it. But it is applied on every path that consults `isIgnored`, including `projectScopeAllowed` on the session lane.

So a project at `/Volumes/MyVolume/repo` (3 segments) is discovered, approved and extracted normally, while every session run inside it is dropped from the mine queue — permanently, with no log line, and with no config override. `scribe triage` ranks those sessions; `scribe triage --in-scope`, the predicate the miner uses, returns nothing.

## The change

```go
if nonEmpty < 4 && m.entryForPath(path) == nil {
    return true
}
```

Enrollment is the decision the heuristic guards. Once it has been made explicitly the guard has no remaining job. `entryForPath` resolves linked worktrees to their parent, so a worktree of an enrolled shallow project is covered.

Deliberately **not** waived by enrollment — TCC, `withinScribeKB`, explicit `ignored_paths`. Those encode a hazard and an explicit user decision; the depth floor encodes neither. Each has its own assertion in the test.

## Verification

`TestManifestIsIgnoredEnrolledProjectDefeatsDepthFloor` covers six cases: un-enrolled shallow still ignored (the discovery heuristic is unchanged), enrolled shallow admitted, enrolled worktree admitted, and the three non-waived gates still winning over enrollment.

Confirmed the test fails without the production change — `enrolled shallow path must not be ignored` — and passes with it. Pre-existing `TestManifestIsIgnored` (which pins `/Users/x/foo` → shallow → ignored) still passes unmodified, since that manifest enrolls nothing. `make check` green, `gofmt` clean.

Measured on the reporting KB, same DB before and after:

```
                         before   after
triage --top 50            35       35
triage --in-scope --top 50  0       29     ← scores up to 272
```

The 29 then mined normally.
