### PR TITLE
fix(status): count a session as pending only if the miner would admit it

### DIFF
--- a/cmd/scribe/status.go
+++ b/cmd/scribe/status.go
@@ -604,6 +604,21 @@ func pendingQueueSummary(cfg PriorityLanesConfig) (hot, normal, aged int, ok boo
 // already-mined session IDs, excluded from the tally. Reads the DB
 // read-only; returns (0, false) on any DB/manifest error so the caller
 // drops the row rather than printing a wrong number.
+//
+// The approval check alone is necessary but not sufficient: it answers
+// "does this path belong to an approved project", while admission asks
+// sessionDropReason — in-a-KB, out-of-scope, pending-approval. A session
+// can satisfy the first and fail the second, and then it is counted as
+// pending forever while the miner refuses it on every run. That gap is
+// what makes the backlog report a floor it can never reach, and a count
+// that cannot reach zero is one people learn to ignore.
+//
+// Both gates are applied, not one: sessionDropReason is deliberately
+// permissive about projects it has never seen (knowledge can be captured
+// before formal enrollment), so using it alone would re-admit the whole
+// machine's session pile on a KB with no approved projects — exactly the
+// #27 regression the approval check exists to prevent. Composed, the
+// count only ever narrows.
 func countScopedPendingSessions(root string, cfg *ScribeConfig, processed map[string]struct{}) (int, bool) {
 	db, err := openSQLiteRO(cfg.CcriderDB)
 	if err != nil {
@@ -636,6 +651,11 @@ func countScopedPendingSessions(root string, cfg *ScribeConfig, processed map[st
 		// a basename collision can't borrow another project's approval.
 		entry := manifest.entryForPath(ppath)
 		if entry == nil || !entry.IsApproved() {
+			continue
+		}
+		// ...and the miner's own admission predicate, so "pending" means
+		// "will actually be mined" rather than "lives somewhere approved".
+		if sessionDropReason(cfg, manifest, root, ppath) != "" {
 			continue
 		}
 		if _, done := processed[sid]; done {

--- a/cmd/scribe/status_sessions_test.go
+++ b/cmd/scribe/status_sessions_test.go
@@ -161,3 +161,56 @@ func writeStatusManifest(t *testing.T, root string, projects map[string]map[stri
 		t.Fatal(err)
 	}
 }
+
+// TestCountScopedPendingSessionsExcludesUnminable pins "pending" to mean
+// "will actually be mined". An approved manifest entry answers only
+// "does this path belong to an approved project"; admission additionally
+// asks sessionDropReason. A session that satisfies the first and fails
+// the second used to be counted forever while the miner refused it on
+// every run, giving the backlog a floor it could never reach.
+//
+// The KB guard is the cheapest drop reason to construct, and the one that
+// bites in practice: sessions run inside a KB checkout are never mined
+// (KBs must not harvest themselves), yet the KB can be an approved project.
+func TestCountScopedPendingSessionsExcludesUnminable(t *testing.T) {
+	db, dbPath := newCcriderDB(t)
+	root := t.TempDir()
+
+	minable := filepath.Join(t.TempDir(), "Projects", "minable")
+	// An approved project that is itself a scribe KB — approved, but the
+	// miner drops every session in it via sessionInKB.
+	kbProject := filepath.Join(t.TempDir(), "Projects", "someKB")
+	if err := os.MkdirAll(kbProject, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(kbProject, "scribe.yaml"), []byte("owner_name: t\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	writeStatusManifest(t, root, map[string]map[string]string{
+		"minable": {"path": minable, "domain": "general"},
+		"someKB":  {"path": kbProject, "domain": "general"},
+	})
+
+	insertFixtureSession(t, db, "s-minable", minable, 50, "", "", "will be mined")
+	insertFixtureSession(t, db, "s-in-kb", kbProject, 50, "", "", "approved but never admissible")
+
+	cfg := loadConfig(root)
+	cfg.CcriderDB = dbPath
+
+	got, ok := countScopedPendingSessions(root, cfg, map[string]struct{}{})
+	if !ok {
+		t.Fatal("countScopedPendingSessions returned ok=false")
+	}
+	if got != 1 {
+		t.Errorf("pending = %d, want 1: the in-KB session is approved but unminable, so it must not be counted", got)
+	}
+	// Guard the composition: sessionDropReason alone is permissive about
+	// unseen projects, so it must not be allowed to re-admit an unenrolled
+	// path and undo #27.
+	insertFixtureSession(t, db, "s-unknown", "/somewhere/else/entirely", 50, "", "", "no manifest entry")
+	got, _ = countScopedPendingSessions(root, cfg, map[string]struct{}{})
+	if got != 1 {
+		t.Errorf("pending = %d, want 1: an unenrolled project must stay uncounted (#27)", got)
+	}
+}


### PR DESCRIPTION
Fixes #110. Third in the #102 / #108 line: those are about sessions the miner cannot admit, this is about the counter that reports them as waiting.

## The gap

`countScopedPendingSessions` asks `entryForPath` "does this path belong to an approved project". Admission asks `sessionDropReason` — in-a-KB, out-of-scope, pending-approval. A session that satisfies the first and fails the second is reported pending forever while the miner refuses it forever, so the backlog has a floor it cannot reach.

On the reporting KB that floor was the whole remaining count: 14 pending, 0 minable (10 unapproved project, 3 in-KB, 1 out of scope).

## The change

```go
entry := manifest.entryForPath(ppath)
if entry == nil || !entry.IsApproved() {
    continue
}
if sessionDropReason(cfg, manifest, root, ppath) != "" {
    continue
}
```

**Both gates, not one.** `sessionDropReason` is deliberately permissive about projects it has never seen — knowledge can be captured before formal enrollment — so replacing the approval check with it would re-admit the machine's whole session pile on a KB with no approved projects, which is the #27 regression that check exists to prevent. Composed, the count only ever narrows; no configuration can make it report more than it does today.

Reusing `sessionDropReason` rather than re-deriving the rules is deliberate: #103 extracted it precisely so two sites could not drift apart, and this is a third caller with the same requirement.

## Verification

`TestCountScopedPendingSessionsExcludesUnminable` covers both halves — an approved-but-in-a-KB project's session is not counted, and an unenrolled project's session stays uncounted so #27 cannot regress.

Confirmed the test fails without the production change, on both assertions (`pending = 2, want 1` each). Both pre-existing tests — `TestCountScopedPendingSessions` and `TestCountScopedPendingSessions_ZeroApproved` — pass unmodified. `make check` green, `gofmt` clean.

Measured on the reporting KB: `sessions (mine): 14 pending` → `0 pending`, with no change to what the miner does.
